### PR TITLE
Step-up contributions + bug fixes (#29 + #33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-calculator",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
@@ -5484,24 +5484,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -27,7 +27,13 @@ import { DataManager } from './data-manager/data-manager';
 
 export const Body = () => {
   const [loans, setLoans] = useState<Loan[]>([]);
+  const [investments, setInvestments] = useState<Investment[]>([]);
   const [testDataEnabled, setTestDataEnabled] = useState<boolean>(false);
+  const [isAddLoanOpen, setIsAddLoanOpen] = useState<boolean>(false);
+  const [isAddInvestmentOpen, setIsAddInvestmentOpen] =
+    useState<boolean>(false);
+  const [editLoan, setEditLoan] = useState<Loan>();
+  const [editInvestment, setEditInvestment] = useState<Investment>();
 
   // Fake data for testing
   const fakeLoans: Loan[] = [
@@ -106,12 +112,6 @@ export const Body = () => {
     }
     setTestDataEnabled(!testDataEnabled);
   };
-  const [investments, setInvestments] = useState<Investment[]>([]);
-  const [isAddLoanOpen, setIsAddLoanOpen] = useState<boolean>(false);
-  const [isAddInvestmentOpen, setIsAddInvestmentOpen] =
-    useState<boolean>(false);
-  const [editLoan, setEditLoan] = useState<Loan>();
-  const [editInvestment, setEditInvestment] = useState<Investment>();
 
   const onLoanAddEdit = (loan?: Loan) => {
     setEditLoan(loan);

--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -82,92 +82,141 @@ describe('exportToJson and importFromJson', () => {
 
   it('should throw error for loans with missing required fields', () => {
     const missingProvider = JSON.stringify({
-      loans: [{ Id: 'test-1', Name: 'Test', StartDate: new Date().toISOString(), EndDate: new Date().toISOString() }],
+      loans: [
+        {
+          Id: 'test-1',
+          Name: 'Test',
+          StartDate: new Date().toISOString(),
+          EndDate: new Date().toISOString(),
+        },
+      ],
       investments: [],
     });
-    expect(() => importFromJson(missingProvider)).toThrow("Missing required field 'Provider'");
+    expect(() => importFromJson(missingProvider)).toThrow(
+      "Missing required field 'Provider'"
+    );
 
     const missingName = JSON.stringify({
-      loans: [{ Id: 'test-1', Provider: 'Bank', StartDate: new Date().toISOString(), EndDate: new Date().toISOString() }],
+      loans: [
+        {
+          Id: 'test-1',
+          Provider: 'Bank',
+          StartDate: new Date().toISOString(),
+          EndDate: new Date().toISOString(),
+        },
+      ],
       investments: [],
     });
-    expect(() => importFromJson(missingName)).toThrow("Missing required field 'Name'");
+    expect(() => importFromJson(missingName)).toThrow(
+      "Missing required field 'Name'"
+    );
   });
 
   it('should throw error for loans with empty string fields', () => {
     const emptyProvider = JSON.stringify({
-      loans: [{
-        Id: 'test-1',
-        Provider: '  ',
-        Name: 'Test',
-        InterestRate: 5,
-        Principal: 10000,
-        CurrentAmount: 10000,
-        StartDate: new Date().toISOString(),
-        EndDate: new Date().toISOString()
-      }],
+      loans: [
+        {
+          Id: 'test-1',
+          Provider: '  ',
+          Name: 'Test',
+          InterestRate: 5,
+          Principal: 10000,
+          CurrentAmount: 10000,
+          StartDate: new Date().toISOString(),
+          EndDate: new Date().toISOString(),
+        },
+      ],
       investments: [],
     });
-    expect(() => importFromJson(emptyProvider)).toThrow("Required field 'Provider' cannot be empty");
+    expect(() => importFromJson(emptyProvider)).toThrow(
+      "Required field 'Provider' cannot be empty"
+    );
 
     const emptyName = JSON.stringify({
-      loans: [{
-        Id: 'test-1',
-        Provider: 'Bank',
-        Name: '',
-        InterestRate: 5,
-        Principal: 10000,
-        CurrentAmount: 10000,
-        StartDate: new Date().toISOString(),
-        EndDate: new Date().toISOString()
-      }],
+      loans: [
+        {
+          Id: 'test-1',
+          Provider: 'Bank',
+          Name: '',
+          InterestRate: 5,
+          Principal: 10000,
+          CurrentAmount: 10000,
+          StartDate: new Date().toISOString(),
+          EndDate: new Date().toISOString(),
+        },
+      ],
       investments: [],
     });
-    expect(() => importFromJson(emptyName)).toThrow("Required field 'Name' cannot be empty");
+    expect(() => importFromJson(emptyName)).toThrow(
+      "Required field 'Name' cannot be empty"
+    );
   });
 
   it('should throw error for investments with missing required fields', () => {
     const missingProvider = JSON.stringify({
       loans: [],
-      investments: [{ Id: 'test-1', Name: 'Test', StartDate: new Date().toISOString() }],
+      investments: [
+        { Id: 'test-1', Name: 'Test', StartDate: new Date().toISOString() },
+      ],
     });
-    expect(() => importFromJson(missingProvider)).toThrow("Missing required field 'Provider'");
+    expect(() => importFromJson(missingProvider)).toThrow(
+      "Missing required field 'Provider'"
+    );
 
     const missingStartingBalance = JSON.stringify({
       loans: [],
-      investments: [{ Id: 'test-1', Provider: 'Fund', Name: 'Test', StartDate: new Date().toISOString(), AverageReturnRate: 5, CompoundingPeriod: 'annually' }],
+      investments: [
+        {
+          Id: 'test-1',
+          Provider: 'Fund',
+          Name: 'Test',
+          StartDate: new Date().toISOString(),
+          AverageReturnRate: 5,
+          CompoundingPeriod: 'annually',
+        },
+      ],
     });
-    expect(() => importFromJson(missingStartingBalance)).toThrow("Missing required field 'StartingBalance'");
+    expect(() => importFromJson(missingStartingBalance)).toThrow(
+      "Missing required field 'StartingBalance'"
+    );
   });
 
   it('should throw error for investments with empty string fields', () => {
     const emptyProvider = JSON.stringify({
       loans: [],
-      investments: [{
-        Id: 'test-1',
-        Provider: '  ',
-        Name: 'Test',
-        StartingBalance: 5000,
-        AverageReturnRate: 5,
-        CompoundingPeriod: 'annually',
-        StartDate: new Date().toISOString()
-      }],
+      investments: [
+        {
+          Id: 'test-1',
+          Provider: '  ',
+          Name: 'Test',
+          StartingBalance: 5000,
+          AverageReturnRate: 5,
+          CompoundingPeriod: 'annually',
+          StartDate: new Date().toISOString(),
+        },
+      ],
     });
-    expect(() => importFromJson(emptyProvider)).toThrow("Required field 'Provider' cannot be empty");
+    expect(() => importFromJson(emptyProvider)).toThrow(
+      "Required field 'Provider' cannot be empty"
+    );
 
     const emptyName = JSON.stringify({
       loans: [],
-      investments: [{
-        Id: 'test-1',
-        Provider: 'Fund',
-        Name: '',
-        StartingBalance: 5000,
-        AverageReturnRate: 5,
-        CompoundingPeriod: 'annually',
-        StartDate: new Date().toISOString()
-      }],
+      investments: [
+        {
+          Id: 'test-1',
+          Provider: 'Fund',
+          Name: '',
+          StartingBalance: 5000,
+          AverageReturnRate: 5,
+          CompoundingPeriod: 'annually',
+          StartDate: new Date().toISOString(),
+        },
+      ],
     });
-    expect(() => importFromJson(emptyName)).toThrow("Required field 'Name' cannot be empty");
+    expect(() => importFromJson(emptyName)).toThrow(
+      "Required field 'Name' cannot be empty"
+    );
   });
 
   it('should throw error for invalid dates', () => {

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -245,5 +245,8 @@ export const mergeData = <T extends { Id: string }>(
   const validItems = Array.from(existingMap.values());
   const emptyIdItems = existing.filter((item) => !isValidId(item.Id));
 
-  return { items: [...emptyIdItems, ...validItems], result: { added, updated } };
+  return {
+    items: [...emptyIdItems, ...validItems],
+    result: { added, updated },
+  };
 };

--- a/src/helpers/investment-helpers.test.ts
+++ b/src/helpers/investment-helpers.test.ts
@@ -6,8 +6,17 @@ import {
   getInvestmentPeriods,
   getNextCompoundingDate,
   getContributionsInPeriod,
+  getContributionForYear,
+  getInvestmentYear,
+  getContributionsWithStepUp,
+  getAnniversaryDate,
+  hasPassedAnniversary,
 } from './investment-helpers';
-import { Investment, CompoundingFrequency } from '../models/investment-model';
+import {
+  Investment,
+  CompoundingFrequency,
+  StepUpType,
+} from '../models/investment-model';
 
 describe('Investment Helpers', () => {
   describe('getPeriodsPerYear', () => {
@@ -21,6 +30,63 @@ describe('Investment Helpers', () => {
 
     it('should return 1 for annually compounding', () => {
       expect(getPeriodsPerYear(CompoundingFrequency.Annually)).toBe(1);
+    });
+  });
+
+  describe('getAnniversaryDate', () => {
+    it('should return correct anniversary date for regular dates', () => {
+      const startDate = new Date(2024, 5, 15); // June 15, 2024
+      const anniversary = getAnniversaryDate(startDate, 2025);
+      expect(anniversary.getFullYear()).toBe(2025);
+      expect(anniversary.getMonth()).toBe(5);
+      expect(anniversary.getDate()).toBe(15);
+    });
+
+    it('should return Feb 28 for Feb 29 start date in non-leap year', () => {
+      const startDate = new Date(2024, 1, 29); // Feb 29, 2024 (leap year)
+      const anniversary = getAnniversaryDate(startDate, 2025); // 2025 is not a leap year
+      expect(anniversary.getFullYear()).toBe(2025);
+      expect(anniversary.getMonth()).toBe(1);
+      expect(anniversary.getDate()).toBe(28);
+    });
+
+    it('should return Feb 29 for Feb 29 start date in leap year', () => {
+      const startDate = new Date(2024, 1, 29); // Feb 29, 2024 (leap year)
+      const anniversary = getAnniversaryDate(startDate, 2028); // 2028 is a leap year
+      expect(anniversary.getFullYear()).toBe(2028);
+      expect(anniversary.getMonth()).toBe(1);
+      expect(anniversary.getDate()).toBe(29);
+    });
+  });
+
+  describe('hasPassedAnniversary', () => {
+    it('should return true when on anniversary', () => {
+      const startDate = new Date(2024, 5, 15); // June 15, 2024
+      const currentDate = new Date(2025, 5, 15); // June 15, 2025
+      expect(hasPassedAnniversary(currentDate, startDate)).toBe(true);
+    });
+
+    it('should return true when past anniversary', () => {
+      const startDate = new Date(2024, 5, 15); // June 15, 2024
+      const currentDate = new Date(2025, 6, 1); // July 1, 2025
+      expect(hasPassedAnniversary(currentDate, startDate)).toBe(true);
+    });
+
+    it('should return false when before anniversary', () => {
+      const startDate = new Date(2024, 5, 15); // June 15, 2024
+      const currentDate = new Date(2025, 4, 1); // May 1, 2025
+      expect(hasPassedAnniversary(currentDate, startDate)).toBe(false);
+    });
+
+    it('should handle Feb 29 leap year edge case correctly', () => {
+      const startDate = new Date(2024, 1, 29); // Feb 29, 2024 (leap year)
+      // In non-leap year, anniversary is Feb 28
+      // Feb 28, 2025 should be considered as passed anniversary
+      expect(hasPassedAnniversary(new Date(2025, 1, 28), startDate)).toBe(true);
+      // Feb 27, 2025 should be before anniversary
+      expect(hasPassedAnniversary(new Date(2025, 1, 27), startDate)).toBe(
+        false
+      );
     });
   });
 
@@ -434,6 +500,365 @@ describe('Investment Helpers', () => {
       // Final value should include contributions
       const finalValue = growth[growth.length - 1].TotalValue;
       expect(finalValue).toBeGreaterThan(10423.0);
+    });
+  });
+
+  describe('Step-Up Contribution Helpers', () => {
+    describe('getContributionForYear', () => {
+      it('should return base contribution for year 1', () => {
+        expect(getContributionForYear(100, 1, 10, StepUpType.Flat)).toBe(100);
+        expect(getContributionForYear(100, 1, 10, StepUpType.Percentage)).toBe(
+          100
+        );
+      });
+
+      it('should apply flat step-up correctly', () => {
+        // $100 base with $10 step-up
+        expect(getContributionForYear(100, 1, 10, StepUpType.Flat)).toBe(100);
+        expect(getContributionForYear(100, 2, 10, StepUpType.Flat)).toBe(110);
+        expect(getContributionForYear(100, 3, 10, StepUpType.Flat)).toBe(120);
+        expect(getContributionForYear(100, 5, 10, StepUpType.Flat)).toBe(140);
+      });
+
+      it('should apply percentage step-up correctly', () => {
+        // $100 base with 10% step-up
+        expect(getContributionForYear(100, 1, 10, StepUpType.Percentage)).toBe(
+          100
+        );
+        expect(getContributionForYear(100, 2, 10, StepUpType.Percentage)).toBe(
+          110
+        );
+        expect(getContributionForYear(100, 3, 10, StepUpType.Percentage)).toBe(
+          121
+        );
+        // Year 4: 100 * 1.1^3 = 133.1
+        expect(getContributionForYear(100, 4, 10, StepUpType.Percentage)).toBe(
+          133.1
+        );
+      });
+
+      it('should return base contribution if no step-up configured', () => {
+        expect(getContributionForYear(100, 3, undefined, undefined)).toBe(100);
+        expect(getContributionForYear(100, 3, 0, StepUpType.Flat)).toBe(100);
+        expect(getContributionForYear(100, 3, undefined, StepUpType.Flat)).toBe(
+          100
+        );
+      });
+
+      it('should return base contribution for negative step-up amounts', () => {
+        // Negative step-up amounts should return base contribution
+        expect(getContributionForYear(100, 3, -10, StepUpType.Flat)).toBe(100);
+        expect(getContributionForYear(100, 3, -10, StepUpType.Percentage)).toBe(
+          100
+        );
+        expect(getContributionForYear(100, 5, -50, StepUpType.Flat)).toBe(100);
+        expect(getContributionForYear(100, 5, -50, StepUpType.Percentage)).toBe(
+          100
+        );
+      });
+
+      it('should handle large percentage step-ups correctly', () => {
+        // 100% step-up doubles each year
+        expect(
+          getContributionForYear(100, 2, 100, StepUpType.Percentage)
+        ).toBeCloseTo(200, 2);
+        expect(
+          getContributionForYear(100, 3, 100, StepUpType.Percentage)
+        ).toBeCloseTo(400, 2);
+        expect(
+          getContributionForYear(100, 4, 100, StepUpType.Percentage)
+        ).toBeCloseTo(800, 2);
+
+        // 200% step-up triples each year
+        expect(
+          getContributionForYear(100, 2, 200, StepUpType.Percentage)
+        ).toBeCloseTo(300, 2);
+        expect(
+          getContributionForYear(100, 3, 200, StepUpType.Percentage)
+        ).toBeCloseTo(900, 2);
+
+        // Very large step-up (500%)
+        expect(
+          getContributionForYear(100, 2, 500, StepUpType.Percentage)
+        ).toBeCloseTo(600, 2);
+        expect(
+          getContributionForYear(100, 3, 500, StepUpType.Percentage)
+        ).toBeCloseTo(3600, 2);
+      });
+    });
+
+    describe('getInvestmentYear', () => {
+      it('should return 1 for dates within the first year', () => {
+        const startDate = new Date(2025, 0, 1);
+        expect(getInvestmentYear(new Date(2025, 0, 1), startDate)).toBe(1);
+        expect(getInvestmentYear(new Date(2025, 6, 15), startDate)).toBe(1);
+        expect(getInvestmentYear(new Date(2025, 11, 31), startDate)).toBe(1);
+      });
+
+      it('should return 2 for dates in the second year', () => {
+        const startDate = new Date(2025, 0, 1);
+        expect(getInvestmentYear(new Date(2026, 0, 1), startDate)).toBe(2);
+        expect(getInvestmentYear(new Date(2026, 6, 15), startDate)).toBe(2);
+      });
+
+      it('should handle mid-year start dates correctly', () => {
+        const startDate = new Date(2025, 5, 15); // June 15, 2025
+        // Before anniversary in 2026
+        expect(getInvestmentYear(new Date(2026, 4, 1), startDate)).toBe(1);
+        // On/after anniversary in 2026
+        expect(getInvestmentYear(new Date(2026, 5, 15), startDate)).toBe(2);
+        expect(getInvestmentYear(new Date(2026, 6, 1), startDate)).toBe(2);
+      });
+
+      it('should return 1 when currentDate is before startDate', () => {
+        const startDate = new Date(2025, 5, 15); // June 15, 2025
+        // Dates before the investment start should return year 1
+        expect(getInvestmentYear(new Date(2025, 0, 1), startDate)).toBe(1);
+        expect(getInvestmentYear(new Date(2024, 11, 31), startDate)).toBe(1);
+        expect(getInvestmentYear(new Date(2020, 0, 1), startDate)).toBe(1);
+      });
+
+      it('should handle leap year (Feb 29) start dates correctly', () => {
+        // Start on Feb 29, 2024 (leap year)
+        const startDate = new Date(2024, 1, 29);
+
+        // On the start date itself
+        expect(getInvestmentYear(new Date(2024, 1, 29), startDate)).toBe(1);
+
+        // Feb 28, 2025 (non-leap year) should be year 2 since Feb 29 doesn't exist
+        // The anniversary in 2025 is Feb 28
+        expect(getInvestmentYear(new Date(2025, 1, 28), startDate)).toBe(2);
+
+        // Feb 27, 2025 should still be year 1 (before anniversary)
+        expect(getInvestmentYear(new Date(2025, 1, 27), startDate)).toBe(1);
+
+        // March 1, 2025 should be year 2
+        expect(getInvestmentYear(new Date(2025, 2, 1), startDate)).toBe(2);
+
+        // Feb 29, 2028 (leap year) should be year 5
+        expect(getInvestmentYear(new Date(2028, 1, 29), startDate)).toBe(5);
+      });
+    });
+
+    describe('getContributionsWithStepUp', () => {
+      it('should calculate contributions without step-up', () => {
+        const startDate = new Date(2025, 0, 1);
+        const endDate = new Date(2025, 3, 1);
+        const investmentStart = new Date(2025, 0, 1);
+
+        // 3 monthly contributions of $100 each (Jan, Feb, Mar)
+        const total = getContributionsWithStepUp(
+          startDate,
+          endDate,
+          investmentStart,
+          100,
+          CompoundingFrequency.Monthly
+        );
+
+        expect(total).toBe(300);
+      });
+
+      it('should apply flat step-up at year boundary', () => {
+        const investmentStart = new Date(2025, 0, 1);
+        // Period spanning year 1 and year 2
+        // Nov 2025 to Feb 2026 = 3 contributions at $100 (Nov, Dec) + 1 at $110 (Jan 2026)
+        // Actually: Nov 1 = $100, Dec 1 = $100, Jan 1 = $110 (year 2 starts)
+        const startDate = new Date(2025, 10, 1); // Nov 1
+        const endDate = new Date(2026, 1, 1); // Feb 1 (exclusive)
+
+        const total = getContributionsWithStepUp(
+          startDate,
+          endDate,
+          investmentStart,
+          100,
+          CompoundingFrequency.Monthly,
+          10,
+          StepUpType.Flat
+        );
+
+        // Nov $100 + Dec $100 + Jan $110 = $310
+        expect(total).toBe(310);
+      });
+
+      it('should apply percentage step-up at year boundary', () => {
+        const investmentStart = new Date(2025, 0, 1);
+        const startDate = new Date(2025, 10, 1); // Nov 1
+        const endDate = new Date(2026, 1, 1); // Feb 1 (exclusive)
+
+        const total = getContributionsWithStepUp(
+          startDate,
+          endDate,
+          investmentStart,
+          100,
+          CompoundingFrequency.Monthly,
+          10,
+          StepUpType.Percentage
+        );
+
+        // Nov $100 + Dec $100 + Jan $110 = $310
+        expect(total).toBe(310);
+      });
+    });
+  });
+
+  describe('Investment Growth with Step-Up Contributions', () => {
+    // Test data from the issue:
+    // Flat example: $100/month with $10 step-up
+    // Year 1: $100/month, Year 2: $110/month, Year 3: $120/month
+
+    describe('Flat Step-Up', () => {
+      it('should apply flat step-up to contributions over multiple years', () => {
+        const investment: Investment = {
+          Id: 'test-step-up-1',
+          Provider: 'Test',
+          Name: 'Flat Step-Up Test',
+          StartDate: new Date(2025, 0, 1),
+          StartingBalance: 0,
+          AverageReturnRate: 0, // No interest to simplify testing contributions
+          CompoundingPeriod: CompoundingFrequency.Annually,
+          RecurringContribution: 100,
+          ContributionFrequency: CompoundingFrequency.Monthly,
+          ContributionStepUpAmount: 10,
+          ContributionStepUpType: StepUpType.Flat,
+        };
+
+        // After 3 years
+        const endDate = new Date(2028, 0, 1);
+        const growth = generateInvestmentGrowth(investment, endDate);
+
+        // Year 1: 12 * $100 = $1,200
+        // Year 2: 12 * $110 = $1,320
+        // Year 3: 12 * $120 = $1,440
+        // Total: $3,960
+
+        const totalContributions = growth.reduce(
+          (sum, entry) => sum + entry.ContributionAmount,
+          0
+        );
+        expect(totalContributions).toBe(3960);
+      });
+
+      it('should calculate correct value after 1 year with flat step-up', () => {
+        const investment: Investment = {
+          Id: 'test-step-up-2',
+          Provider: 'Test',
+          Name: 'Flat Step-Up Test',
+          StartDate: new Date(2025, 0, 1),
+          StartingBalance: 0,
+          AverageReturnRate: 0,
+          CompoundingPeriod: CompoundingFrequency.Annually,
+          RecurringContribution: 100,
+          ContributionFrequency: CompoundingFrequency.Monthly,
+          ContributionStepUpAmount: 10,
+          ContributionStepUpType: StepUpType.Flat,
+        };
+
+        // After 1 year (no step-up applied yet)
+        const endDate = new Date(2026, 0, 1);
+        const growth = generateInvestmentGrowth(investment, endDate);
+
+        // Year 1: 12 * $100 = $1,200
+        const totalContributions = growth.reduce(
+          (sum, entry) => sum + entry.ContributionAmount,
+          0
+        );
+        expect(totalContributions).toBe(1200);
+      });
+    });
+
+    describe('Percentage Step-Up', () => {
+      it('should apply percentage step-up to contributions over multiple years', () => {
+        const investment: Investment = {
+          Id: 'test-step-up-3',
+          Provider: 'Test',
+          Name: 'Percentage Step-Up Test',
+          StartDate: new Date(2025, 0, 1),
+          StartingBalance: 0,
+          AverageReturnRate: 0, // No interest to simplify testing contributions
+          CompoundingPeriod: CompoundingFrequency.Annually,
+          RecurringContribution: 100,
+          ContributionFrequency: CompoundingFrequency.Monthly,
+          ContributionStepUpAmount: 10,
+          ContributionStepUpType: StepUpType.Percentage,
+        };
+
+        // After 3 years
+        const endDate = new Date(2028, 0, 1);
+        const growth = generateInvestmentGrowth(investment, endDate);
+
+        // Year 1: 12 * $100 = $1,200
+        // Year 2: 12 * $110 = $1,320
+        // Year 3: 12 * $121 = $1,452
+        // Total: $3,972
+
+        const totalContributions = growth.reduce(
+          (sum, entry) => sum + entry.ContributionAmount,
+          0
+        );
+        expect(totalContributions).toBe(3972);
+      });
+
+      it('should compound percentage step-up over many years', () => {
+        const investment: Investment = {
+          Id: 'test-step-up-4',
+          Provider: 'Test',
+          Name: 'Percentage Step-Up Test',
+          StartDate: new Date(2025, 0, 1),
+          StartingBalance: 0,
+          AverageReturnRate: 0,
+          CompoundingPeriod: CompoundingFrequency.Annually,
+          RecurringContribution: 100,
+          ContributionFrequency: CompoundingFrequency.Monthly,
+          ContributionStepUpAmount: 10,
+          ContributionStepUpType: StepUpType.Percentage,
+        };
+
+        // After 5 years
+        const endDate = new Date(2030, 0, 1);
+        const growth = generateInvestmentGrowth(investment, endDate);
+
+        // Year 1: 12 * 100 = 1,200
+        // Year 2: 12 * 110 = 1,320
+        // Year 3: 12 * 121 = 1,452
+        // Year 4: 12 * 133.1 = 1,597.2
+        // Year 5: 12 * 146.41 = 1,756.92
+        // Total: 7,326.12
+
+        const totalContributions = growth.reduce(
+          (sum, entry) => sum + entry.ContributionAmount,
+          0
+        );
+        expect(totalContributions).toBeCloseTo(7326.12, 0);
+      });
+    });
+
+    describe('Step-Up with Interest', () => {
+      it('should correctly compound interest with flat step-up contributions', () => {
+        const investment: Investment = {
+          Id: 'test-step-up-5',
+          Provider: 'Test',
+          Name: 'Step-Up with Interest',
+          StartDate: new Date(2025, 0, 1),
+          StartingBalance: 10000,
+          AverageReturnRate: 5,
+          CompoundingPeriod: CompoundingFrequency.Annually,
+          RecurringContribution: 100,
+          ContributionFrequency: CompoundingFrequency.Monthly,
+          ContributionStepUpAmount: 10,
+          ContributionStepUpType: StepUpType.Flat,
+        };
+
+        const endDate = new Date(2027, 0, 1);
+        const growth = generateInvestmentGrowth(investment, endDate);
+
+        // Year 1: Start $10,000 + $1,200 contributions = $11,200
+        // After 5% interest = $11,760
+        // Year 2: $11,760 + $1,320 contributions = $13,080
+        // After 5% interest = $13,734
+
+        const finalValue = growth[growth.length - 1].TotalValue;
+        expect(finalValue).toBeCloseTo(13734, 0);
+      });
     });
   });
 });

--- a/src/helpers/investment-helpers.test.ts
+++ b/src/helpers/investment-helpers.test.ts
@@ -698,6 +698,20 @@ describe('Investment Helpers', () => {
         // Nov $100 + Dec $100 + Jan $110 = $310
         expect(total).toBe(310);
       });
+
+      it('should not over-count when compounding is more frequent than contributions', () => {
+        const investmentStart = new Date(2025, 0, 1); // Jan 1 — quarterly contributions on Jan/Apr/Jul/Oct
+        // Monthly compounding: period 2 covers Feb 1 – Mar 1
+        // Next quarterly contribution after Jan 1 is Apr 1, which is outside this window → 0 contributions
+        const total = getContributionsWithStepUp(
+          new Date(2025, 1, 1), // Feb 1
+          new Date(2025, 2, 1), // Mar 1
+          investmentStart,
+          100,
+          CompoundingFrequency.Quarterly
+        );
+        expect(total).toBe(0);
+      });
     });
   });
 

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -218,9 +218,16 @@ export const getContributionsWithStepUp = (
   stepUpType?: StepUpType
 ): number => {
   let totalContribution = 0;
-  let currentDate = new Date(startDate.getTime());
 
-  // Iterate through each contribution date in the period
+  // Anchor to investmentStartDate and advance to first contribution date on or after startDate.
+  // This keeps contribution timing consistent across compounding periods — without this,
+  // each period would treat its own start as a contribution date, over-counting when
+  // compounding is more frequent than contributions (e.g. monthly compounding + quarterly contributions).
+  let currentDate = new Date(investmentStartDate.getTime());
+  while (currentDate < startDate) {
+    currentDate = getNextCompoundingDate(currentDate, contributionFrequency);
+  }
+
   while (currentDate < endDate) {
     // Determine which year this contribution falls in
     const yearNumber = getInvestmentYear(currentDate, investmentStartDate);

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -3,6 +3,7 @@ import {
   InvestmentGrowthEntry,
   PitInvestment,
   CompoundingFrequency,
+  StepUpType,
 } from '../models/investment-model';
 
 // Returns the number of compounding periods per year based on frequency
@@ -17,6 +18,45 @@ export const getPeriodsPerYear = (frequency: CompoundingFrequency): number => {
     default:
       return 1;
   }
+};
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+// Get the anniversary date for a given year based on a start date
+// Handles leap year edge case: if start date is Feb 29, uses Feb 28 for non-leap years
+export const getAnniversaryDate = (
+  startDate: Date,
+  targetYear: number
+): Date => {
+  const anniversaryMonth = startDate.getMonth();
+  let anniversaryDay = startDate.getDate();
+
+  // Check if start date is Feb 29 (leap day)
+  if (anniversaryMonth === 1 && anniversaryDay === 29) {
+    // Check if target year is a leap year
+    const isLeapYear =
+      (targetYear % 4 === 0 && targetYear % 100 !== 0) ||
+      targetYear % 400 === 0;
+    if (!isLeapYear) {
+      // Use Feb 28 for non-leap years
+      anniversaryDay = 28;
+    }
+  }
+
+  return new Date(targetYear, anniversaryMonth, anniversaryDay);
+};
+
+// Check if we've passed the anniversary for a given year
+// Returns true if currentDate is on or after the anniversary in that year
+export const hasPassedAnniversary = (
+  currentDate: Date,
+  startDate: Date
+): boolean => {
+  const anniversaryThisYear = getAnniversaryDate(
+    startDate,
+    currentDate.getFullYear()
+  );
+  return currentDate >= anniversaryThisYear;
 };
 
 // Returns the number of periods between start date and end date (or current date)
@@ -70,13 +110,8 @@ export const getInvestmentPeriods = (
   } else {
     // Annually
     periods = end.getFullYear() - start.getFullYear();
-    // Add partial year if we've passed the anniversary
-    const anniversary = new Date(
-      end.getFullYear(),
-      start.getMonth(),
-      start.getDate()
-    );
-    if (end >= anniversary) {
+    // Add partial year if we've passed the anniversary (using shared helper for consistency)
+    if (hasPassedAnniversary(end, start)) {
       periods += 1;
     }
   }
@@ -125,6 +160,86 @@ export const getContributionsInPeriod = (
   return count;
 };
 
+// Calculate the contribution amount for a specific year with step-up applied
+// Year 1 = first year (no step-up yet), Year 2 = second year (first step-up applied), etc.
+export const getContributionForYear = (
+  baseContribution: number,
+  yearNumber: number,
+  stepUpAmount?: number,
+  stepUpType?: StepUpType
+): number => {
+  if (!stepUpAmount || stepUpAmount <= 0 || !stepUpType || yearNumber <= 1) {
+    return roundToCents(baseContribution);
+  }
+
+  // Number of step-ups applied (first year has no step-up)
+  const stepUpsApplied = yearNumber - 1;
+
+  if (stepUpType === StepUpType.Flat) {
+    // Flat: add step-up amount for each year after the first
+    return roundToCents(baseContribution + stepUpAmount * stepUpsApplied);
+  } else {
+    // Percentage: compound the step-up for each year after the first
+    return roundToCents(
+      baseContribution * Math.pow(1 + stepUpAmount / 100, stepUpsApplied)
+    );
+  }
+};
+
+// Calculate the investment year number (1-indexed) based on how many years have passed since start
+export const getInvestmentYear = (
+  currentDate: Date,
+  startDate: Date
+): number => {
+  // If currentDate is before startDate, return 1 (investment hasn't started yet, treat as year 1)
+  if (currentDate < startDate) {
+    return 1;
+  }
+
+  // Calculate years elapsed since start
+  const yearsElapsed = currentDate.getFullYear() - startDate.getFullYear();
+
+  // Use shared helper to check if we've passed the anniversary this calendar year
+  if (hasPassedAnniversary(currentDate, startDate)) {
+    return yearsElapsed + 1;
+  } else {
+    return yearsElapsed;
+  }
+};
+
+// Calculate total contributions in a period, accounting for step-up at year boundaries
+export const getContributionsWithStepUp = (
+  startDate: Date,
+  endDate: Date,
+  investmentStartDate: Date,
+  baseContribution: number,
+  contributionFrequency: CompoundingFrequency,
+  stepUpAmount?: number,
+  stepUpType?: StepUpType
+): number => {
+  let totalContribution = 0;
+  let currentDate = new Date(startDate.getTime());
+
+  // Iterate through each contribution date in the period
+  while (currentDate < endDate) {
+    // Determine which year this contribution falls in
+    const yearNumber = getInvestmentYear(currentDate, investmentStartDate);
+
+    // Get the contribution amount for this year
+    const contributionAmount = getContributionForYear(
+      baseContribution,
+      yearNumber,
+      stepUpAmount,
+      stepUpType
+    );
+
+    totalContribution += contributionAmount;
+    currentDate = getNextCompoundingDate(currentDate, contributionFrequency);
+  }
+
+  return roundToCents(totalContribution);
+};
+
 // Generate growth projection for an investment using date-based calculations
 export const generateInvestmentGrowth = (
   investment: Investment,
@@ -162,18 +277,21 @@ export const generateInvestmentGrowth = (
 
     period++;
 
-    // Calculate contributions in this period
+    // Calculate contributions in this period (with step-up if configured)
     let contributionThisPeriod = 0;
     if (
       (investment.RecurringContribution || 0) > 0 &&
       investment.ContributionFrequency
     ) {
-      contributionThisPeriod =
-        getContributionsInPeriod(
-          currentDate,
-          periodEndDate,
-          investment.ContributionFrequency
-        ) * (investment.RecurringContribution || 0);
+      contributionThisPeriod = getContributionsWithStepUp(
+        currentDate,
+        periodEndDate,
+        investment.StartDate,
+        investment.RecurringContribution || 0,
+        investment.ContributionFrequency,
+        investment.ContributionStepUpAmount,
+        investment.ContributionStepUpType
+      );
 
       currentValue += contributionThisPeriod;
     }

--- a/src/helpers/loan-helpers.test.ts
+++ b/src/helpers/loan-helpers.test.ts
@@ -150,6 +150,44 @@ describe('Loan Helpers', () => {
       expect(pit.RemainingPrincipal).toBeLessThan(10000);
       expect(pit.RemainingTerms).toBeGreaterThan(0);
     });
+
+    it('should only sum interest up to paidTerms when a full amortization schedule is pre-generated', () => {
+      const loan: Loan = {
+        Id: 'test-id-7',
+        Provider: 'Test Lender',
+        Name: 'Test Loan',
+        StartDate: new Date('2025-01-01'),
+        EndDate: new Date('2026-01-01'),
+        Principal: 10000,
+        CurrentAmount: 10000,
+        InterestRate: 6,
+        MonthlyPayment: 860.66,
+      };
+
+      // Pre-generate the full amortization schedule (all 12 terms)
+      const fullSchedule = generateAmortizationSchedule(loan);
+      const loanWithSchedule: Loan = {
+        ...loan,
+        AmortizationSchedule: fullSchedule,
+      };
+
+      // Query at 6 months into a 12-month loan
+      const pitPartial = getPitCalculation(
+        loanWithSchedule,
+        new Date('2025-07-01')
+      );
+
+      // PaidInterest should only reflect the first 7 terms, not the full 12
+      const expectedInterest = fullSchedule
+        .slice(0, pitPartial.PaidTerms)
+        .reduce((acc, entry) => acc + entry.InterestPayment, 0);
+
+      expect(pitPartial.PaidInterest).toBeCloseTo(expectedInterest, 2);
+
+      // Sanity check: interest at 6 months must be less than interest for the full loan
+      const fullPit = getPitCalculation(loanWithSchedule, loan.EndDate);
+      expect(pitPartial.PaidInterest).toBeLessThan(fullPit.PaidInterest);
+    });
   });
 
   describe('Edge Cases', () => {

--- a/src/helpers/loan-helpers.test.ts
+++ b/src/helpers/loan-helpers.test.ts
@@ -157,7 +157,7 @@ describe('Loan Helpers', () => {
         Provider: 'Test Lender',
         Name: 'Test Loan',
         StartDate: new Date('2025-01-01'),
-        EndDate: new Date('2026-01-01'),
+        EndDate: new Date('2025-12-01'),
         Principal: 10000,
         CurrentAmount: 10000,
         InterestRate: 6,

--- a/src/helpers/loan-helpers.ts
+++ b/src/helpers/loan-helpers.ts
@@ -61,10 +61,9 @@ export const getPitCalculation = (loan: Loan, date: Date): PitLoan => {
     RemainingTerms: getTerms(loan) - lastEntry.Term,
     RemainingPrincipal: lastEntry.RemainingBalance,
     PaidPrincipal: loan.Principal - lastEntry.RemainingBalance,
-    PaidInterest: relevantAmortization.reduce(
-      (acc, entry) => acc + entry.InterestPayment,
-      0
-    ),
+    PaidInterest: relevantAmortization
+      .slice(0, paidTerms)
+      .reduce((acc, entry) => acc + entry.InterestPayment, 0),
   } as PitLoan;
 };
 

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -17,6 +17,7 @@ import {
   emptyInvestment,
   Investment,
   CompoundingFrequency,
+  StepUpType,
 } from '../models/investment-model';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
@@ -27,6 +28,10 @@ import { generateInvestmentGrowth } from '../helpers/investment-helpers';
 export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   const [newInvestment, setNewInvestment] =
     useState<Investment>(emptyInvestment);
+
+  const hasRecurringContribution =
+    typeof newInvestment.RecurringContribution === 'number' &&
+    newInvestment.RecurringContribution > 0;
 
   const isFormValid = () => {
     return (
@@ -76,6 +81,8 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
     newInvestment.CompoundingPeriod,
     newInvestment.RecurringContribution,
     newInvestment.ContributionFrequency,
+    newInvestment.ContributionStepUpAmount,
+    newInvestment.ContributionStepUpType,
   ]);
 
   return (
@@ -190,33 +197,91 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                 });
               }}
             />
-            {typeof newInvestment.RecurringContribution === 'number' &&
-              newInvestment.RecurringContribution > 0 && (
-                <FormControl fullWidth>
-                  <InputLabel>Contribution Frequency</InputLabel>
-                  <Select
-                    value={
-                      newInvestment.ContributionFrequency ||
-                      CompoundingFrequency.Monthly
-                    }
-                    label="Contribution Frequency"
-                    onChange={(e) =>
-                      setNewInvestment({
-                        ...newInvestment,
-                        ContributionFrequency: e.target
-                          .value as CompoundingFrequency,
-                      })
-                    }
-                  >
-                    {Object.entries(CompoundingFrequency).map(
-                      ([key, value]) => (
-                        <MenuItem key={key} value={value}>
-                          {key}
-                        </MenuItem>
-                      )
-                    )}
-                  </Select>
-                </FormControl>
+            {hasRecurringContribution && (
+              <FormControl fullWidth>
+                <InputLabel>Contribution Frequency</InputLabel>
+                <Select
+                  value={
+                    newInvestment.ContributionFrequency ||
+                    CompoundingFrequency.Monthly
+                  }
+                  label="Contribution Frequency"
+                  onChange={(e) =>
+                    setNewInvestment({
+                      ...newInvestment,
+                      ContributionFrequency: e.target
+                        .value as CompoundingFrequency,
+                    })
+                  }
+                >
+                  {Object.entries(CompoundingFrequency).map(([key, value]) => (
+                    <MenuItem key={key} value={value}>
+                      {key}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+            {hasRecurringContribution && (
+              <FormControl fullWidth>
+                <InputLabel>Yearly Step-Up Type (Optional)</InputLabel>
+                <Select
+                  value={newInvestment.ContributionStepUpType || ''}
+                  label="Yearly Step-Up Type (Optional)"
+                  onChange={(e) =>
+                    setNewInvestment({
+                      ...newInvestment,
+                      ContributionStepUpType: e.target.value
+                        ? (e.target.value as StepUpType)
+                        : undefined,
+                      ContributionStepUpAmount: e.target.value
+                        ? newInvestment.ContributionStepUpAmount
+                        : undefined,
+                    })
+                  }
+                >
+                  <MenuItem value="">None</MenuItem>
+                  {Object.entries(StepUpType).map(([key, value]) => (
+                    <MenuItem key={key} value={value}>
+                      {key}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+            {hasRecurringContribution &&
+              newInvestment.ContributionStepUpType && (
+                <NumericFormat
+                  label={
+                    newInvestment.ContributionStepUpType === StepUpType.Flat
+                      ? 'Yearly Step-Up Amount'
+                      : 'Yearly Step-Up Percentage'
+                  }
+                  value={newInvestment.ContributionStepUpAmount || ''}
+                  thousandSeparator
+                  decimalScale={2}
+                  allowNegative={false}
+                  prefix={
+                    newInvestment.ContributionStepUpType === StepUpType.Flat
+                      ? '$'
+                      : undefined
+                  }
+                  suffix={
+                    newInvestment.ContributionStepUpType ===
+                    StepUpType.Percentage
+                      ? '%'
+                      : undefined
+                  }
+                  customInput={TextField}
+                  onValueChange={(vs) => {
+                    setNewInvestment({
+                      ...newInvestment,
+                      ContributionStepUpAmount: vs.value
+                        ? Number(vs.value)
+                        : undefined,
+                    });
+                  }}
+                />
               )}
             <Stack direction="row">
               {props.investment && (

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -189,10 +189,17 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
               prefix={'$'}
               customInput={TextField}
               onValueChange={(vs) => {
+                const hasContribution = Boolean(vs.value);
                 setNewInvestment({
                   ...newInvestment,
-                  RecurringContribution: vs.value
+                  RecurringContribution: hasContribution
                     ? Number(vs.value)
+                    : undefined,
+                  ContributionStepUpType: hasContribution
+                    ? newInvestment.ContributionStepUpType
+                    : undefined,
+                  ContributionStepUpAmount: hasContribution
+                    ? newInvestment.ContributionStepUpAmount
                     : undefined,
                 });
               }}

--- a/src/investment/growth-schedule-popout.tsx
+++ b/src/investment/growth-schedule-popout.tsx
@@ -116,7 +116,7 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
         vertical: 'center',
         horizontal: 'center',
       }}
-      style={{ maxHeight: '90vh' }}
+      sx={{ maxHeight: '90vh' }}
     >
       <Card>
         <CardContent>

--- a/src/investment/growth-schedule-popout.tsx
+++ b/src/investment/growth-schedule-popout.tsx
@@ -11,7 +11,10 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import { Investment, CompoundingFrequency } from '../models/investment-model';
+import {
+  Investment,
+  CompoundingFrequency,
+} from '../models/investment-model';
 import {
   generateInvestmentGrowth,
   getPeriodsPerYear,
@@ -21,6 +24,7 @@ import dayjs from 'dayjs';
 type ScheduleEntry = {
   period: number;
   date: string;
+  contributionAmount: number;
   totalInvested: number;
   interestAccrued: number;
   balance: number;
@@ -62,6 +66,10 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
     }
   };
 
+  const hasStepUp =
+    !!props.investment.ContributionStepUpType &&
+    !!props.investment.ContributionStepUpAmount;
+
   // For monthly and quarterly, show individual periods; for annual, group by year
   let cumulativeInvested = props.investment.StartingBalance;
   const scheduleEntries: ScheduleEntry[] = schedule.map((entry) => {
@@ -98,6 +106,7 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
     return {
       period: entry.Period,
       date: periodDate.format(getDateFormat()),
+      contributionAmount: entry.ContributionAmount,
       totalInvested: cumulativeInvested,
       interestAccrued: entry.InterestEarned,
       balance: entry.TotalValue,
@@ -129,6 +138,7 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
                 <TableRow>
                   <TableCell>{getPeriodLabel()}</TableCell>
                   <TableCell>Date</TableCell>
+                  {hasStepUp && <TableCell>Contribution</TableCell>}
                   <TableCell>Total Invested</TableCell>
                   <TableCell>Interest This Period</TableCell>
                   <TableCell>Balance</TableCell>
@@ -139,6 +149,16 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
                   <TableRow key={entry.period}>
                     <TableCell>{entry.period}</TableCell>
                     <TableCell>{entry.date}</TableCell>
+                    {hasStepUp && (
+                      <TableCell>
+                        {entry.contributionAmount.toLocaleString(undefined, {
+                          style: 'currency',
+                          currency: 'USD',
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </TableCell>
+                    )}
                     <TableCell>
                       {entry.totalInvested.toLocaleString(undefined, {
                         style: 'currency',

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -15,7 +15,11 @@ import {
   useMediaQuery,
   IconButton,
 } from '@mui/material';
-import { Investment, CompoundingFrequency } from '../models/investment-model';
+import {
+  Investment,
+  CompoundingFrequency,
+  StepUpType,
+} from '../models/investment-model';
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
 import { Calculate, Edit, TrendingUp } from '@mui/icons-material';
 import { useState } from 'react';
@@ -39,6 +43,18 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
 
   const formatPercent = (rate: number) => {
     return `${rate.toFixed(3)}%`;
+  };
+
+  const formatContribution = (investment: Investment): string => {
+    if (!investment.RecurringContribution) return 'None';
+    const base = formatCurrency(investment.RecurringContribution);
+    if (!investment.ContributionStepUpType || !investment.ContributionStepUpAmount)
+      return base;
+    const stepUp =
+      investment.ContributionStepUpType === StepUpType.Flat
+        ? `+${formatCurrency(investment.ContributionStepUpAmount)}/yr`
+        : `+${investment.ContributionStepUpAmount}%/yr`;
+    return `${base} (${stepUp})`;
   };
 
   const getCompoundingText = (period: CompoundingFrequency) => {
@@ -135,9 +151,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                 <strong>Recurring:</strong>
               </Typography>
               <Typography variant="body2">
-                {investment.RecurringContribution
-                  ? formatCurrency(investment.RecurringContribution)
-                  : 'None'}
+                {formatContribution(investment)}
               </Typography>
             </Grid>
           </Grid>
@@ -205,11 +219,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                   <TableCell>
                     {getCompoundingText(row.CompoundingPeriod)}
                   </TableCell>
-                  <TableCell>
-                    {row.RecurringContribution
-                      ? formatCurrency(row.RecurringContribution)
-                      : 'None'}
-                  </TableCell>
+                  <TableCell>{formatContribution(row)}</TableCell>
                   <TableCell>
                     <InvestmentActions investment={row} isMobile={false} />
                   </TableCell>

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -178,7 +178,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
       {isMobile ? (
         <Box>
           {props.investments.map((investment) => (
-            <InvestmentCard key={investment.Name} investment={investment} />
+            <InvestmentCard key={investment.Id} investment={investment} />
           ))}
         </Box>
       ) : (
@@ -197,7 +197,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
             </TableHead>
             <TableBody>
               {props.investments.map((row) => (
-                <TableRow key={row.Name}>
+                <TableRow key={row.Id}>
                   <TableCell>{row.Name}</TableCell>
                   <TableCell>{row.Provider}</TableCell>
                   <TableCell>{formatCurrency(row.StartingBalance)}</TableCell>

--- a/src/loan/amortization-popout.tsx
+++ b/src/loan/amortization-popout.tsx
@@ -31,7 +31,7 @@ export const AmortizationPopout = (props: AmortizationPopoutProps) => {
         vertical: 'center',
         horizontal: 'center',
       }}
-      style={{ maxHeight: '90vh' }}
+      sx={{ maxHeight: '90vh' }}
     >
       <Card>
         <CardContent>

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -155,7 +155,7 @@ export const LoanTable = (props: LoanTableProps) => {
       {isMobile ? (
         <Box>
           {props.loans.map((loan) => (
-            <LoanCard key={loan.Name} loan={loan} />
+            <LoanCard key={loan.Id} loan={loan} />
           ))}
         </Box>
       ) : (
@@ -174,7 +174,7 @@ export const LoanTable = (props: LoanTableProps) => {
             </TableHead>
             <TableBody>
               {props.loans.map((row) => (
-                <TableRow key={row.Name}>
+                <TableRow key={row.Id}>
                   <TableCell>{row.Name}</TableCell>
                   <TableCell>{row.Provider}</TableCell>
                   <TableCell>{formatCurrency(row.Principal)}</TableCell>

--- a/src/loan/pit-popout.tsx
+++ b/src/loan/pit-popout.tsx
@@ -92,6 +92,15 @@ export const PitPopout = (props: PitPopoutProps) => {
                 maximumFractionDigits: 2,
               }
             )}`}</Typography>
+            <Typography>{`Paid Interest: ${pitLoan.PaidInterest.toLocaleString(
+              undefined,
+              {
+                style: 'currency',
+                currency: 'USD',
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2,
+              }
+            )}`}</Typography>
             <Typography>{`Remaining Principal: ${pitLoan.RemainingPrincipal.toLocaleString(
               undefined,
               {

--- a/src/models/investment-model.ts
+++ b/src/models/investment-model.ts
@@ -4,6 +4,11 @@ export enum CompoundingFrequency {
   Annually = 'annually',
 }
 
+export enum StepUpType {
+  Flat = 'flat',
+  Percentage = 'percentage',
+}
+
 export interface Investment {
   Id: string;
   Provider: string;
@@ -14,6 +19,8 @@ export interface Investment {
   CompoundingPeriod: CompoundingFrequency;
   RecurringContribution?: number;
   ContributionFrequency?: CompoundingFrequency;
+  ContributionStepUpAmount?: number; // Yearly step-up: flat dollar amount or percentage value
+  ContributionStepUpType?: StepUpType; // Type of step-up: flat or percentage
   CurrentValue?: number; // Calculated field
   ProjectedGrowth?: InvestmentGrowthEntry[]; // Calculated field
 }


### PR DESCRIPTION
Squashes and rebases two Copilot PRs onto current main, with lockfile and version fixes applied.

## Step-up investment contributions (fixes #21)

Adds a yearly step-up to investment recurring contributions — either a flat dollar amount or a compounding percentage — applied at each anniversary of the investment start date.

**Model changes** (`investment-model.ts`): `StepUpType` enum, `ContributionStepUpAmount` and `ContributionStepUpType` optional fields on `Investment`.

**New helpers** (`investment-helpers.ts`):
- `getAnniversaryDate` — leap-year-safe anniversary calculation
- `hasPassedAnniversary` — shared helper used by period calc and step-up
- `getContributionForYear` — returns contribution amount for a given year number
- `getContributionsWithStepUp` — replaces simple `getContributionsInPeriod * base` in `generateInvestmentGrowth`, iterating contribution dates and applying the step-up at year boundaries

**UI** (`add-edit-investment.tsx`): step-up type selector and amount/percentage input, shown only when a recurring contribution is set.

## Bug fixes

- **`getPitCalculation` wrong `PaidInterest`** (`loan-helpers.ts`): reduced over the full pre-attached amortization schedule instead of slicing to `paidTerms`. For a 30-year loan queried at year 1, users saw ~30 years of interest as "Paid Interest". Fixed with `.slice(0, paidTerms)`.
- **Non-unique React keys** (`loan-table.tsx`, `investment-table.tsx`): keyed on `Name` instead of `Id` — two identically-named items would mis-reconcile. Changed to `Id`.
- **Loan PIT popup never showed `PaidInterest`** (`pit-popout.tsx`): field was computed but omitted from the render.
- `sx` instead of `style` prop on `Popover` in amortization/growth popouts
- `useState` declarations moved before test data in `Body.tsx`
- Prettier formatting fixes in `data-helpers`

## Other

- Reverted `package-lock.json` changes from both PRs (both deleted a `yaml` entry that breaks `npm ci`)
- Version bumped to `0.6.0`

Closes #29
Closes #33