### PR TITLE
Fix Pages deploy: bump CI to Node 24 to match lock file npm version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem
The "Deploy to GitHub Pages" workflow fails on main at `npm ci`:

```
npm error Missing: yaml@2.9.0 from lock file
```

## Root cause
`vite@7.3.0` (nested under `vitest`) declares `yaml` as an **optional** peer dependency. npm 10 (bundled with Node 20, used by CI) expects a nested `yaml` entry in the lock file, while npm 11 (Node 24, used locally) omits it. PR #34 regenerated the lock with npm 11, which deleted the `node_modules/vitest/node_modules/yaml` entry — valid for npm 11, out-of-sync for npm 10.

## Fix
Bump the workflow's Node version from 20 to 24 so CI uses the same npm major as the environment that generates the lock file. Node 20 is also past EOL (April 2026).

Verified locally on npm 11.13.0: `npm ci` and `npm run build` both pass against the current lock file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
