### PR TITLE
Add CI workflow for PRs and main (roadmap 0.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run check:lint
+
+      - name: Check formatting
+        run: npm run check:format
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/src/investment/growth-schedule-popout.tsx
+++ b/src/investment/growth-schedule-popout.tsx
@@ -11,10 +11,7 @@ import {
   TableRow,
   Typography,
 } from '@mui/material';
-import {
-  Investment,
-  CompoundingFrequency,
-} from '../models/investment-model';
+import { Investment, CompoundingFrequency } from '../models/investment-model';
 import {
   generateInvestmentGrowth,
   getPeriodsPerYear,

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -48,7 +48,10 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
   const formatContribution = (investment: Investment): string => {
     if (!investment.RecurringContribution) return 'None';
     const base = formatCurrency(investment.RecurringContribution);
-    if (!investment.ContributionStepUpType || !investment.ContributionStepUpAmount)
+    if (
+      !investment.ContributionStepUpType ||
+      !investment.ContributionStepUpAmount
+    )
       return base;
     const stepUp =
       investment.ContributionStepUpType === StepUpType.Flat


### PR DESCRIPTION
## Summary
Roadmap Phase 0, item 0.1: adds `.github/workflows/ci.yml` running the four checks the repo already defines — `check:lint`, `check:format`, `test`, `build` — on every pull request and push to `main`. The deploy workflow is unchanged. Node 24 matches the existing deploy setup.

Also fixes pre-existing Prettier drift in `growth-schedule-popout.tsx` and `investment-table.tsx` (5 lines each) so the format gate starts green.

Verified locally: 92 tests pass, lint clean, format clean, production build succeeds.

No behavior change; no version bump per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)