### PR TITLE
Add date-indexed forecast engine (roadmap 0.2)

### DIFF
--- a/src/helpers/forecast-helpers.test.ts
+++ b/src/helpers/forecast-helpers.test.ts
@@ -82,6 +82,15 @@ describe('Forecast Helpers', () => {
       expect(series[12].Date.getTime()).toBe(monthsFromToday(12).getTime());
     });
 
+    it('should span past a horizon that falls mid-month', () => {
+      const horizon = dayjs(today).add(12, 'month').add(10, 'day').toDate();
+      const series = forecastLoan(makeLoan(), horizon, 0, today);
+      expect(series).toHaveLength(14);
+      expect(series[series.length - 1].Date.getTime()).toBeGreaterThanOrEqual(
+        horizon.getTime()
+      );
+    });
+
     it('should anchor the first point to CurrentAmount, not Principal', () => {
       const loan = makeLoan({ Principal: 10000, CurrentAmount: 6000 });
       const series = forecastLoan(loan, monthsFromToday(12), 0, today);
@@ -153,18 +162,33 @@ describe('Forecast Helpers', () => {
       expect(series[12].Value).toBeGreaterThan(10000);
     });
 
-    it('should derive the payment when MonthlyPayment is missing', () => {
+    it('should derive a payment from the current balance and remaining term when MonthlyPayment is missing', () => {
       const loan = makeLoan({
         InterestRate: 6,
-        Principal: 12000,
+        Principal: 24000,
         CurrentAmount: 12000,
-        StartDate: today,
+        StartDate: new Date(2024, 5, 1),
         EndDate: monthsFromToday(12),
         MonthlyPayment: undefined,
       });
       const series = forecastLoan(loan, monthsFromToday(12), 0, today);
       expect(series[1].Value).toBeLessThan(series[0].Value);
-      expect(series[12].Value).toBeLessThan(series[1].Value);
+      // Derived payment should amortize today's balance by the end date.
+      expect(series[12].Value).toBeLessThan(1);
+    });
+
+    it('should derive a principal-only payment for a zero-interest loan', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        Principal: 12000,
+        CurrentAmount: 6000,
+        StartDate: new Date(2024, 5, 1),
+        EndDate: monthsFromToday(12),
+        MonthlyPayment: undefined,
+      });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      expect(series[1].Value).toBe(5500);
+      expect(series[12].Value).toBe(0);
     });
   });
 
@@ -259,6 +283,43 @@ describe('Forecast Helpers', () => {
         today
       );
       expect(series[12].Value).toBe(1000 + 4 * 100);
+    });
+
+    it('should not apply contributions when ContributionFrequency is missing', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: undefined,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      series.forEach((point) => expect(point.Value).toBe(1000));
+    });
+
+    it('should anchor contribution cadence to the investment start date', () => {
+      const investment = makeInvestment({
+        StartDate: new Date(2026, 3, 1), // April 1, 2026 — off-cycle vs. today
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Quarterly,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      // Cadence runs Apr/Jul/Oct/Jan regardless of the forecast run date:
+      // contributions land at months 1 (Jul), 4 (Oct), 7 (Jan), 10 (Apr).
+      expect(series[1].Value).toBe(1100);
+      expect(series[3].Value).toBe(1100);
+      expect(series[4].Value).toBe(1200);
+      expect(series[10].Value).toBe(1400);
+      expect(series[12].Value).toBe(1400);
     });
 
     it('should add extra monthly contributions on top of recurring ones', () => {

--- a/src/helpers/forecast-helpers.test.ts
+++ b/src/helpers/forecast-helpers.test.ts
@@ -1,0 +1,400 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+import {
+  forecastLoan,
+  forecastInvestment,
+  forecastNetWorth,
+  getDefaultHorizon,
+  getPayoffDate,
+} from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
+import { generateInvestmentGrowth } from './investment-helpers';
+
+// Fixed reference date so every test is deterministic.
+const today = new Date(2026, 5, 1); // June 1, 2026
+
+const monthsFromToday = (months: number): Date =>
+  dayjs(today).add(months, 'month').toDate();
+
+const makeLoan = (overrides: Partial<Loan> = {}): Loan => ({
+  Id: 'loan-1',
+  Provider: 'Test Bank',
+  Name: 'Test Loan',
+  InterestRate: 0,
+  StartDate: new Date(2024, 5, 1),
+  EndDate: new Date(2034, 5, 1),
+  Principal: 10000,
+  CurrentAmount: 10000,
+  MonthlyPayment: 500,
+  ...overrides,
+});
+
+const makeInvestment = (overrides: Partial<Investment> = {}): Investment => ({
+  Id: 'inv-1',
+  Provider: 'Test Fund',
+  Name: 'Test Investment',
+  StartDate: today,
+  StartingBalance: 1000,
+  AverageReturnRate: 0,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...overrides,
+});
+
+describe('Forecast Helpers', () => {
+  describe('getDefaultHorizon', () => {
+    it('should return 30 years from today when there is no data', () => {
+      const horizon = getDefaultHorizon([], [], today);
+      expect(horizon.getTime()).toBe(dayjs(today).add(30, 'year').valueOf());
+    });
+
+    it('should return the latest loan end date when only loans exist', () => {
+      const loans = [
+        makeLoan({ EndDate: new Date(2040, 0, 1) }),
+        makeLoan({ Id: 'loan-2', EndDate: new Date(2035, 0, 1) }),
+      ];
+      const horizon = getDefaultHorizon(loans, [], today);
+      expect(horizon.getTime()).toBe(new Date(2040, 0, 1).getTime());
+    });
+
+    it('should extend to 30 years from today when investments exist', () => {
+      const loans = [makeLoan({ EndDate: new Date(2030, 0, 1) })];
+      const horizon = getDefaultHorizon(loans, [makeInvestment()], today);
+      expect(horizon.getTime()).toBe(dayjs(today).add(30, 'year').valueOf());
+    });
+
+    it('should keep a loan end date beyond 30 years even with investments', () => {
+      const loans = [makeLoan({ EndDate: new Date(2070, 0, 1) })];
+      const horizon = getDefaultHorizon(loans, [makeInvestment()], today);
+      expect(horizon.getTime()).toBe(new Date(2070, 0, 1).getTime());
+    });
+  });
+
+  describe('forecastLoan', () => {
+    it('should produce one point per month plus the anchor point', () => {
+      const series = forecastLoan(makeLoan(), monthsFromToday(12), 0, today);
+      expect(series).toHaveLength(13);
+      expect(series[0].Date.getTime()).toBe(today.getTime());
+      expect(series[12].Date.getTime()).toBe(monthsFromToday(12).getTime());
+    });
+
+    it('should anchor the first point to CurrentAmount, not Principal', () => {
+      const loan = makeLoan({ Principal: 10000, CurrentAmount: 6000 });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      expect(series[0].Value).toBe(6000);
+    });
+
+    it('should pay off a zero-interest loan in exactly balance/payment months', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        CurrentAmount: 1200,
+        MonthlyPayment: 100,
+      });
+      const series = forecastLoan(loan, monthsFromToday(15), 0, today);
+      expect(series[11].Value).toBe(100);
+      expect(series[12].Value).toBe(0);
+    });
+
+    it('should keep the balance at zero after payoff', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        CurrentAmount: 1200,
+        MonthlyPayment: 100,
+      });
+      const series = forecastLoan(loan, monthsFromToday(24), 0, today);
+      series.slice(12).forEach((point) => expect(point.Value).toBe(0));
+    });
+
+    it('should apply monthly interest before the payment', () => {
+      const loan = makeLoan({
+        InterestRate: 12,
+        CurrentAmount: 10000,
+        MonthlyPayment: 500,
+      });
+      const series = forecastLoan(loan, monthsFromToday(1), 0, today);
+      // 10000 + 1% interest - 500 payment
+      expect(series[1].Value).toBeCloseTo(9600, 2);
+    });
+
+    it('should shorten the payoff with an extra monthly payment', () => {
+      const loan = makeLoan({
+        InterestRate: 5,
+        CurrentAmount: 10000,
+        MonthlyPayment: 500,
+      });
+      const horizon = monthsFromToday(36);
+      const baseline = forecastLoan(loan, horizon, 0, today);
+      const accelerated = forecastLoan(loan, horizon, 500, today);
+
+      const basePayoff = getPayoffDate(baseline);
+      const fastPayoff = getPayoffDate(accelerated);
+      expect(basePayoff).toBeDefined();
+      expect(fastPayoff).toBeDefined();
+      expect(fastPayoff!.getTime()).toBeLessThan(basePayoff!.getTime());
+    });
+
+    it('should return all zeros for an already paid-off loan', () => {
+      const loan = makeLoan({ CurrentAmount: 0 });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      series.forEach((point) => expect(point.Value).toBe(0));
+    });
+
+    it('should grow the balance when the payment does not cover interest', () => {
+      const loan = makeLoan({
+        InterestRate: 12,
+        CurrentAmount: 10000,
+        MonthlyPayment: 50,
+      });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      expect(series[12].Value).toBeGreaterThan(10000);
+    });
+
+    it('should derive the payment when MonthlyPayment is missing', () => {
+      const loan = makeLoan({
+        InterestRate: 6,
+        Principal: 12000,
+        CurrentAmount: 12000,
+        StartDate: today,
+        EndDate: monthsFromToday(12),
+        MonthlyPayment: undefined,
+      });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      expect(series[1].Value).toBeLessThan(series[0].Value);
+      expect(series[12].Value).toBeLessThan(series[1].Value);
+    });
+  });
+
+  describe('forecastInvestment', () => {
+    it('should anchor the first point to CurrentValue when present', () => {
+      const investment = makeInvestment({ CurrentValue: 2500 });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      expect(series[0].Value).toBe(2500);
+    });
+
+    it('should anchor to the value projected for today when CurrentValue is missing', () => {
+      const investment = makeInvestment({
+        StartDate: new Date(2020, 0, 1),
+        StartingBalance: 5000,
+        AverageReturnRate: 5,
+        CompoundingPeriod: CompoundingFrequency.Annually,
+      });
+      const growth = generateInvestmentGrowth(investment, today);
+      const expected = growth[growth.length - 1].TotalValue;
+
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      expect(series[0].Value).toBe(expected);
+    });
+
+    it('should compound annually at the end of each year', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        AverageReturnRate: 5,
+        CompoundingPeriod: CompoundingFrequency.Annually,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      expect(series[11].Value).toBe(1000);
+      expect(series[12].Value).toBeCloseTo(1050, 2);
+    });
+
+    it('should compound monthly each month', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        AverageReturnRate: 12,
+        CompoundingPeriod: CompoundingFrequency.Monthly,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(2),
+        0,
+        today
+      );
+      expect(series[1].Value).toBeCloseTo(1010, 2);
+      expect(series[2].Value).toBeCloseTo(1020.1, 2);
+    });
+
+    it('should add monthly contributions', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      expect(series[12].Value).toBe(1000 + 12 * 100);
+    });
+
+    it('should add quarterly contributions four times per year', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Quarterly,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      expect(series[12].Value).toBe(1000 + 4 * 100);
+    });
+
+    it('should add extra monthly contributions on top of recurring ones', () => {
+      const investment = makeInvestment({
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        50,
+        today
+      );
+      expect(series[12].Value).toBe(1000 + 12 * 100 + 12 * 50);
+    });
+
+    it('should apply the yearly step-up at the investment anniversary', () => {
+      const investment = makeInvestment({
+        StartDate: today,
+        CurrentValue: 1000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+        ContributionStepUpAmount: 50,
+        ContributionStepUpType: StepUpType.Flat,
+      });
+      const series = forecastInvestment(
+        investment,
+        monthsFromToday(12),
+        0,
+        today
+      );
+      // Months 1-11 fall in year one (100 each); month 12 lands on the
+      // anniversary and steps up to 150.
+      expect(series[12].Value).toBe(1000 + 11 * 100 + 150);
+    });
+  });
+
+  describe('forecastNetWorth', () => {
+    it('should equal investments minus loans at every point', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        CurrentAmount: 1200,
+        MonthlyPayment: 100,
+      });
+      const investment = makeInvestment({
+        CurrentValue: 5000,
+        RecurringContribution: 100,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+      });
+      const horizon = monthsFromToday(12);
+
+      const loanSeries = forecastLoan(loan, horizon, 0, today);
+      const investmentSeries = forecastInvestment(
+        investment,
+        horizon,
+        0,
+        today
+      );
+      const netWorth = forecastNetWorth(
+        [loan],
+        [investment],
+        horizon,
+        undefined,
+        today
+      );
+
+      expect(netWorth).toHaveLength(13);
+      netWorth.forEach((point, index) => {
+        expect(point.Value).toBeCloseTo(
+          investmentSeries[index].Value - loanSeries[index].Value,
+          2
+        );
+      });
+    });
+
+    it('should improve net worth at the horizon when a scenario adds loan payments', () => {
+      const loan = makeLoan({
+        InterestRate: 12,
+        CurrentAmount: 10000,
+        MonthlyPayment: 200,
+      });
+      const horizon = monthsFromToday(12);
+
+      const baseline = forecastNetWorth([loan], [], horizon, undefined, today);
+      const scenario = forecastNetWorth(
+        [loan],
+        [],
+        horizon,
+        { ExtraLoanPayments: { 'loan-1': 300 } },
+        today
+      );
+
+      expect(scenario[12].Value).toBeGreaterThan(baseline[12].Value);
+    });
+
+    it('should ignore scenario entries whose IDs match nothing', () => {
+      const loan = makeLoan();
+      const horizon = monthsFromToday(12);
+
+      const baseline = forecastNetWorth([loan], [], horizon, undefined, today);
+      const scenario = forecastNetWorth(
+        [loan],
+        [],
+        horizon,
+        { ExtraLoanPayments: { 'no-such-loan': 300 } },
+        today
+      );
+
+      baseline.forEach((point, index) => {
+        expect(scenario[index].Value).toBe(point.Value);
+      });
+    });
+  });
+
+  describe('getPayoffDate', () => {
+    it('should return the first date the series reaches zero', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        CurrentAmount: 1200,
+        MonthlyPayment: 100,
+      });
+      const series = forecastLoan(loan, monthsFromToday(24), 0, today);
+      expect(getPayoffDate(series)!.getTime()).toBe(
+        monthsFromToday(12).getTime()
+      );
+    });
+
+    it('should return undefined when the loan outlives the horizon', () => {
+      const loan = makeLoan({
+        InterestRate: 0,
+        CurrentAmount: 100000,
+        MonthlyPayment: 100,
+      });
+      const series = forecastLoan(loan, monthsFromToday(12), 0, today);
+      expect(getPayoffDate(series)).toBeUndefined();
+    });
+  });
+});

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -2,7 +2,7 @@ import dayjs from 'dayjs';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
 import { ForecastPoint, ScenarioInput } from '../models/forecast-model';
-import { getMonthlyPayment, getTerms } from './loan-helpers';
+import { getMonthlyPayment } from './loan-helpers';
 import {
   generateInvestmentGrowth,
   getContributionForYear,
@@ -12,9 +12,10 @@ import {
 
 const roundToCents = (value: number): number => Math.round(value * 100) / 100;
 
-// Number of whole months from start to end (never negative).
+// Number of months from start to end, rounded up so a series always spans
+// at least to the requested end date (never negative).
 const getMonthsBetween = (start: Date, end: Date): number =>
-  Math.max(0, dayjs(end).diff(dayjs(start), 'month'));
+  Math.max(0, Math.ceil(dayjs(end).diff(dayjs(start), 'month', true)));
 
 // Months between occurrences for a frequency (monthly=1, quarterly=3, annually=12).
 const getIntervalMonths = (frequency: CompoundingFrequency): number =>
@@ -64,24 +65,30 @@ export const forecastLoan = (
   const months = getMonthsBetween(today, horizon);
   const start = dayjs(today);
   const monthlyRate = loan.InterestRate / 100 / 12;
+
+  let balance = roundToCents(Math.max(loan.CurrentAmount, 0));
+
+  // When no payment is stored, derive one that amortizes today's actual
+  // balance over the remaining term — not the original principal over the
+  // full term, which would mis-estimate an anchored forecast.
+  const remainingTerms = Math.max(1, getMonthsBetween(today, loan.EndDate));
   const basePayment =
     loan.MonthlyPayment ??
-    getMonthlyPayment(loan.Principal, loan.InterestRate, getTerms(loan));
+    (loan.InterestRate > 0
+      ? getMonthlyPayment(balance, loan.InterestRate, remainingTerms)
+      : roundToCents(balance / remainingTerms));
   const payment = basePayment + extraMonthlyPayment;
 
-  let balance = Math.max(loan.CurrentAmount, 0);
-  const points: ForecastPoint[] = [
-    { Date: start.toDate(), Value: roundToCents(balance) },
-  ];
+  const points: ForecastPoint[] = [{ Date: start.toDate(), Value: balance }];
 
   for (let month = 1; month <= months; month++) {
     if (balance > 0) {
       const interest = balance * monthlyRate;
-      balance = Math.max(0, balance + interest - payment);
+      balance = roundToCents(Math.max(0, balance + interest - payment));
     }
     points.push({
       Date: start.add(month, 'month').toDate(),
-      Value: roundToCents(balance),
+      Value: balance,
     });
   }
 
@@ -91,10 +98,11 @@ export const forecastLoan = (
 // Forecast an investment's value month by month from today to the horizon.
 // The series is anchored to CurrentValue when provided, otherwise to the
 // value projected for today from the investment's historical inputs.
-// Contributions land at the start of each contribution interval (with any
-// configured yearly step-up, anchored to the investment's start date);
-// interest compounds at the end of each compounding interval. Index 0 is
-// today.
+// Contribution and compounding cadence is anchored to the investment's
+// StartDate at calendar-month granularity (matching the date-based schedule
+// of generateInvestmentGrowth), so a forecast does not shift depending on
+// when it is generated. Yearly step-ups follow StartDate anniversaries.
+// Index 0 is today.
 export const forecastInvestment = (
   investment: Investment,
   horizon: Date,
@@ -116,10 +124,17 @@ export const forecastInvestment = (
     100 /
     getPeriodsPerYear(investment.CompoundingPeriod);
   const compoundingInterval = getIntervalMonths(investment.CompoundingPeriod);
-  const contributionInterval = getIntervalMonths(
-    investment.ContributionFrequency ?? CompoundingFrequency.Monthly
-  );
-  const baseContribution = investment.RecurringContribution ?? 0;
+
+  // Match generateInvestmentGrowth: contributions only apply when both the
+  // amount and the frequency are set.
+  const baseContribution = investment.ContributionFrequency
+    ? (investment.RecurringContribution ?? 0)
+    : 0;
+  const contributionInterval = investment.ContributionFrequency
+    ? getIntervalMonths(investment.ContributionFrequency)
+    : 1;
+
+  const investmentStartMonth = dayjs(investment.StartDate).startOf('month');
 
   let value = anchorValue;
   const points: ForecastPoint[] = [
@@ -128,8 +143,17 @@ export const forecastInvestment = (
 
   for (let month = 1; month <= months; month++) {
     const monthDate = start.add(month, 'month');
+    // Calendar months since the investment started; events stay anchored to
+    // the StartDate cadence regardless of the forecast's run date.
+    const elapsedMonths = monthDate
+      .startOf('month')
+      .diff(investmentStartMonth, 'month');
 
-    if (baseContribution > 0 && (month - 1) % contributionInterval === 0) {
+    if (
+      baseContribution > 0 &&
+      elapsedMonths >= 0 &&
+      elapsedMonths % contributionInterval === 0
+    ) {
       const yearNumber = getInvestmentYear(
         monthDate.toDate(),
         investment.StartDate
@@ -146,7 +170,7 @@ export const forecastInvestment = (
       value += extraMonthlyContribution;
     }
 
-    if (month % compoundingInterval === 0) {
+    if (elapsedMonths > 0 && elapsedMonths % compoundingInterval === 0) {
       value *= 1 + periodRate;
     }
 

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -1,0 +1,214 @@
+import dayjs from 'dayjs';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+import { ForecastPoint, ScenarioInput } from '../models/forecast-model';
+import { getMonthlyPayment, getTerms } from './loan-helpers';
+import {
+  generateInvestmentGrowth,
+  getContributionForYear,
+  getInvestmentYear,
+  getPeriodsPerYear,
+} from './investment-helpers';
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+// Number of whole months from start to end (never negative).
+const getMonthsBetween = (start: Date, end: Date): number =>
+  Math.max(0, dayjs(end).diff(dayjs(start), 'month'));
+
+// Months between occurrences for a frequency (monthly=1, quarterly=3, annually=12).
+const getIntervalMonths = (frequency: CompoundingFrequency): number =>
+  12 / getPeriodsPerYear(frequency);
+
+// Default chart horizon: the longest loan schedule, extended to at least
+// 30 years from today when any investments exist (or when there is nothing
+// else to anchor to).
+export const getDefaultHorizon = (
+  loans: Loan[],
+  investments: Investment[],
+  today: Date = new Date()
+): Date => {
+  const thirtyYearsOut = dayjs(today).add(30, 'year');
+
+  const latestLoanEnd = loans.reduce<dayjs.Dayjs | undefined>(
+    (latest, loan) => {
+      const end = dayjs(loan.EndDate);
+      return !latest || end.isAfter(latest) ? end : latest;
+    },
+    undefined
+  );
+
+  if (!latestLoanEnd) {
+    return thirtyYearsOut.toDate();
+  }
+
+  if (investments.length > 0 && thirtyYearsOut.isAfter(latestLoanEnd)) {
+    return thirtyYearsOut.toDate();
+  }
+
+  return latestLoanEnd.toDate();
+};
+
+// Forecast a loan's remaining balance month by month from today to the
+// horizon. The series is anchored to CurrentAmount (today's actual balance)
+// rather than replaying the theoretical schedule from StartDate, so the
+// forecast starts from reality even after past extra payments or drift.
+// Index 0 is today; the balance stays at 0 after payoff so series can be
+// summed across entities on a shared axis.
+export const forecastLoan = (
+  loan: Loan,
+  horizon: Date,
+  extraMonthlyPayment: number = 0,
+  today: Date = new Date()
+): ForecastPoint[] => {
+  const months = getMonthsBetween(today, horizon);
+  const start = dayjs(today);
+  const monthlyRate = loan.InterestRate / 100 / 12;
+  const basePayment =
+    loan.MonthlyPayment ??
+    getMonthlyPayment(loan.Principal, loan.InterestRate, getTerms(loan));
+  const payment = basePayment + extraMonthlyPayment;
+
+  let balance = Math.max(loan.CurrentAmount, 0);
+  const points: ForecastPoint[] = [
+    { Date: start.toDate(), Value: roundToCents(balance) },
+  ];
+
+  for (let month = 1; month <= months; month++) {
+    if (balance > 0) {
+      const interest = balance * monthlyRate;
+      balance = Math.max(0, balance + interest - payment);
+    }
+    points.push({
+      Date: start.add(month, 'month').toDate(),
+      Value: roundToCents(balance),
+    });
+  }
+
+  return points;
+};
+
+// Forecast an investment's value month by month from today to the horizon.
+// The series is anchored to CurrentValue when provided, otherwise to the
+// value projected for today from the investment's historical inputs.
+// Contributions land at the start of each contribution interval (with any
+// configured yearly step-up, anchored to the investment's start date);
+// interest compounds at the end of each compounding interval. Index 0 is
+// today.
+export const forecastInvestment = (
+  investment: Investment,
+  horizon: Date,
+  extraMonthlyContribution: number = 0,
+  today: Date = new Date()
+): ForecastPoint[] => {
+  const months = getMonthsBetween(today, horizon);
+  const start = dayjs(today);
+
+  const growthToToday = generateInvestmentGrowth(investment, today);
+  const anchorValue =
+    investment.CurrentValue ??
+    (growthToToday.length > 0
+      ? growthToToday[growthToToday.length - 1].TotalValue
+      : investment.StartingBalance);
+
+  const periodRate =
+    investment.AverageReturnRate /
+    100 /
+    getPeriodsPerYear(investment.CompoundingPeriod);
+  const compoundingInterval = getIntervalMonths(investment.CompoundingPeriod);
+  const contributionInterval = getIntervalMonths(
+    investment.ContributionFrequency ?? CompoundingFrequency.Monthly
+  );
+  const baseContribution = investment.RecurringContribution ?? 0;
+
+  let value = anchorValue;
+  const points: ForecastPoint[] = [
+    { Date: start.toDate(), Value: roundToCents(value) },
+  ];
+
+  for (let month = 1; month <= months; month++) {
+    const monthDate = start.add(month, 'month');
+
+    if (baseContribution > 0 && (month - 1) % contributionInterval === 0) {
+      const yearNumber = getInvestmentYear(
+        monthDate.toDate(),
+        investment.StartDate
+      );
+      value += getContributionForYear(
+        baseContribution,
+        yearNumber,
+        investment.ContributionStepUpAmount,
+        investment.ContributionStepUpType
+      );
+    }
+
+    if (extraMonthlyContribution > 0) {
+      value += extraMonthlyContribution;
+    }
+
+    if (month % compoundingInterval === 0) {
+      value *= 1 + periodRate;
+    }
+
+    points.push({
+      Date: monthDate.toDate(),
+      Value: roundToCents(value),
+    });
+  }
+
+  return points;
+};
+
+// Forecast overall net worth (total investment value minus total loan
+// balance) on a shared monthly axis from today to the horizon. Scenario
+// extras are applied to the matching entities by ID.
+export const forecastNetWorth = (
+  loans: Loan[],
+  investments: Investment[],
+  horizon: Date,
+  scenario?: ScenarioInput,
+  today: Date = new Date()
+): ForecastPoint[] => {
+  const months = getMonthsBetween(today, horizon);
+  const start = dayjs(today);
+
+  const loanSeries = loans.map((loan) =>
+    forecastLoan(
+      loan,
+      horizon,
+      scenario?.ExtraLoanPayments?.[loan.Id] ?? 0,
+      today
+    )
+  );
+  const investmentSeries = investments.map((investment) =>
+    forecastInvestment(
+      investment,
+      horizon,
+      scenario?.ExtraContributions?.[investment.Id] ?? 0,
+      today
+    )
+  );
+
+  const points: ForecastPoint[] = [];
+  for (let month = 0; month <= months; month++) {
+    const assets = investmentSeries.reduce(
+      (sum, series) => sum + series[month].Value,
+      0
+    );
+    const debts = loanSeries.reduce(
+      (sum, series) => sum + series[month].Value,
+      0
+    );
+    points.push({
+      Date: start.add(month, 'month').toDate(),
+      Value: roundToCents(assets - debts),
+    });
+  }
+
+  return points;
+};
+
+// First date a forecast series reaches zero, or undefined if it never does
+// within the series (e.g. payoff falls beyond the horizon).
+export const getPayoffDate = (series: ForecastPoint[]): Date | undefined =>
+  series.find((point) => point.Value === 0)?.Date;

--- a/src/models/forecast-model.ts
+++ b/src/models/forecast-model.ts
@@ -1,0 +1,16 @@
+// A single point on a date-indexed monthly forecast series.
+// For loans the value is the remaining balance (a liability);
+// for investments it is the projected value; for net worth it is
+// total investment value minus total loan balance.
+export type ForecastPoint = {
+  Date: Date;
+  Value: number;
+};
+
+// Extra monthly amounts applied on top of existing payments/contributions,
+// keyed by entity ID. Used to model what-if scenarios without mutating the
+// underlying loans/investments.
+export type ScenarioInput = {
+  ExtraLoanPayments?: Record<string, number>;
+  ExtraContributions?: Record<string, number>;
+};


### PR DESCRIPTION
## Summary
Roadmap Phase 0, item 0.2 — the shared time-series engine that charts (#18), scenarios (#24), the net worth dashboard, and the next-dollar optimizer all build on.

New pure module `src/helpers/forecast-helpers.ts` (+ `src/models/forecast-model.ts` types) projecting everything onto a **shared monthly date axis from today to a horizon**:

- `forecastLoan(loan, horizon, extraMonthlyPayment?, today?)` — balance series **anchored to `CurrentAmount`** (today actual balance) instead of replaying the theoretical schedule from `StartDate` (closes gap G4); supports extra monthly payments (gap G5); balance holds at 0 after payoff so series sum cleanly
- `forecastInvestment(investment, horizon, extraMonthlyContribution?, today?)` — value series anchored to `CurrentValue` (or the value projected for today from historical inputs); honors compounding frequency, contribution frequency, and yearly step-ups (reuses the tested `getContributionForYear`/`getInvestmentYear` logic)
- `forecastNetWorth(loans, investments, horizon, scenario?, today?)` — total investments minus total loans on the shared axis; `ScenarioInput` applies per-entity extras by ID, designed for Phase 4 overlays and Phase 5 allocation plans
- `getDefaultHorizon` — longest loan schedule, extended to 30 years from today when investments exist (per issue #18)
- `getPayoffDate` — first zero point of a series

## Notes
- No UI changes; nothing imports the module yet. Existing helpers remain the inner math.
- 26 new unit tests with a fixed reference date (118 total pass). Lint, format, and build verified locally.
- Negative amortization (payment < interest) is simulated rather than rejected, capped by the horizon.
- No version bump: no runtime behavior change; the v0.7.0 bump lands with the user-facing Phase 0 items per the roadmap.
- Modeling simplification vs. the term-indexed amortization helpers: payments are applied on a uniform monthly grid anchored to today rather than to each loan statement date — appropriate for forecasting/comparison, not for to-the-penny payoff quotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)