### PR TITLE
Phase 0 UX overhaul: theme + dark mode, dialogs, validation, empty states, polish, green rebrand (roadmap 0.6–0.10)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -63,7 +63,7 @@ src/
 - **Interfaces**: PascalCase (e.g., `Loan`, `Investment`, `AmortizationScheduleEntry`)
 - **Interface Properties**: PascalCase (e.g., `Principal`, `InterestRate`, `StartDate`)
 - **Functions**: camelCase (e.g., `generateAmortizationSchedule`, `calculateMonthlyPayment`)
-- **Variables**: camelCase (e.g., `loans`, `testDataEnabled`)
+- **Variables**: camelCase (e.g., `loans`, `sampleDataLoaded`)
 - **Files**: kebab-case (e.g., `loan-helpers.ts`, `add-edit-loan.tsx`)
 
 ### Material-UI Usage

--- a/src/App.css
+++ b/src/App.css
@@ -1,77 +1,10 @@
 #root {
   text-align: center;
   width: 100%;
-  /* display: flex;
-  height: 100vh;
-  flex-direction: column;
-  width: 100%; */
 }
 
 .wrapper {
   display: flex; /* Use Flexbox */
   flex-direction: column; /* Stack children vertically */
   height: 100vh;
-}
-
-.header {
-  background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
-  color: white;
-  padding: 12px 20px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.body {
-  flex: 1; /* Grow to fill remaining space */
-  padding: 20px; /* Add some padding */
-  background: linear-gradient(to bottom, #f5f7fa 0%, #e8ecf1 100%);
-}
-
-.footer {
-  background: linear-gradient(135deg, #2a5298 0%, #1e3c72 100%);
-  color: white;
-  padding: 8px;
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
-}
-
-h2 {
-  font-family: 'Lato', sans-serif;
-  font-weight: 300;
-  letter-spacing: 2px;
-  font-size: 48px;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,29 +4,42 @@ import { Footer } from './Footer';
 import { Body } from './Body';
 import { Header } from './Header';
 import { LocalizationProvider } from '@mui/x-date-pickers';
-import { Box, Stack } from '@mui/material';
+import {
+  Box,
+  CssBaseline,
+  InitColorSchemeScript,
+  Stack,
+  ThemeProvider,
+} from '@mui/material';
 import { FinanceDataProvider } from './state/finance-data-context';
+import { theme } from './theme';
 
 function App() {
   return (
     <div className="wrapper">
-      <LocalizationProvider dateAdapter={AdapterDayjs}>
-        <FinanceDataProvider>
-          <Stack sx={{ height: '100vh', flexDirection: 'column' }}>
-            <Header />
-            <Box
-              sx={{
-                flexGrow: 1,
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-            >
-              <Body />
-            </Box>
-            <Footer />
-          </Stack>
-        </FinanceDataProvider>
-      </LocalizationProvider>
+      {/* Applies the persisted color scheme before first paint to avoid a
+          light/dark flash on reload. */}
+      <InitColorSchemeScript attribute="data-mui-color-scheme" />
+      <ThemeProvider theme={theme} defaultMode="light">
+        <CssBaseline />
+        <LocalizationProvider dateAdapter={AdapterDayjs}>
+          <FinanceDataProvider>
+            <Stack sx={{ height: '100vh', flexDirection: 'column' }}>
+              <Header />
+              <Box
+                sx={{
+                  flexGrow: 1,
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <Body />
+              </Box>
+              <Footer />
+            </Stack>
+          </FinanceDataProvider>
+        </LocalizationProvider>
+      </ThemeProvider>
     </div>
   );
 }

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -17,7 +17,7 @@ import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { useFinanceData } from './state/use-finance-data';
-import { ColorModeToggle } from './theme';
+import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
 import {
   OnboardingEmptyState,
@@ -159,25 +159,29 @@ export const Body = () => {
   return (
     <Container>
       <AppBar>
+        {/* Command bar (roadmap 0.10): the two "Add" actions are the primary
+            actions — `contained color="inherit"` renders them as solid light
+            buttons that contrast against the brand-blue pill in both light and
+            dark mode. DataManager's import/export are secondary (text variant
+            with icons + tooltips). The dark-mode toggle is pushed to the right
+            with `marginLeft: 'auto'`; on narrow viewports the Toolbar wraps
+            cleanly (theme `MuiToolbar` flexWrap/gap). */}
         <Toolbar>
           <Button
-            variant="outlined"
+            variant="contained"
             color="inherit"
-            sx={{ margin: '5px' }}
             onClick={() => onLoanAddEdit()}
           >
             Add Loan
           </Button>
           <Button
-            variant="outlined"
+            variant="contained"
             color="inherit"
-            sx={{ margin: '5px' }}
             onClick={() => onInvestmentAddEdit()}
           >
             Add Investment
           </Button>
           <DataManager />
-          <div style={{ flex: 1 }} />
           <ColorModeToggle />
         </Toolbar>
       </AppBar>
@@ -188,7 +192,7 @@ export const Body = () => {
       {sampleDataLoaded && (
         <Alert
           severity="info"
-          sx={{ marginBottom: '20px' }}
+          sx={{ marginBottom: SECTION_GAP }}
           action={
             <Button color="inherit" size="small" onClick={clearSampleData}>
               Clear sample data
@@ -200,7 +204,7 @@ export const Body = () => {
       )}
 
       {bothEmpty ? (
-        <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+        <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
           <OnboardingEmptyState
             onAddLoan={() => onLoanAddEdit()}
             onAddInvestment={() => onInvestmentAddEdit()}
@@ -209,7 +213,7 @@ export const Body = () => {
         </Paper>
       ) : (
         <>
-          <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Loans</Divider>
             {loans.length > 0 ? (
               <LoanTable
@@ -226,7 +230,7 @@ export const Body = () => {
             )}
           </Paper>
 
-          <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Investments</Divider>
             {investments.length > 0 ? (
               <InvestmentTable

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -1,9 +1,11 @@
 import {
+  Alert,
   AppBar,
   Button,
   Container,
   Divider,
   Paper,
+  Snackbar,
   Toolbar,
   Typography,
   Switch,
@@ -19,6 +21,21 @@ import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle } from './theme';
+import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
+
+// A delete pending confirmation: which kind of entity, and the entity itself
+// (we need its name for the prompt).
+type PendingDelete =
+  | { kind: 'loan'; entity: Loan }
+  | { kind: 'investment'; entity: Investment };
+
+// A delete that just happened and can still be undone: the removed entity plus
+// the index it occupied, so undo can restore it exactly where it was.
+type UndoableDelete =
+  | { kind: 'loan'; entity: Loan; index: number }
+  | { kind: 'investment'; entity: Investment; index: number };
+
+const DELETE_UNDO_DURATION_MS = 6000;
 
 // Fake data for the dev "Test Data" toggle. Lives here as a UI seed, not as
 // state — the provider stashes the user's real data when this is loaded.
@@ -77,9 +94,11 @@ export const Body = () => {
     addLoan,
     updateLoan,
     deleteLoan,
+    insertLoanAt,
     addInvestment,
     updateInvestment,
     deleteInvestment,
+    insertInvestmentAt,
     enableTestData,
     disableTestData,
   } = useFinanceData();
@@ -90,6 +109,10 @@ export const Body = () => {
     useState<boolean>(false);
   const [editLoan, setEditLoan] = useState<Loan>();
   const [editInvestment, setEditInvestment] = useState<Investment>();
+
+  // Delete confirmation + soft-undo state (roadmap 0.7).
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
+  const [undoableDelete, setUndoableDelete] = useState<UndoableDelete>();
 
   const handleToggleTestData = () => {
     if (!testDataEnabled) {
@@ -117,8 +140,9 @@ export const Body = () => {
     }
   };
 
+  // Step 1: clicking the row/card trash icon asks for confirmation.
   const onLoanDelete = (loan: Loan) => {
-    deleteLoan(loan.Id);
+    setPendingDelete({ kind: 'loan', entity: loan });
   };
 
   const onInvestmentAddEdit = (investment?: Investment) => {
@@ -142,9 +166,49 @@ export const Body = () => {
     }
   };
 
+  // Step 1: clicking the row/card trash icon asks for confirmation.
   const onInvestmentDelete = (investment: Investment) => {
-    deleteInvestment(investment.Id);
+    setPendingDelete({ kind: 'investment', entity: investment });
   };
+
+  // Step 2: confirmation accepted — actually delete, remembering the original
+  // index so the snackbar can offer an exact-position undo.
+  const onConfirmDelete = () => {
+    if (!pendingDelete) {
+      return;
+    }
+    if (pendingDelete.kind === 'loan') {
+      const index = loans.findIndex((l) => l.Id === pendingDelete.entity.Id);
+      deleteLoan(pendingDelete.entity.Id);
+      setUndoableDelete({ kind: 'loan', entity: pendingDelete.entity, index });
+    } else {
+      const index = investments.findIndex(
+        (i) => i.Id === pendingDelete.entity.Id
+      );
+      deleteInvestment(pendingDelete.entity.Id);
+      setUndoableDelete({
+        kind: 'investment',
+        entity: pendingDelete.entity,
+        index,
+      });
+    }
+    setPendingDelete(undefined);
+  };
+
+  // Step 3 (optional): undo restores the entity at its original index.
+  const onUndoDelete = () => {
+    if (!undoableDelete) {
+      return;
+    }
+    if (undoableDelete.kind === 'loan') {
+      insertLoanAt(undoableDelete.entity, undoableDelete.index);
+    } else {
+      insertInvestmentAt(undoableDelete.entity, undoableDelete.index);
+    }
+    setUndoableDelete(undefined);
+  };
+
+  const deletedName = undoableDelete?.entity.Name ?? '';
 
   return (
     <Container>
@@ -187,7 +251,11 @@ export const Body = () => {
       <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
         <Divider>Loans</Divider>
         {loans.length > 0 ? (
-          <LoanTable loans={loans} onLoanEdit={onLoanAddEdit} />
+          <LoanTable
+            loans={loans}
+            onLoanEdit={onLoanAddEdit}
+            onLoanDelete={onLoanDelete}
+          />
         ) : (
           <Typography sx={{ marginTop: '25px', marginBottom: '15px' }}>
             No loans yet, add one from the command bar!
@@ -201,6 +269,7 @@ export const Body = () => {
           <InvestmentTable
             investments={investments}
             onInvestmentEdit={onInvestmentAddEdit}
+            onInvestmentDelete={onInvestmentDelete}
           />
         ) : (
           <Typography sx={{ marginTop: '25px', marginBottom: '15px' }}>
@@ -212,7 +281,6 @@ export const Body = () => {
       <AddEditLoan
         open={isAddLoanOpen}
         onSave={onLoanAddEditSave}
-        onDelete={onLoanDelete}
         onClose={onLoanAddEditClose}
         loan={editLoan}
       />
@@ -220,10 +288,37 @@ export const Body = () => {
       <AddEditInvestment
         open={isAddInvestmentOpen}
         onSave={onInvestmentAddEditSave}
-        onDelete={onInvestmentDelete}
         onClose={onInvestmentAddEditClose}
         investment={editInvestment}
       />
+
+      <ConfirmDeleteDialog
+        itemName={pendingDelete?.entity.Name}
+        onCancel={() => setPendingDelete(undefined)}
+        onConfirm={onConfirmDelete}
+      />
+
+      {/* Soft-undo for delete: matches DataManager's snackbar conventions
+          (bottom-center, ~6s) but adds an UNDO action that restores the entity
+          at its original index. */}
+      <Snackbar
+        open={!!undoableDelete}
+        autoHideDuration={DELETE_UNDO_DURATION_MS}
+        onClose={() => setUndoableDelete(undefined)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="info"
+          sx={{ width: '100%' }}
+          action={
+            <Button color="inherit" size="small" onClick={onUndoDelete}>
+              UNDO
+            </Button>
+          }
+        >
+          {`Deleted ${deletedName}`}
+        </Alert>
+      </Snackbar>
     </Container>
   );
 };

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -7,21 +7,23 @@ import {
   Paper,
   Snackbar,
   Toolbar,
-  Typography,
-  Switch,
-  FormControlLabel,
 } from '@mui/material';
 import { useState } from 'react';
 import { AddEditLoan } from './loan/add-edit-loan';
 import { Loan } from './models/loan-model';
 import { LoanTable } from './loan/loan-table';
 import { AddEditInvestment } from './investment/add-edit-investment';
-import { CompoundingFrequency, Investment } from './models/investment-model';
+import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
+import {
+  OnboardingEmptyState,
+  SectionEmptyState,
+} from './components/empty-state';
+import { sampleLoans, sampleInvestments } from './state/sample-data';
 
 // A delete pending confirmation: which kind of entity, and the entity itself
 // (we need its name for the prompt).
@@ -37,60 +39,9 @@ type UndoableDelete =
 
 const DELETE_UNDO_DURATION_MS = 6000;
 
-// Fake data for the dev "Test Data" toggle. Lives here as a UI seed, not as
-// state — the provider stashes the user's real data when this is loaded.
-const fakeLoans: Loan[] = [
-  {
-    Id: '00000000-0000-0000-0000-000000000001',
-    Name: 'Test Loan 1',
-    Provider: 'Fake Provider',
-    InterestRate: 5,
-    Principal: 300000,
-    CurrentAmount: 300000,
-    MonthlyPayment: 1610.46,
-    StartDate: new Date('2024-11-02'),
-    EndDate: new Date('2054-10-02'),
-  },
-  {
-    Id: '00000000-0000-0000-0000-000000000002',
-    Name: 'Test Loan 2',
-    Provider: 'Sample Bank',
-    InterestRate: 3.5,
-    Principal: 150000,
-    CurrentAmount: 120000,
-    MonthlyPayment: 900.12,
-    StartDate: new Date('2022-01-01'),
-    EndDate: new Date('2042-01-01'),
-  },
-];
-
-const fakeInvestments: Investment[] = [
-  {
-    Id: '00000000-0000-0000-0000-000000000003',
-    Name: 'Test Investment 1',
-    Provider: 'Fake Investment Co.',
-    StartingBalance: 10000,
-    CurrentValue: 12500,
-    AverageReturnRate: 5.5,
-    CompoundingPeriod: CompoundingFrequency.Annually,
-    StartDate: new Date('2020-01-01'),
-  },
-  {
-    Id: '00000000-0000-0000-0000-000000000004',
-    Name: 'Test Investment 2',
-    Provider: 'Sample Fund',
-    StartingBalance: 5000,
-    AverageReturnRate: 2.1,
-    CompoundingPeriod: CompoundingFrequency.Monthly,
-    StartDate: new Date('2021-06-15'),
-    RecurringContribution: 50,
-    ContributionFrequency: CompoundingFrequency.Monthly,
-  },
-];
-
 export const Body = () => {
   const {
-    state: { loans, investments, testDataEnabled },
+    state: { loans, investments, sampleDataLoaded },
     addLoan,
     updateLoan,
     deleteLoan,
@@ -99,8 +50,8 @@ export const Body = () => {
     updateInvestment,
     deleteInvestment,
     insertInvestmentAt,
-    enableTestData,
-    disableTestData,
+    loadSampleData,
+    clearSampleData,
   } = useFinanceData();
 
   // Local UI state only: dialog open/closed and which entity is being edited.
@@ -114,13 +65,7 @@ export const Body = () => {
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
   const [undoableDelete, setUndoableDelete] = useState<UndoableDelete>();
 
-  const handleToggleTestData = () => {
-    if (!testDataEnabled) {
-      enableTestData(fakeLoans, fakeInvestments);
-    } else {
-      disableTestData();
-    }
-  };
+  const onLoadSampleData = () => loadSampleData(sampleLoans, sampleInvestments);
 
   const onLoanAddEdit = (loan?: Loan) => {
     setEditLoan(loan);
@@ -209,6 +154,7 @@ export const Body = () => {
   };
 
   const deletedName = undoableDelete?.entity.Name ?? '';
+  const bothEmpty = loans.length === 0 && investments.length === 0;
 
   return (
     <Container>
@@ -232,51 +178,72 @@ export const Body = () => {
           </Button>
           <DataManager />
           <div style={{ flex: 1 }} />
-          <FormControlLabel
-            control={
-              <Switch
-                checked={testDataEnabled}
-                onChange={handleToggleTestData}
-                color="secondary"
-              />
-            }
-            label={'Test Data'}
-            labelPlacement="start"
-            sx={{ margin: '5px' }}
-          />
           <ColorModeToggle />
         </Toolbar>
       </AppBar>
 
-      <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
-        <Divider>Loans</Divider>
-        {loans.length > 0 ? (
-          <LoanTable
-            loans={loans}
-            onLoanEdit={onLoanAddEdit}
-            onLoanDelete={onLoanDelete}
-          />
-        ) : (
-          <Typography sx={{ marginTop: '25px', marginBottom: '15px' }}>
-            No loans yet, add one from the command bar!
-          </Typography>
-        )}
-      </Paper>
+      {/* Sample-data indicator (roadmap 0.9): while samples are loaded, keep a
+          one-click "Clear sample data" right above the tables, where the user
+          is already looking. The reducer restores any stashed real data. */}
+      {sampleDataLoaded && (
+        <Alert
+          severity="info"
+          sx={{ marginBottom: '20px' }}
+          action={
+            <Button color="inherit" size="small" onClick={clearSampleData}>
+              Clear sample data
+            </Button>
+          }
+        >
+          Showing sample data
+        </Alert>
+      )}
 
-      <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
-        <Divider>Investments</Divider>
-        {investments.length > 0 ? (
-          <InvestmentTable
-            investments={investments}
-            onInvestmentEdit={onInvestmentAddEdit}
-            onInvestmentDelete={onInvestmentDelete}
+      {bothEmpty ? (
+        <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+          <OnboardingEmptyState
+            onAddLoan={() => onLoanAddEdit()}
+            onAddInvestment={() => onInvestmentAddEdit()}
+            onLoadSampleData={onLoadSampleData}
           />
-        ) : (
-          <Typography sx={{ marginTop: '25px', marginBottom: '15px' }}>
-            No investments yet, add one from the command bar!
-          </Typography>
-        )}
-      </Paper>
+        </Paper>
+      ) : (
+        <>
+          <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+            <Divider>Loans</Divider>
+            {loans.length > 0 ? (
+              <LoanTable
+                loans={loans}
+                onLoanEdit={onLoanAddEdit}
+                onLoanDelete={onLoanDelete}
+              />
+            ) : (
+              <SectionEmptyState
+                message="No loans yet."
+                actionLabel="Add your first loan"
+                onAction={() => onLoanAddEdit()}
+              />
+            )}
+          </Paper>
+
+          <Paper sx={{ marginBottom: '20px', padding: '5px' }}>
+            <Divider>Investments</Divider>
+            {investments.length > 0 ? (
+              <InvestmentTable
+                investments={investments}
+                onInvestmentEdit={onInvestmentAddEdit}
+                onInvestmentDelete={onInvestmentDelete}
+              />
+            ) : (
+              <SectionEmptyState
+                message="No investments yet."
+                actionLabel="Add your first investment"
+                onAction={() => onInvestmentAddEdit()}
+              />
+            )}
+          </Paper>
+        </>
+      )}
 
       <AddEditLoan
         open={isAddLoanOpen}

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -18,6 +18,7 @@ import { CompoundingFrequency, Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { useFinanceData } from './state/use-finance-data';
+import { ColorModeToggle } from './theme';
 
 // Fake data for the dev "Test Data" toggle. Lives here as a UI seed, not as
 // state — the provider stashes the user's real data when this is loaded.
@@ -147,15 +148,7 @@ export const Body = () => {
 
   return (
     <Container>
-      <AppBar
-        position="static"
-        sx={{
-          borderRadius: '30px',
-          marginTop: '15px',
-          marginBottom: '15px',
-          overflow: 'hidden',
-        }}
-      >
+      <AppBar>
         <Toolbar>
           <Button
             variant="outlined"
@@ -187,6 +180,7 @@ export const Body = () => {
             labelPlacement="start"
             sx={{ margin: '5px' }}
           />
+          <ColorModeToggle />
         </Toolbar>
       </AppBar>
 

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,7 +1,17 @@
+import { Box } from '@mui/material';
+import { brandGradientReversed } from './theme';
+
 export const Footer = () => {
   return (
-    <div className="footer">
+    <Box
+      sx={{
+        background: brandGradientReversed,
+        color: '#ffffff',
+        padding: '8px',
+        boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.15)',
+      }}
+    >
       <p>Version {APP_VERSION}</p>
-    </div>
+    </Box>
   );
 };

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,17 +1,48 @@
-import { Box } from '@mui/material';
+import { Box, Link, Stack, Typography } from '@mui/material';
+import GitHubIcon from '@mui/icons-material/GitHub';
 import { brandGradientReversed } from './theme';
 
+const REPO_URL = 'https://github.com/bberardi/finance-calculator';
+
+// Minimal footer (roadmap 0.10): a link to the GitHub repo and the app version
+// (injected from package.json at build time — see vite.config.ts). Sits on the
+// brand gradient like the Header, so white text is intentional and reads in both
+// color schemes.
 export const Footer = () => {
   return (
     <Box
+      component="footer"
       sx={{
         background: brandGradientReversed,
         color: '#ffffff',
-        padding: '8px',
+        padding: 1,
         boxShadow: '0 -2px 8px rgba(0, 0, 0, 0.15)',
       }}
     >
-      <p>Version {APP_VERSION}</p>
+      <Stack
+        direction="row"
+        spacing={2}
+        sx={{ justifyContent: 'center', alignItems: 'center' }}
+      >
+        <Link
+          href={REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+          sx={{
+            color: 'inherit',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.5,
+          }}
+        >
+          <GitHubIcon fontSize="small" />
+          GitHub
+        </Link>
+        <Typography variant="body2" sx={{ opacity: 0.9 }}>
+          Version {__APP_VERSION__}
+        </Typography>
+      </Stack>
     </Box>
   );
 };

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,9 +1,17 @@
-import { CardMedia, Stack, Typography } from '@mui/material';
+import { Box, CardMedia, Stack, Typography } from '@mui/material';
 import Logo from './assets/pathwise-icon.png';
+import { brandGradient } from './theme';
 
 export const Header = () => {
   return (
-    <div className="header">
+    <Box
+      sx={{
+        background: brandGradient,
+        color: '#ffffff',
+        padding: '12px 20px',
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.15)',
+      }}
+    >
       <Stack
         direction="row"
         spacing={2}
@@ -27,6 +35,6 @@ export const Header = () => {
           </Typography>
         </Stack>
       </Stack>
-    </div>
+    </Box>
   );
 };

--- a/src/components/confirm-delete-dialog.tsx
+++ b/src/components/confirm-delete-dialog.tsx
@@ -1,0 +1,51 @@
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+} from '@mui/material';
+import { ResponsiveDialog } from './responsive-dialog';
+
+// Small confirmation guard for destructive deletes (roadmap 0.7).
+//
+// Delete moved out of the edit form onto the table rows / mobile cards; this
+// dialog is the confirmation step before the delete actually fires. The
+// snackbar soft-undo (in Body) is the second safety net.
+export interface ConfirmDeleteDialogProps {
+  // When set, the dialog is open and asks to delete the entity with this name.
+  // Null/undefined keeps the dialog closed.
+  itemName?: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const ConfirmDeleteDialog = ({
+  itemName,
+  onCancel,
+  onConfirm,
+}: ConfirmDeleteDialogProps) => (
+  <ResponsiveDialog
+    open={!!itemName}
+    onClose={onCancel}
+    maxWidth="xs"
+    // A tiny confirmation never needs to fill a phone screen.
+    fullScreen={false}
+  >
+    <DialogTitle>Delete {itemName}?</DialogTitle>
+    <DialogContent>
+      <DialogContentText>
+        This can be undone right after, but the entry will be removed from your
+        lists.
+      </DialogContentText>
+    </DialogContent>
+    <DialogActions>
+      <Button color="secondary" onClick={onCancel}>
+        Cancel
+      </Button>
+      <Button color="error" variant="contained" onClick={onConfirm} autoFocus>
+        Delete
+      </Button>
+    </DialogActions>
+  </ResponsiveDialog>
+);

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,82 @@
+import { Box, Button, Stack, Typography } from '@mui/material';
+
+// Onboarding & empty states (roadmap 0.9).
+//
+// Two flavors:
+//  - <OnboardingEmptyState>: shown when there are NO loans AND NO investments.
+//    Explains what PathWise does and offers all three first-run CTAs (add a
+//    loan, add an investment, load sample data).
+//  - <SectionEmptyState>: a lighter per-section empty state shown when only ONE
+//    collection is empty (e.g. loans exist but investments don't), with that
+//    section's single "Add" CTA.
+//
+// Both are theme-only (no hardcoded colors); text uses `text.secondary` so they
+// read correctly in light and dark mode.
+
+export interface OnboardingEmptyStateProps {
+  onAddLoan: () => void;
+  onAddInvestment: () => void;
+  onLoadSampleData: () => void;
+}
+
+export const OnboardingEmptyState = ({
+  onAddLoan,
+  onAddInvestment,
+  onLoadSampleData,
+}: OnboardingEmptyStateProps) => (
+  <Box sx={{ textAlign: 'center', paddingY: 5, paddingX: 2 }}>
+    <Typography variant="h5" gutterBottom>
+      Welcome to PathWise
+    </Typography>
+    <Typography
+      variant="body1"
+      color="text.secondary"
+      sx={{ maxWidth: 560, marginX: 'auto', marginBottom: 3 }}
+    >
+      PathWise forecasts your net worth across all of your loans and investments
+      at once, so you can see your whole financial position and decide where
+      your extra money should go. Add your first entry, or load some sample data
+      to explore.
+    </Typography>
+    <Stack
+      direction={{ xs: 'column', sm: 'row' }}
+      spacing={1.5}
+      sx={{ justifyContent: 'center', alignItems: 'center' }}
+    >
+      <Button variant="contained" onClick={onAddLoan}>
+        Add your first loan
+      </Button>
+      <Button variant="contained" onClick={onAddInvestment}>
+        Add your first investment
+      </Button>
+      <Button variant="outlined" onClick={onLoadSampleData}>
+        Load sample data
+      </Button>
+    </Stack>
+  </Box>
+);
+
+export interface SectionEmptyStateProps {
+  message: string;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+export const SectionEmptyState = ({
+  message,
+  actionLabel,
+  onAction,
+}: SectionEmptyStateProps) => (
+  <Box sx={{ textAlign: 'center', paddingY: 3, paddingX: 2 }}>
+    <Typography
+      variant="body2"
+      color="text.secondary"
+      sx={{ marginBottom: 1.5 }}
+    >
+      {message}
+    </Typography>
+    <Button variant="outlined" size="small" onClick={onAction}>
+      {actionLabel}
+    </Button>
+  </Box>
+);

--- a/src/components/entity-row-actions.tsx
+++ b/src/components/entity-row-actions.tsx
@@ -1,0 +1,49 @@
+import { Box, IconButton } from '@mui/material';
+import { ReactNode } from 'react';
+
+// Shared row/card action buttons for the loan and investment tables (roadmap
+// 0.7/0.10). Both tables render the same cluster of icon buttons — a couple of
+// entity-specific tools plus Edit and Delete — laid out identically (spread on
+// mobile cards, left-aligned in desktop table rows). This component owns that
+// layout once; each table just supplies its own `actions` list.
+//
+// Defining it at module scope (rather than inline inside each table component)
+// is deliberate: an inline component is a new type on every parent render, which
+// makes React remount the whole button cluster — and its enclosing row/card —
+// each time the table re-renders (e.g. when a popout opens).
+export interface RowAction {
+  icon: ReactNode;
+  title: string;
+  onClick: () => void;
+  color?: 'primary' | 'error';
+}
+
+export interface EntityRowActionsProps {
+  actions: RowAction[];
+  isMobile?: boolean;
+}
+
+export const EntityRowActions = ({
+  actions,
+  isMobile = false,
+}: EntityRowActionsProps) => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: isMobile ? 'space-around' : 'flex-start',
+      gap: isMobile ? 0 : 1,
+    }}
+  >
+    {actions.map((action) => (
+      <IconButton
+        key={action.title}
+        onClick={action.onClick}
+        color={action.color ?? 'primary'}
+        size={isMobile ? 'medium' : 'small'}
+        title={action.title}
+      >
+        {action.icon}
+      </IconButton>
+    ))}
+  </Box>
+);

--- a/src/components/field-helper-text.tsx
+++ b/src/components/field-helper-text.tsx
@@ -1,0 +1,26 @@
+import { Box } from '@mui/material';
+import { ReactNode } from 'react';
+
+// Renders helper text for a form field (roadmap 0.8). Errors render in the
+// theme error color (handled by the field's own `error` prop), warnings render
+// in the theme warning color so they are visually distinct from errors and from
+// neutral helper text. Returns the node to pass as a TextField `helperText`.
+//
+// No hardcoded colors: `warning.main` comes from the active theme palette, so it
+// adapts to dark mode automatically.
+export const fieldHelperText = (
+  error?: string,
+  warning?: string
+): ReactNode => {
+  if (error) {
+    return error;
+  }
+  if (warning) {
+    return (
+      <Box component="span" sx={{ color: 'warning.main' }}>
+        {warning}
+      </Box>
+    );
+  }
+  return undefined;
+};

--- a/src/components/responsive-dialog.tsx
+++ b/src/components/responsive-dialog.tsx
@@ -1,0 +1,51 @@
+import { Dialog, DialogProps, useMediaQuery, useTheme } from '@mui/material';
+import { ReactNode } from 'react';
+
+// Shared modal wrapper for PathWise (roadmap 0.7).
+//
+// The add/edit forms and the schedule/PIT popouts previously abused MUI
+// `Popover` as a modal. `Popover` gives no focus trap, no Escape handling, and
+// no responsive layout — all of which a real `Dialog` provides for free.
+//
+// This wrapper exists because six surfaces needed the same conversion and every
+// later phase is told to copy this pattern. It does exactly one thing on top of
+// `Dialog`: go full-screen on small viewports so forms/tables are usable on
+// mobile. Everything else (focus trap, Escape-to-close, backdrop click,
+// `DialogTitle`/`DialogContent`/`DialogActions` structure, theme surfaces in
+// both light and dark mode) comes from `Dialog` itself — so callers compose the
+// standard MUI dialog sub-components inside, and dark mode "just works" because
+// the dialog surface is the themed `paper` color.
+//
+// Keep it thin: it forwards `maxWidth`, `fullWidth`, and any other `DialogProps`
+// straight through, and never fights the Dialog's built-in keyboard/focus
+// behavior.
+export interface ResponsiveDialogProps extends DialogProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+export const ResponsiveDialog = ({
+  open,
+  onClose,
+  children,
+  maxWidth = 'sm',
+  fullWidth = true,
+  ...rest
+}: ResponsiveDialogProps) => {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down('sm'));
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      fullScreen={fullScreen}
+      fullWidth={fullWidth}
+      maxWidth={maxWidth}
+      {...rest}
+    >
+      {children}
+    </Dialog>
+  );
+};

--- a/src/data-manager/data-manager.tsx
+++ b/src/data-manager/data-manager.tsx
@@ -1,4 +1,4 @@
-import { Button, Alert, Snackbar } from '@mui/material';
+import { Button, Alert, Snackbar, Tooltip } from '@mui/material';
 import { useState, useRef } from 'react';
 import {
   exportToJson,
@@ -124,25 +124,35 @@ export const DataManager = () => {
 
   return (
     <>
-      <Button
-        variant="outlined"
-        color="inherit"
-        sx={{ margin: '5px' }}
-        onClick={handleUploadClick}
-        startIcon={<UploadFileIcon />}
+      {/* Import/export are secondary actions (roadmap 0.10): de-emphasized as
+          `text` buttons with icons + tooltips, so the primary "Add" actions
+          lead the command bar. */}
+      <Tooltip title="Import data from a JSON file">
+        <Button
+          variant="text"
+          color="inherit"
+          onClick={handleUploadClick}
+          startIcon={<UploadFileIcon />}
+        >
+          Upload
+        </Button>
+      </Tooltip>
+      <Tooltip
+        title={hasData ? 'Export your data as JSON' : 'No data to export'}
       >
-        Upload
-      </Button>
-      <Button
-        variant="outlined"
-        color="inherit"
-        sx={{ margin: '5px' }}
-        onClick={handleExport}
-        disabled={!hasData}
-        startIcon={<DownloadIcon />}
-      >
-        Export
-      </Button>
+        {/* Span keeps the tooltip working while the button is disabled. */}
+        <span>
+          <Button
+            variant="text"
+            color="inherit"
+            onClick={handleExport}
+            disabled={!hasData}
+            startIcon={<DownloadIcon />}
+          >
+            Export
+          </Button>
+        </span>
+      </Tooltip>
       <input
         ref={fileInputRef}
         type="file"

--- a/src/helpers/format-helpers.test.ts
+++ b/src/helpers/format-helpers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { formatCurrency, formatPercent } from './format-helpers';
+
+describe('formatCurrency', () => {
+  it('formats a whole-dollar amount with two fraction digits', () => {
+    expect(formatCurrency(300000)).toBe('$300,000.00');
+  });
+
+  it('formats a fractional amount, rounding to cents', () => {
+    expect(formatCurrency(1234.5)).toBe('$1,234.50');
+    expect(formatCurrency(1234.567)).toBe('$1,234.57');
+  });
+
+  it('formats zero', () => {
+    expect(formatCurrency(0)).toBe('$0.00');
+  });
+
+  it('formats negative values with a leading minus', () => {
+    expect(formatCurrency(-1234.5)).toBe('-$1,234.50');
+    expect(formatCurrency(-0.01)).toBe('-$0.01');
+  });
+
+  it('formats large values with grouping separators', () => {
+    expect(formatCurrency(1000000)).toBe('$1,000,000.00');
+    expect(formatCurrency(1234567890.12)).toBe('$1,234,567,890.12');
+  });
+
+  it('formats small sub-dollar values', () => {
+    expect(formatCurrency(0.5)).toBe('$0.50');
+    expect(formatCurrency(0.009)).toBe('$0.01');
+  });
+
+  it('matches the prior toLocaleString output exactly', () => {
+    // Guard against drift from the implementation it replaced.
+    for (const value of [0, 12.34, 99999.99, -42.5, 5000000]) {
+      const expected = value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+      expect(formatCurrency(value)).toBe(expected);
+    }
+  });
+});
+
+describe('formatPercent', () => {
+  it('defaults to two fraction digits (loan-table behavior)', () => {
+    expect(formatPercent(5)).toBe('5.00%');
+    expect(formatPercent(3.5)).toBe('3.50%');
+  });
+
+  it('honors a custom fraction-digit count (investment-table behavior)', () => {
+    expect(formatPercent(5.5, 3)).toBe('5.500%');
+    expect(formatPercent(2.1, 3)).toBe('2.100%');
+  });
+
+  it('formats zero', () => {
+    expect(formatPercent(0)).toBe('0.00%');
+    expect(formatPercent(0, 3)).toBe('0.000%');
+  });
+
+  it('formats negative percentages', () => {
+    expect(formatPercent(-2.5)).toBe('-2.50%');
+    expect(formatPercent(-2.5, 3)).toBe('-2.500%');
+  });
+
+  it('formats large percentages with grouping', () => {
+    expect(formatPercent(1000)).toBe('1,000.00%');
+    expect(formatPercent(100)).toBe('100.00%');
+  });
+
+  it('rounds to the requested precision', () => {
+    expect(formatPercent(3.567)).toBe('3.57%');
+    expect(formatPercent(12.345, 3)).toBe('12.345%');
+  });
+
+  it('matches the prior loan percent output (percent style /100, 2 digits)', () => {
+    for (const value of [5, 5.5, 0, -2.5, 100, 12.345]) {
+      const expected = (value / 100).toLocaleString('en-US', {
+        style: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+      expect(formatPercent(value)).toBe(expected);
+    }
+  });
+});

--- a/src/helpers/format-helpers.ts
+++ b/src/helpers/format-helpers.ts
@@ -1,0 +1,50 @@
+// Pure formatting helpers shared across the UI. Per decision D7 this module is
+// part of the boundary-enforced core layer: TypeScript only, NO React/MUI
+// imports. It centralizes the currency/percent formatting that was previously
+// duplicated (and subtly inconsistent) across the loan/investment tables and
+// their popouts.
+
+// Reuse a single Intl.NumberFormat instance per shape. Constructing an
+// Intl.NumberFormat is relatively expensive, and these run once per table cell.
+const usdFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+// Percent formatters are keyed by fraction-digit count so callers that want a
+// different precision (loans: 2 digits, investments: 3) share cached instances.
+const percentFormatters = new Map<number, Intl.NumberFormat>();
+
+const getPercentFormatter = (fractionDigits: number): Intl.NumberFormat => {
+  let formatter = percentFormatters.get(fractionDigits);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat('en-US', {
+      style: 'percent',
+      minimumFractionDigits: fractionDigits,
+      maximumFractionDigits: fractionDigits,
+    });
+    percentFormatters.set(fractionDigits, formatter);
+  }
+  return formatter;
+};
+
+/**
+ * Formats a number as US dollars, e.g. `1234.5` -> `"$1,234.50"`.
+ * Always shows exactly two fraction digits, matching the prior behavior of the
+ * loan/investment tables and PIT/schedule popouts.
+ */
+export const formatCurrency = (amount: number): string =>
+  usdFormatter.format(amount);
+
+/**
+ * Formats a percentage value, where `percent` is the human-facing percent
+ * number (e.g. `5.5` for 5.5%, not the fraction `0.055`).
+ *
+ * @param percent - the percentage value (5.5 means 5.5%)
+ * @param fractionDigits - number of fraction digits to show (default 2). Loans
+ *   display 2 digits; investment return rates historically displayed 3.
+ */
+export const formatPercent = (percent: number, fractionDigits = 2): string =>
+  getPercentFormatter(fractionDigits).format(percent / 100);

--- a/src/helpers/use-field-tracking.ts
+++ b/src/helpers/use-field-tracking.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+import { ValidationResult } from './validation-helpers';
+
+// Shared form-field reveal/tracking for the add/edit forms (roadmap 0.8).
+//
+// The loan and investment forms both need the same "don't open all-red"
+// behavior: a field's error/warning is shown only once the user has touched it
+// OR a save has been attempted, plus an always-visible explanation of why Save
+// is disabled. That logic was duplicated byte-for-byte in both forms; it lives
+// here so the two forms can't drift.
+//
+// It is generic over the form's field-key union and consumes the pure
+// `ValidationResult` produced by validation-helpers — this hook owns only the
+// touched/submit-attempted UI state, never the validation rules themselves.
+export interface FieldTracking<TField extends string> {
+  // Whether a field's messages should currently be revealed.
+  showFor: (field: TField) => boolean;
+  // Mark a field as touched (typically onBlur / onChange).
+  touch: (field: TField) => void;
+  // The field's error message, but only once it should be revealed.
+  errorFor: (field: TField) => string | undefined;
+  // The field's warning message, but only once it should be revealed.
+  warningFor: (field: TField) => string | undefined;
+  // Reset touched + submit-attempted (on open/cancel/successful save).
+  resetTracking: () => void;
+  // Flag a blocked save attempt so every field's error reveals at once.
+  markSubmitAttempted: () => void;
+  // Why Save is disabled: the revealed errors joined, or a neutral prompt.
+  saveDisabledReason: string;
+}
+
+export const useFieldTracking = <TField extends string>(
+  validation: ValidationResult<TField>
+): FieldTracking<TField> => {
+  const [touched, setTouched] = useState<Partial<Record<TField, boolean>>>({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  const showFor = (field: TField) => submitAttempted || Boolean(touched[field]);
+  const touch = (field: TField) =>
+    setTouched((prev) => ({ ...prev, [field]: true }));
+  const errorFor = (field: TField) =>
+    showFor(field) ? validation.errors[field] : undefined;
+  const warningFor = (field: TField) =>
+    showFor(field) ? validation.warnings[field] : undefined;
+
+  // Stable so the forms can safely list it in effect dependency arrays.
+  const resetTracking = useCallback(() => {
+    setTouched({});
+    setSubmitAttempted(false);
+  }, []);
+  const markSubmitAttempted = useCallback(() => setSubmitAttempted(true), []);
+
+  // Why Save is disabled, always visible while invalid: list the specific
+  // revealed errors once fields are touched / a save was attempted, otherwise a
+  // neutral prompt so the form doesn't open all-red.
+  const revealedErrors = (Object.keys(validation.errors) as TField[])
+    .filter((field) => showFor(field))
+    .map((field) => validation.errors[field])
+    .filter((message): message is string => Boolean(message));
+  const saveDisabledReason =
+    revealedErrors.length > 0
+      ? revealedErrors.join(' ')
+      : 'Fill in all required fields to enable saving.';
+
+  return {
+    showFor,
+    touch,
+    errorFor,
+    warningFor,
+    resetTracking,
+    markSubmitAttempted,
+    saveDisabledReason,
+  };
+};

--- a/src/helpers/validation-helpers.test.ts
+++ b/src/helpers/validation-helpers.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import { Loan } from '../models/loan-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
+import {
+  INVESTMENT_RETURN_WARNING_THRESHOLD,
+  isInvestmentValid,
+  isLoanValid,
+  LOAN_RATE_WARNING_THRESHOLD,
+  validateInvestment,
+  validateLoan,
+} from './validation-helpers';
+
+// A fully valid loan: every error rule passes, no warnings triggered.
+const validLoan = (): Loan => ({
+  Id: '1',
+  Provider: 'Acme Bank',
+  Name: 'Car loan',
+  InterestRate: 5,
+  StartDate: new Date('2024-01-01'),
+  EndDate: new Date('2029-01-01'),
+  Principal: 20000,
+  CurrentAmount: 15000,
+  MonthlyPayment: 380,
+});
+
+// A fully valid investment: every error rule passes, no warnings triggered.
+const validInvestment = (): Investment => ({
+  Id: '1',
+  Provider: 'Vanguard',
+  Name: 'Index fund',
+  StartDate: new Date('2024-01-01'),
+  StartingBalance: 10000,
+  AverageReturnRate: 7,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+});
+
+describe('validateLoan — errors', () => {
+  it('returns no errors for a fully valid loan', () => {
+    const result = validateLoan(validLoan());
+    expect(result.errors).toEqual({});
+    expect(isLoanValid(validLoan())).toBe(true);
+  });
+
+  it('requires a non-empty Name (and treats whitespace as empty)', () => {
+    expect(
+      validateLoan({ ...validLoan(), Name: '' }).errors.Name
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), Name: '   ' }).errors.Name
+    ).toBeDefined();
+  });
+
+  it('requires a non-empty Provider', () => {
+    expect(
+      validateLoan({ ...validLoan(), Provider: '' }).errors.Provider
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), Provider: '  ' }).errors.Provider
+    ).toBeDefined();
+  });
+
+  it('requires Principal > 0 (boundary: 0 fails, 0.01 passes, negative fails)', () => {
+    expect(
+      validateLoan({ ...validLoan(), Principal: 0 }).errors.Principal
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), Principal: -1 }).errors.Principal
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), Principal: 0.01, CurrentAmount: 0.01 })
+        .errors.Principal
+    ).toBeUndefined();
+  });
+
+  it('requires CurrentAmount > 0 (boundary: 0 fails, 0.01 passes)', () => {
+    expect(
+      validateLoan({ ...validLoan(), CurrentAmount: 0 }).errors.CurrentAmount
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), CurrentAmount: 0.01 }).errors.CurrentAmount
+    ).toBeUndefined();
+  });
+
+  it('requires InterestRate > 0 (boundary: 0 fails, 0.001 passes)', () => {
+    expect(
+      validateLoan({ ...validLoan(), InterestRate: 0 }).errors.InterestRate
+    ).toBeDefined();
+    expect(
+      validateLoan({ ...validLoan(), InterestRate: 0.001 }).errors.InterestRate
+    ).toBeUndefined();
+  });
+
+  it('requires EndDate strictly after StartDate (equal dates fail)', () => {
+    const sameDay = new Date('2024-01-01');
+    const loan = { ...validLoan(), StartDate: sameDay, EndDate: sameDay };
+    expect(validateLoan(loan).errors.EndDate).toBeDefined();
+
+    const reversed = {
+      ...validLoan(),
+      StartDate: new Date('2029-01-01'),
+      EndDate: new Date('2024-01-01'),
+    };
+    expect(validateLoan(reversed).errors.EndDate).toBeDefined();
+
+    // One day apart is valid.
+    const valid = {
+      ...validLoan(),
+      StartDate: new Date('2024-01-01'),
+      EndDate: new Date('2024-01-02'),
+    };
+    expect(validateLoan(valid).errors.EndDate).toBeUndefined();
+  });
+
+  it('isLoanValid is false whenever any error is present', () => {
+    expect(isLoanValid({ ...validLoan(), Name: '' })).toBe(false);
+    expect(isLoanValid({ ...validLoan(), Principal: 0 })).toBe(false);
+  });
+});
+
+describe('validateLoan — warnings (non-blocking)', () => {
+  it('warns when CurrentAmount exceeds Principal but does not block saving', () => {
+    const loan = { ...validLoan(), Principal: 10000, CurrentAmount: 15000 };
+    const result = validateLoan(loan);
+    expect(result.warnings.CurrentAmount).toBeDefined();
+    expect(result.errors.CurrentAmount).toBeUndefined();
+    expect(isLoanValid(loan)).toBe(true);
+  });
+
+  it('does not warn when CurrentAmount equals Principal (boundary)', () => {
+    const loan = { ...validLoan(), Principal: 10000, CurrentAmount: 10000 };
+    expect(validateLoan(loan).warnings.CurrentAmount).toBeUndefined();
+  });
+
+  it(`warns on interest rate above ${LOAN_RATE_WARNING_THRESHOLD}% (boundary: threshold itself does not warn)`, () => {
+    expect(
+      validateLoan({
+        ...validLoan(),
+        InterestRate: LOAN_RATE_WARNING_THRESHOLD,
+      }).warnings.InterestRate
+    ).toBeUndefined();
+    const high = {
+      ...validLoan(),
+      InterestRate: LOAN_RATE_WARNING_THRESHOLD + 0.01,
+    };
+    expect(validateLoan(high).warnings.InterestRate).toBeDefined();
+    expect(isLoanValid(high)).toBe(true);
+  });
+});
+
+describe('validateInvestment — errors', () => {
+  it('returns no errors for a fully valid investment', () => {
+    const result = validateInvestment(validInvestment());
+    expect(result.errors).toEqual({});
+    expect(isInvestmentValid(validInvestment())).toBe(true);
+  });
+
+  it('requires a non-empty Name and Provider', () => {
+    expect(
+      validateInvestment({ ...validInvestment(), Name: '  ' }).errors.Name
+    ).toBeDefined();
+    expect(
+      validateInvestment({ ...validInvestment(), Provider: '' }).errors.Provider
+    ).toBeDefined();
+  });
+
+  it('requires StartingBalance > 0 (boundary: 0 fails, 0.01 passes)', () => {
+    expect(
+      validateInvestment({ ...validInvestment(), StartingBalance: 0 }).errors
+        .StartingBalance
+    ).toBeDefined();
+    expect(
+      validateInvestment({ ...validInvestment(), StartingBalance: 0.01 }).errors
+        .StartingBalance
+    ).toBeUndefined();
+  });
+
+  it('allows AverageReturnRate of 0 but rejects negative (boundary)', () => {
+    expect(
+      validateInvestment({ ...validInvestment(), AverageReturnRate: 0 }).errors
+        .AverageReturnRate
+    ).toBeUndefined();
+    expect(
+      validateInvestment({ ...validInvestment(), AverageReturnRate: -0.01 })
+        .errors.AverageReturnRate
+    ).toBeDefined();
+  });
+
+  it('isInvestmentValid is false whenever any error is present', () => {
+    expect(isInvestmentValid({ ...validInvestment(), Name: '' })).toBe(false);
+    expect(
+      isInvestmentValid({ ...validInvestment(), StartingBalance: 0 })
+    ).toBe(false);
+  });
+});
+
+describe('validateInvestment — warnings (non-blocking)', () => {
+  it(`warns on return above ${INVESTMENT_RETURN_WARNING_THRESHOLD}% (boundary: threshold itself does not warn)`, () => {
+    expect(
+      validateInvestment({
+        ...validInvestment(),
+        AverageReturnRate: INVESTMENT_RETURN_WARNING_THRESHOLD,
+      }).warnings.AverageReturnRate
+    ).toBeUndefined();
+    const high = {
+      ...validInvestment(),
+      AverageReturnRate: INVESTMENT_RETURN_WARNING_THRESHOLD + 0.01,
+    };
+    expect(validateInvestment(high).warnings.AverageReturnRate).toBeDefined();
+    expect(isInvestmentValid(high)).toBe(true);
+  });
+
+  it('warns when contribution cadence is finer than the compounding period', () => {
+    // Monthly contributions, annual compounding -> finer cadence -> warn.
+    const inv = {
+      ...validInvestment(),
+      CompoundingPeriod: CompoundingFrequency.Annually,
+      RecurringContribution: 100,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    };
+    const result = validateInvestment(inv);
+    expect(result.warnings.ContributionFrequency).toBeDefined();
+    expect(isInvestmentValid(inv)).toBe(true);
+  });
+
+  it('warns when cadence is quarterly and compounding is annual', () => {
+    const inv = {
+      ...validInvestment(),
+      CompoundingPeriod: CompoundingFrequency.Annually,
+      RecurringContribution: 100,
+      ContributionFrequency: CompoundingFrequency.Quarterly,
+    };
+    expect(
+      validateInvestment(inv).warnings.ContributionFrequency
+    ).toBeDefined();
+  });
+
+  it('does not warn when cadence matches or is coarser than compounding', () => {
+    const matching = {
+      ...validInvestment(),
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+      RecurringContribution: 100,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    };
+    expect(
+      validateInvestment(matching).warnings.ContributionFrequency
+    ).toBeUndefined();
+
+    const coarser = {
+      ...validInvestment(),
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+      RecurringContribution: 100,
+      ContributionFrequency: CompoundingFrequency.Annually,
+    };
+    expect(
+      validateInvestment(coarser).warnings.ContributionFrequency
+    ).toBeUndefined();
+  });
+
+  it('does not warn about cadence when there is no recurring contribution', () => {
+    const inv = {
+      ...validInvestment(),
+      CompoundingPeriod: CompoundingFrequency.Annually,
+      RecurringContribution: 0,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    };
+    expect(
+      validateInvestment(inv).warnings.ContributionFrequency
+    ).toBeUndefined();
+  });
+
+  it('warns when a step-up type is set but the amount is zero/missing', () => {
+    const flat = {
+      ...validInvestment(),
+      RecurringContribution: 100,
+      ContributionStepUpType: StepUpType.Flat,
+      ContributionStepUpAmount: 0,
+    };
+    expect(
+      validateInvestment(flat).warnings.ContributionStepUpAmount
+    ).toBeDefined();
+
+    const pct = {
+      ...validInvestment(),
+      RecurringContribution: 100,
+      ContributionStepUpType: StepUpType.Percentage,
+      ContributionStepUpAmount: undefined,
+    };
+    expect(
+      validateInvestment(pct).warnings.ContributionStepUpAmount
+    ).toBeDefined();
+  });
+
+  it('does not warn about step-up when an amount is provided', () => {
+    const inv = {
+      ...validInvestment(),
+      RecurringContribution: 100,
+      ContributionStepUpType: StepUpType.Flat,
+      ContributionStepUpAmount: 50,
+    };
+    expect(
+      validateInvestment(inv).warnings.ContributionStepUpAmount
+    ).toBeUndefined();
+  });
+
+  it('does not warn about step-up when there is no recurring contribution', () => {
+    const inv = {
+      ...validInvestment(),
+      RecurringContribution: 0,
+      ContributionStepUpType: StepUpType.Flat,
+      ContributionStepUpAmount: 0,
+    };
+    expect(
+      validateInvestment(inv).warnings.ContributionStepUpAmount
+    ).toBeUndefined();
+  });
+});

--- a/src/helpers/validation-helpers.ts
+++ b/src/helpers/validation-helpers.ts
@@ -1,0 +1,193 @@
+// Pure form-validation rules for the loan and investment add/edit forms
+// (roadmap 0.8). D7 boundary: this module operates on plain field values /
+// model objects and returns structured results — NO React/MUI imports.
+//
+// Two kinds of result:
+//   - errors:   block saving. These mirror the existing `isFormValid()` rules
+//               so the button-disabled state and the per-field messages share a
+//               single source of truth.
+//   - warnings: do NOT block saving. Cross-field "sanity" checks that flag
+//               inputs which pass type validation but likely produce a wrong
+//               forecast (the Charter's "plausible chart on a wrong premise",
+//               on the input side).
+//
+// `isFormValid` for each entity is simply: no error keys present.
+
+import { Loan } from '../models/loan-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
+
+export interface ValidationResult<TField extends string> {
+  errors: Partial<Record<TField, string>>;
+  warnings: Partial<Record<TField, string>>;
+  // Errors not tied to a specific field (e.g. a cross-field rule whose offending
+  // field is ambiguous). Surfaced in the form's actions summary so the user can
+  // always see why Save is disabled.
+  formErrors: string[];
+}
+
+// Thresholds for the non-blocking sanity warnings. Chosen as "well outside the
+// range of normal consumer products" so the warning is rare and meaningful:
+//   - A consumer loan above 30% APR is almost always a data-entry slip (e.g. a
+//     5.5% rate typed as 55). Payday/credit-card extremes exist, hence a warning
+//     rather than an error.
+//   - A long-run average investment return above 20%/yr beats every broad index
+//     historically; usually a typo (e.g. 7 -> 70).
+export const LOAN_RATE_WARNING_THRESHOLD = 30;
+export const INVESTMENT_RETURN_WARNING_THRESHOLD = 20;
+
+// Cadence ordering, finest (most frequent) first. A contribution cadence that is
+// FINER than the compounding period means contributions land between compounding
+// boundaries — the engine's premise (contribute on a compounding boundary) no
+// longer holds, so the forecast may be off. Lower index = more frequent.
+const CADENCE_ORDER: CompoundingFrequency[] = [
+  CompoundingFrequency.Monthly,
+  CompoundingFrequency.Quarterly,
+  CompoundingFrequency.Annually,
+];
+
+const cadenceRank = (freq: CompoundingFrequency): number =>
+  CADENCE_ORDER.indexOf(freq);
+
+export type LoanField =
+  | 'Name'
+  | 'Provider'
+  | 'Principal'
+  | 'CurrentAmount'
+  | 'InterestRate'
+  | 'StartDate'
+  | 'EndDate'
+  | 'MonthlyPayment';
+
+export const validateLoan = (loan: Loan): ValidationResult<LoanField> => {
+  const errors: Partial<Record<LoanField, string>> = {};
+  const warnings: Partial<Record<LoanField, string>> = {};
+  const formErrors: string[] = [];
+
+  // --- Blocking errors (mirror the original isFormValid rules) ---
+  if (loan.Name.trim() === '') {
+    errors.Name = 'Name is required.';
+  }
+  if (loan.Provider.trim() === '') {
+    errors.Provider = 'Loan provider is required.';
+  }
+  if (!(loan.Principal > 0)) {
+    errors.Principal = 'Principal must be greater than 0.';
+  }
+  if (!(loan.CurrentAmount > 0)) {
+    errors.CurrentAmount = 'Current amount must be greater than 0.';
+  }
+  if (!(loan.InterestRate > 0)) {
+    errors.InterestRate = 'Interest rate must be greater than 0.';
+  }
+  if (!loan.StartDate) {
+    errors.StartDate = 'Start date is required.';
+  }
+  if (!loan.EndDate) {
+    errors.EndDate = 'End date is required.';
+  }
+  // End date must be strictly after start date. This was part of the original
+  // isFormValid expression, so it stays an error (per the task's "if that's an
+  // error already, keep it an error").
+  if (loan.StartDate && loan.EndDate && !(loan.StartDate < loan.EndDate)) {
+    errors.EndDate = 'End date must be after the start date.';
+  }
+
+  // --- Non-blocking sanity warnings ---
+  if (
+    loan.Principal > 0 &&
+    loan.CurrentAmount > 0 &&
+    loan.CurrentAmount > loan.Principal
+  ) {
+    warnings.CurrentAmount =
+      'Current amount is greater than the original principal — the forecast may be wrong.';
+  }
+  if (loan.InterestRate > LOAN_RATE_WARNING_THRESHOLD) {
+    warnings.InterestRate = `Interest rate above ${LOAN_RATE_WARNING_THRESHOLD}% is unusually high — double-check the value.`;
+  }
+
+  return { errors, warnings, formErrors };
+};
+
+export const isLoanValid = (loan: Loan): boolean =>
+  Object.keys(validateLoan(loan).errors).length === 0;
+
+export type InvestmentField =
+  | 'Name'
+  | 'Provider'
+  | 'StartingBalance'
+  | 'AverageReturnRate'
+  | 'StartDate'
+  | 'CompoundingPeriod'
+  | 'RecurringContribution'
+  | 'ContributionFrequency'
+  | 'ContributionStepUpAmount';
+
+export const validateInvestment = (
+  investment: Investment
+): ValidationResult<InvestmentField> => {
+  const errors: Partial<Record<InvestmentField, string>> = {};
+  const warnings: Partial<Record<InvestmentField, string>> = {};
+  const formErrors: string[] = [];
+
+  // --- Blocking errors (mirror the original isFormValid rules) ---
+  if (investment.Name.trim() === '') {
+    errors.Name = 'Investment name is required.';
+  }
+  if (investment.Provider.trim() === '') {
+    errors.Provider = 'Provider is required.';
+  }
+  if (!(investment.StartingBalance > 0)) {
+    errors.StartingBalance = 'Starting balance must be greater than 0.';
+  }
+  // Original rule: AverageReturnRate >= 0 (0 is valid; negative is not).
+  if (!(investment.AverageReturnRate >= 0)) {
+    errors.AverageReturnRate = 'Average return rate cannot be negative.';
+  }
+  if (!investment.StartDate) {
+    errors.StartDate = 'Start date is required.';
+  }
+
+  // --- Non-blocking sanity warnings ---
+  if (investment.AverageReturnRate > INVESTMENT_RETURN_WARNING_THRESHOLD) {
+    warnings.AverageReturnRate = `A return above ${INVESTMENT_RETURN_WARNING_THRESHOLD}%/yr beats every broad index historically — double-check the value.`;
+  }
+
+  // A step-up that is configured but has no (or zero) amount silently does
+  // nothing — warn rather than block, since the investment still forecasts.
+  if (
+    typeof investment.RecurringContribution === 'number' &&
+    investment.RecurringContribution > 0 &&
+    investment.ContributionStepUpType &&
+    !(
+      typeof investment.ContributionStepUpAmount === 'number' &&
+      investment.ContributionStepUpAmount > 0
+    )
+  ) {
+    warnings.ContributionStepUpAmount =
+      investment.ContributionStepUpType === StepUpType.Percentage
+        ? 'Step-up percentage is 0 — contributions will never increase.'
+        : 'Step-up amount is 0 — contributions will never increase.';
+  }
+
+  // Contribution cadence finer than the compounding period: contributions land
+  // between compounding boundaries, so the forecast premise may be off.
+  if (
+    typeof investment.RecurringContribution === 'number' &&
+    investment.RecurringContribution > 0 &&
+    investment.ContributionFrequency &&
+    cadenceRank(investment.ContributionFrequency) <
+      cadenceRank(investment.CompoundingPeriod)
+  ) {
+    warnings.ContributionFrequency =
+      'Contributions are more frequent than compounding — the forecast may understate growth between compounding dates.';
+  }
+
+  return { errors, warnings, formErrors };
+};
+
+export const isInvestmentValid = (investment: Investment): boolean =>
+  Object.keys(validateInvestment(investment).errors).length === 0;

--- a/src/index.css
+++ b/src/index.css
@@ -3,66 +3,14 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -1,12 +1,10 @@
 import {
   Box,
   Button,
-  Card,
-  CardContent,
-  Popover,
-  Stack,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   TextField,
-  Typography,
   MenuItem,
   FormControl,
   InputLabel,
@@ -22,7 +20,7 @@ import {
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { NumericFormat } from 'react-number-format';
-import { Delete } from '@mui/icons-material';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   const [newInvestment, setNewInvestment] =
@@ -51,116 +49,138 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
     setNewInvestment(emptyInvestment);
   };
 
-  const onDelete = () => {
-    if (props.investment) {
-      props.onDelete(props.investment);
-    }
-    props.onClose();
-    setNewInvestment(emptyInvestment);
-  };
-
   useEffect(() => {
     setNewInvestment(props.investment ?? emptyInvestment);
   }, [props.investment]);
 
   return (
-    <Popover
-      open={props.open}
-      onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-    >
-      <Card>
-        <CardContent>
-          <Typography
-            variant="h5"
-            gutterBottom
-            sx={{
-              textAlign: 'center',
+    <ResponsiveDialog open={props.open} onClose={props.onClose}>
+      <DialogTitle sx={{ textAlign: 'center' }}>
+        {!props.investment ? 'Add Investment' : 'Edit Investment'}
+      </DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            mt: 1,
+          }}
+        >
+          <TextField
+            label="Investment Name"
+            value={newInvestment.Name}
+            onChange={(e) =>
+              setNewInvestment({ ...newInvestment, Name: e.target.value })
+            }
+            required
+          />
+          <TextField
+            label="Provider"
+            value={newInvestment.Provider}
+            onChange={(e) =>
+              setNewInvestment({ ...newInvestment, Provider: e.target.value })
+            }
+            required
+          />
+          <NumericFormat
+            label="Starting Balance"
+            value={newInvestment.StartingBalance}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              setNewInvestment({
+                ...newInvestment,
+                StartingBalance: Number(vs.value),
+              });
             }}
-          >
-            {!props.investment ? 'Add Investment' : 'Edit Investment'}
-          </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
+            required
+          />
+          <DatePicker
+            label="Start Date"
+            value={dayjs(newInvestment.StartDate)}
+            onChange={(date) =>
+              setNewInvestment({
+                ...newInvestment,
+                StartDate: date?.toDate() ?? new Date(),
+              })
+            }
+            views={['year', 'month', 'day']}
+            openTo="day"
+          />
+          <NumericFormat
+            label="Average Return Rate"
+            value={newInvestment.AverageReturnRate}
+            thousandSeparator
+            decimalScale={3}
+            suffix={'%'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              setNewInvestment({
+                ...newInvestment,
+                AverageReturnRate: Number(vs.value),
+              });
             }}
-          >
-            <TextField
-              label="Investment Name"
-              value={newInvestment.Name}
+            required
+          />
+          <FormControl fullWidth>
+            <InputLabel>Compounding Period</InputLabel>
+            <Select
+              value={newInvestment.CompoundingPeriod}
+              label="Compounding Period"
               onChange={(e) =>
-                setNewInvestment({ ...newInvestment, Name: e.target.value })
-              }
-              required
-            />
-            <TextField
-              label="Provider"
-              value={newInvestment.Provider}
-              onChange={(e) =>
-                setNewInvestment({ ...newInvestment, Provider: e.target.value })
-              }
-              required
-            />
-            <NumericFormat
-              label="Starting Balance"
-              value={newInvestment.StartingBalance}
-              thousandSeparator
-              decimalScale={2}
-              prefix={'$'}
-              customInput={TextField}
-              onValueChange={(vs) => {
                 setNewInvestment({
                   ...newInvestment,
-                  StartingBalance: Number(vs.value),
-                });
-              }}
-              required
-            />
-            <DatePicker
-              label="Start Date"
-              value={dayjs(newInvestment.StartDate)}
-              onChange={(date) =>
-                setNewInvestment({
-                  ...newInvestment,
-                  StartDate: date?.toDate() ?? new Date(),
+                  CompoundingPeriod: e.target.value as CompoundingFrequency,
                 })
               }
-              views={['year', 'month', 'day']}
-              openTo="day"
-            />
-            <NumericFormat
-              label="Average Return Rate"
-              value={newInvestment.AverageReturnRate}
-              thousandSeparator
-              decimalScale={3}
-              suffix={'%'}
-              customInput={TextField}
-              onValueChange={(vs) => {
-                setNewInvestment({
-                  ...newInvestment,
-                  AverageReturnRate: Number(vs.value),
-                });
-              }}
-              required
-            />
+            >
+              {Object.entries(CompoundingFrequency).map(([key, value]) => (
+                <MenuItem key={key} value={value}>
+                  {key}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <NumericFormat
+            label="Recurring Contribution (Optional)"
+            value={newInvestment.RecurringContribution || ''}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              const hasContribution = Boolean(vs.value);
+              setNewInvestment({
+                ...newInvestment,
+                RecurringContribution: hasContribution
+                  ? Number(vs.value)
+                  : undefined,
+                ContributionStepUpType: hasContribution
+                  ? newInvestment.ContributionStepUpType
+                  : undefined,
+                ContributionStepUpAmount: hasContribution
+                  ? newInvestment.ContributionStepUpAmount
+                  : undefined,
+              });
+            }}
+          />
+          {hasRecurringContribution && (
             <FormControl fullWidth>
-              <InputLabel>Compounding Period</InputLabel>
+              <InputLabel>Contribution Frequency</InputLabel>
               <Select
-                value={newInvestment.CompoundingPeriod}
-                label="Compounding Period"
+                value={
+                  newInvestment.ContributionFrequency ||
+                  CompoundingFrequency.Monthly
+                }
+                label="Contribution Frequency"
                 onChange={(e) =>
                   setNewInvestment({
                     ...newInvestment,
-                    CompoundingPeriod: e.target.value as CompoundingFrequency,
+                    ContributionFrequency: e.target
+                      .value as CompoundingFrequency,
                   })
                 }
               >
@@ -171,154 +191,89 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                 ))}
               </Select>
             </FormControl>
+          )}
+          {hasRecurringContribution && (
+            <FormControl fullWidth>
+              <InputLabel>Yearly Step-Up Type (Optional)</InputLabel>
+              <Select
+                value={newInvestment.ContributionStepUpType || ''}
+                label="Yearly Step-Up Type (Optional)"
+                onChange={(e) =>
+                  setNewInvestment({
+                    ...newInvestment,
+                    ContributionStepUpType: e.target.value
+                      ? (e.target.value as StepUpType)
+                      : undefined,
+                    ContributionStepUpAmount: e.target.value
+                      ? newInvestment.ContributionStepUpAmount
+                      : undefined,
+                  })
+                }
+              >
+                <MenuItem value="">None</MenuItem>
+                {Object.entries(StepUpType).map(([key, value]) => (
+                  <MenuItem key={key} value={value}>
+                    {key}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+          {hasRecurringContribution && newInvestment.ContributionStepUpType && (
             <NumericFormat
-              label="Recurring Contribution (Optional)"
-              value={newInvestment.RecurringContribution || ''}
+              label={
+                newInvestment.ContributionStepUpType === StepUpType.Flat
+                  ? 'Yearly Step-Up Amount'
+                  : 'Yearly Step-Up Percentage'
+              }
+              value={newInvestment.ContributionStepUpAmount || ''}
               thousandSeparator
               decimalScale={2}
-              prefix={'$'}
+              allowNegative={false}
+              prefix={
+                newInvestment.ContributionStepUpType === StepUpType.Flat
+                  ? '$'
+                  : undefined
+              }
+              suffix={
+                newInvestment.ContributionStepUpType === StepUpType.Percentage
+                  ? '%'
+                  : undefined
+              }
               customInput={TextField}
               onValueChange={(vs) => {
-                const hasContribution = Boolean(vs.value);
                 setNewInvestment({
                   ...newInvestment,
-                  RecurringContribution: hasContribution
+                  ContributionStepUpAmount: vs.value
                     ? Number(vs.value)
-                    : undefined,
-                  ContributionStepUpType: hasContribution
-                    ? newInvestment.ContributionStepUpType
-                    : undefined,
-                  ContributionStepUpAmount: hasContribution
-                    ? newInvestment.ContributionStepUpAmount
                     : undefined,
                 });
               }}
             />
-            {hasRecurringContribution && (
-              <FormControl fullWidth>
-                <InputLabel>Contribution Frequency</InputLabel>
-                <Select
-                  value={
-                    newInvestment.ContributionFrequency ||
-                    CompoundingFrequency.Monthly
-                  }
-                  label="Contribution Frequency"
-                  onChange={(e) =>
-                    setNewInvestment({
-                      ...newInvestment,
-                      ContributionFrequency: e.target
-                        .value as CompoundingFrequency,
-                    })
-                  }
-                >
-                  {Object.entries(CompoundingFrequency).map(([key, value]) => (
-                    <MenuItem key={key} value={value}>
-                      {key}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-            {hasRecurringContribution && (
-              <FormControl fullWidth>
-                <InputLabel>Yearly Step-Up Type (Optional)</InputLabel>
-                <Select
-                  value={newInvestment.ContributionStepUpType || ''}
-                  label="Yearly Step-Up Type (Optional)"
-                  onChange={(e) =>
-                    setNewInvestment({
-                      ...newInvestment,
-                      ContributionStepUpType: e.target.value
-                        ? (e.target.value as StepUpType)
-                        : undefined,
-                      ContributionStepUpAmount: e.target.value
-                        ? newInvestment.ContributionStepUpAmount
-                        : undefined,
-                    })
-                  }
-                >
-                  <MenuItem value="">None</MenuItem>
-                  {Object.entries(StepUpType).map(([key, value]) => (
-                    <MenuItem key={key} value={value}>
-                      {key}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-            {hasRecurringContribution &&
-              newInvestment.ContributionStepUpType && (
-                <NumericFormat
-                  label={
-                    newInvestment.ContributionStepUpType === StepUpType.Flat
-                      ? 'Yearly Step-Up Amount'
-                      : 'Yearly Step-Up Percentage'
-                  }
-                  value={newInvestment.ContributionStepUpAmount || ''}
-                  thousandSeparator
-                  decimalScale={2}
-                  allowNegative={false}
-                  prefix={
-                    newInvestment.ContributionStepUpType === StepUpType.Flat
-                      ? '$'
-                      : undefined
-                  }
-                  suffix={
-                    newInvestment.ContributionStepUpType ===
-                    StepUpType.Percentage
-                      ? '%'
-                      : undefined
-                  }
-                  customInput={TextField}
-                  onValueChange={(vs) => {
-                    setNewInvestment({
-                      ...newInvestment,
-                      ContributionStepUpAmount: vs.value
-                        ? Number(vs.value)
-                        : undefined,
-                    });
-                  }}
-                />
-              )}
-            <Stack direction="row">
-              {props.investment && (
-                <Button
-                  onClick={onDelete}
-                  sx={{ backgroundColor: 'error.main', color: 'white' }}
-                >
-                  <Delete />
-                </Button>
-              )}
-              <Button
-                type="reset"
-                color="secondary"
-                onClick={props.onClose}
-                sx={{ flex: 3 }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                onClick={onSave}
-                disabled={!isFormValid()}
-                sx={{ flex: 5 }}
-              >
-                {!props.investment ? 'Add Investment' : 'Save Investment'}
-              </Button>
-            </Stack>
-          </Box>
-        </CardContent>
-      </Card>
-    </Popover>
+          )}
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button type="reset" color="secondary" onClick={props.onClose}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          disabled={!isFormValid()}
+        >
+          {!props.investment ? 'Add Investment' : 'Save Investment'}
+        </Button>
+      </DialogActions>
+    </ResponsiveDialog>
   );
 };
 
 export interface AddEditInvestmentProps {
   open: boolean;
   onSave: (newInvestment: Investment, oldInvestment?: Investment) => void;
-  onDelete: (investment: Investment) => void;
   onClose: () => void;
   investment?: Investment;
 }

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   DialogActions,
@@ -7,10 +8,11 @@ import {
   TextField,
   MenuItem,
   FormControl,
+  FormHelperText,
   InputLabel,
   Select,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   emptyInvestment,
   Investment,
@@ -21,37 +23,77 @@ import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { NumericFormat } from 'react-number-format';
 import { ResponsiveDialog } from '../components/responsive-dialog';
+import {
+  InvestmentField,
+  isInvestmentValid,
+  validateInvestment,
+} from '../helpers/validation-helpers';
+import { fieldHelperText } from '../components/field-helper-text';
 
 export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   const [newInvestment, setNewInvestment] =
     useState<Investment>(emptyInvestment);
+  // Reveal a field's error only once it's touched or a save was attempted, so an
+  // untouched add form doesn't open all-red.
+  const [touched, setTouched] = useState<
+    Partial<Record<InvestmentField, boolean>>
+  >({});
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   const hasRecurringContribution =
     typeof newInvestment.RecurringContribution === 'number' &&
     newInvestment.RecurringContribution > 0;
 
-  const isFormValid = () => {
-    return (
-      newInvestment.Name.trim() !== '' &&
-      newInvestment.Provider.trim() !== '' &&
-      newInvestment.StartingBalance > 0 &&
-      newInvestment.AverageReturnRate >= 0 &&
-      newInvestment.StartDate
-    );
+  const validation = useMemo(
+    () => validateInvestment(newInvestment),
+    [newInvestment]
+  );
+  const isFormValid = () => isInvestmentValid(newInvestment);
+
+  const showFor = (field: InvestmentField) => submitAttempted || touched[field];
+  const touch = (field: InvestmentField) =>
+    setTouched((prev) => ({ ...prev, [field]: true }));
+  const errorFor = (field: InvestmentField) =>
+    showFor(field) ? validation.errors[field] : undefined;
+  const warningFor = (field: InvestmentField) =>
+    showFor(field) ? validation.warnings[field] : undefined;
+
+  const resetTracking = () => {
+    setTouched({});
+    setSubmitAttempted(false);
   };
+
+  // Why Save is disabled, always visible while invalid. Lists revealed errors
+  // once fields are touched/save attempted; otherwise a neutral prompt.
+  const revealedErrors = (Object.keys(validation.errors) as InvestmentField[])
+    .filter((field) => showFor(field))
+    .map((field) => validation.errors[field]);
+  const saveDisabledReason =
+    revealedErrors.length > 0
+      ? revealedErrors.join(' ')
+      : 'Fill in all required fields to enable saving.';
 
   const onSave = () => {
     if (!isFormValid()) {
+      setSubmitAttempted(true);
       return;
     }
     props.onSave(newInvestment, props.investment);
     props.onClose();
     setNewInvestment(emptyInvestment);
+    resetTracking();
+  };
+
+  const onCancel = () => {
+    props.onClose();
+    resetTracking();
   };
 
   useEffect(() => {
     setNewInvestment(props.investment ?? emptyInvestment);
-  }, [props.investment]);
+    setTouched({});
+    setSubmitAttempted(false);
+  }, [props.investment, props.open]);
 
   return (
     <ResponsiveDialog open={props.open} onClose={props.onClose}>
@@ -73,6 +115,9 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
             onChange={(e) =>
               setNewInvestment({ ...newInvestment, Name: e.target.value })
             }
+            onBlur={() => touch('Name')}
+            error={Boolean(errorFor('Name'))}
+            helperText={fieldHelperText(errorFor('Name'), warningFor('Name'))}
             required
           />
           <TextField
@@ -81,6 +126,12 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
             onChange={(e) =>
               setNewInvestment({ ...newInvestment, Provider: e.target.value })
             }
+            onBlur={() => touch('Provider')}
+            error={Boolean(errorFor('Provider'))}
+            helperText={fieldHelperText(
+              errorFor('Provider'),
+              warningFor('Provider')
+            )}
             required
           />
           <NumericFormat
@@ -96,19 +147,36 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                 StartingBalance: Number(vs.value),
               });
             }}
+            onBlur={() => touch('StartingBalance')}
+            error={Boolean(errorFor('StartingBalance'))}
+            helperText={fieldHelperText(
+              errorFor('StartingBalance'),
+              warningFor('StartingBalance')
+            )}
             required
           />
           <DatePicker
             label="Start Date"
             value={dayjs(newInvestment.StartDate)}
-            onChange={(date) =>
+            onChange={(date) => {
+              touch('StartDate');
               setNewInvestment({
                 ...newInvestment,
                 StartDate: date?.toDate() ?? new Date(),
-              })
-            }
+              });
+            }}
             views={['year', 'month', 'day']}
             openTo="day"
+            slotProps={{
+              textField: {
+                onBlur: () => touch('StartDate'),
+                error: Boolean(errorFor('StartDate')),
+                helperText: fieldHelperText(
+                  errorFor('StartDate'),
+                  warningFor('StartDate')
+                ),
+              },
+            }}
           />
           <NumericFormat
             label="Average Return Rate"
@@ -123,6 +191,12 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                 AverageReturnRate: Number(vs.value),
               });
             }}
+            onBlur={() => touch('AverageReturnRate')}
+            error={Boolean(errorFor('AverageReturnRate'))}
+            helperText={fieldHelperText(
+              errorFor('AverageReturnRate'),
+              warningFor('AverageReturnRate')
+            )}
             required
           />
           <FormControl fullWidth>
@@ -153,6 +227,12 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
             customInput={TextField}
             onValueChange={(vs) => {
               const hasContribution = Boolean(vs.value);
+              // Reveal the cadence/step-up sanity warnings once contributions
+              // are active, since their fields may keep their default values.
+              if (hasContribution) {
+                touch('ContributionFrequency');
+                touch('ContributionStepUpAmount');
+              }
               setNewInvestment({
                 ...newInvestment,
                 RecurringContribution: hasContribution
@@ -176,13 +256,14 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                   CompoundingFrequency.Monthly
                 }
                 label="Contribution Frequency"
-                onChange={(e) =>
+                onChange={(e) => {
+                  touch('ContributionFrequency');
                   setNewInvestment({
                     ...newInvestment,
                     ContributionFrequency: e.target
                       .value as CompoundingFrequency,
-                  })
-                }
+                  });
+                }}
               >
                 {Object.entries(CompoundingFrequency).map(([key, value]) => (
                   <MenuItem key={key} value={value}>
@@ -190,6 +271,14 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                   </MenuItem>
                 ))}
               </Select>
+              {warningFor('ContributionFrequency') && (
+                <FormHelperText>
+                  {fieldHelperText(
+                    undefined,
+                    warningFor('ContributionFrequency')
+                  )}
+                </FormHelperText>
+              )}
             </FormControl>
           )}
           {hasRecurringContribution && (
@@ -242,6 +331,7 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
               }
               customInput={TextField}
               onValueChange={(vs) => {
+                touch('ContributionStepUpAmount');
                 setNewInvestment({
                   ...newInvestment,
                   ContributionStepUpAmount: vs.value
@@ -249,12 +339,25 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                     : undefined,
                 });
               }}
+              onBlur={() => touch('ContributionStepUpAmount')}
+              error={Boolean(errorFor('ContributionStepUpAmount'))}
+              helperText={fieldHelperText(
+                errorFor('ContributionStepUpAmount'),
+                warningFor('ContributionStepUpAmount')
+              )}
             />
           )}
         </Box>
       </DialogContent>
+      <Box sx={{ px: 3 }}>
+        {!isFormValid() && (
+          <Alert severity="info" sx={{ mb: 1 }}>
+            {saveDisabledReason}
+          </Alert>
+        )}
+      </Box>
       <DialogActions>
-        <Button type="reset" color="secondary" onClick={props.onClose}>
+        <Button type="reset" color="secondary" onClick={onCancel}>
           Cancel
         </Button>
         <Button

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -24,21 +24,15 @@ import dayjs from 'dayjs';
 import { NumericFormat } from 'react-number-format';
 import { ResponsiveDialog } from '../components/responsive-dialog';
 import {
-  InvestmentField,
   isInvestmentValid,
   validateInvestment,
 } from '../helpers/validation-helpers';
 import { fieldHelperText } from '../components/field-helper-text';
+import { useFieldTracking } from '../helpers/use-field-tracking';
 
 export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   const [newInvestment, setNewInvestment] =
     useState<Investment>(emptyInvestment);
-  // Reveal a field's error only once it's touched or a save was attempted, so an
-  // untouched add form doesn't open all-red.
-  const [touched, setTouched] = useState<
-    Partial<Record<InvestmentField, boolean>>
-  >({});
-  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   const hasRecurringContribution =
     typeof newInvestment.RecurringContribution === 'number' &&
@@ -50,32 +44,20 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   );
   const isFormValid = () => isInvestmentValid(newInvestment);
 
-  const showFor = (field: InvestmentField) => submitAttempted || touched[field];
-  const touch = (field: InvestmentField) =>
-    setTouched((prev) => ({ ...prev, [field]: true }));
-  const errorFor = (field: InvestmentField) =>
-    showFor(field) ? validation.errors[field] : undefined;
-  const warningFor = (field: InvestmentField) =>
-    showFor(field) ? validation.warnings[field] : undefined;
-
-  const resetTracking = () => {
-    setTouched({});
-    setSubmitAttempted(false);
-  };
-
-  // Why Save is disabled, always visible while invalid. Lists revealed errors
-  // once fields are touched/save attempted; otherwise a neutral prompt.
-  const revealedErrors = (Object.keys(validation.errors) as InvestmentField[])
-    .filter((field) => showFor(field))
-    .map((field) => validation.errors[field]);
-  const saveDisabledReason =
-    revealedErrors.length > 0
-      ? revealedErrors.join(' ')
-      : 'Fill in all required fields to enable saving.';
+  // Touched / submit-attempt reveal logic + the save-disabled explanation,
+  // shared with the loan form (see use-field-tracking).
+  const {
+    touch,
+    errorFor,
+    warningFor,
+    resetTracking,
+    markSubmitAttempted,
+    saveDisabledReason,
+  } = useFieldTracking(validation);
 
   const onSave = () => {
     if (!isFormValid()) {
-      setSubmitAttempted(true);
+      markSubmitAttempted();
       return;
     }
     props.onSave(newInvestment, props.investment);
@@ -91,9 +73,8 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
 
   useEffect(() => {
     setNewInvestment(props.investment ?? emptyInvestment);
-    setTouched({});
-    setSubmitAttempted(false);
-  }, [props.investment, props.open]);
+    resetTracking();
+  }, [props.investment, props.open, resetTracking]);
 
   return (
     <ResponsiveDialog open={props.open} onClose={props.onClose}>

--- a/src/investment/growth-schedule-popout.tsx
+++ b/src/investment/growth-schedule-popout.tsx
@@ -1,15 +1,13 @@
 import {
-  Card,
-  CardContent,
+  DialogContent,
+  DialogTitle,
   Paper,
-  Popover,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  Typography,
 } from '@mui/material';
 import { Investment, CompoundingFrequency } from '../models/investment-model';
 import {
@@ -19,6 +17,7 @@ import {
 import { formatCurrency } from '../helpers/format-helpers';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 type ScheduleEntry = {
   period: number;
@@ -115,59 +114,45 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
   });
 
   return (
-    <Popover
+    <ResponsiveDialog
       open={!!props.investment}
       onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      sx={{ maxHeight: '90vh' }}
+      maxWidth="md"
     >
-      <Card>
-        <CardContent>
-          <Typography variant="h5" gutterBottom>
-            Growth Schedule
-          </Typography>
-          <TableContainer component={Paper} sx={{ maxHeight: '75vh' }}>
-            <Table stickyHeader>
-              <TableHead>
-                <TableRow>
-                  <TableCell>{getPeriodLabel()}</TableCell>
-                  <TableCell>Date</TableCell>
-                  {hasStepUp && <TableCell>Contribution</TableCell>}
-                  <TableCell>Total Invested</TableCell>
-                  <TableCell>Interest This Period</TableCell>
-                  <TableCell>Balance</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {scheduleEntries.map((entry) => (
-                  <TableRow key={entry.period}>
-                    <TableCell>{entry.period}</TableCell>
-                    <TableCell>{entry.date}</TableCell>
-                    {hasStepUp && (
-                      <TableCell>
-                        {formatCurrency(entry.contributionAmount)}
-                      </TableCell>
-                    )}
-                    <TableCell>{formatCurrency(entry.totalInvested)}</TableCell>
+      <DialogTitle>Growth Schedule</DialogTitle>
+      <DialogContent>
+        <TableContainer component={Paper}>
+          <Table stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>{getPeriodLabel()}</TableCell>
+                <TableCell>Date</TableCell>
+                {hasStepUp && <TableCell>Contribution</TableCell>}
+                <TableCell>Total Invested</TableCell>
+                <TableCell>Interest This Period</TableCell>
+                <TableCell>Balance</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {scheduleEntries.map((entry) => (
+                <TableRow key={entry.period}>
+                  <TableCell>{entry.period}</TableCell>
+                  <TableCell>{entry.date}</TableCell>
+                  {hasStepUp && (
                     <TableCell>
-                      {formatCurrency(entry.interestAccrued)}
+                      {formatCurrency(entry.contributionAmount)}
                     </TableCell>
-                    <TableCell>{formatCurrency(entry.balance)}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </CardContent>
-      </Card>
-    </Popover>
+                  )}
+                  <TableCell>{formatCurrency(entry.totalInvested)}</TableCell>
+                  <TableCell>{formatCurrency(entry.interestAccrued)}</TableCell>
+                  <TableCell>{formatCurrency(entry.balance)}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </DialogContent>
+    </ResponsiveDialog>
   );
 };
 

--- a/src/investment/growth-schedule-popout.tsx
+++ b/src/investment/growth-schedule-popout.tsx
@@ -16,6 +16,7 @@ import {
   generateInvestmentGrowth,
   getPeriodsPerYear,
 } from '../helpers/investment-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
@@ -151,38 +152,14 @@ export const GrowthSchedulePopout = (props: GrowthSchedulePopoutProps) => {
                     <TableCell>{entry.date}</TableCell>
                     {hasStepUp && (
                       <TableCell>
-                        {entry.contributionAmount.toLocaleString(undefined, {
-                          style: 'currency',
-                          currency: 'USD',
-                          minimumFractionDigits: 2,
-                          maximumFractionDigits: 2,
-                        })}
+                        {formatCurrency(entry.contributionAmount)}
                       </TableCell>
                     )}
+                    <TableCell>{formatCurrency(entry.totalInvested)}</TableCell>
                     <TableCell>
-                      {entry.totalInvested.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      {formatCurrency(entry.interestAccrued)}
                     </TableCell>
-                    <TableCell>
-                      {entry.interestAccrued.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
-                    <TableCell>
-                      {entry.balance.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
+                    <TableCell>{formatCurrency(entry.balance)}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -13,7 +13,6 @@ import {
   Grid,
   useTheme,
   useMediaQuery,
-  IconButton,
 } from '@mui/material';
 import {
   Investment,
@@ -26,6 +25,170 @@ import { Calculate, Delete, Edit, TrendingUp } from '@mui/icons-material';
 import { useState } from 'react';
 import { PitPopout } from './pit-popout';
 import { GrowthSchedulePopout } from './growth-schedule-popout';
+import { EntityRowActions, RowAction } from '../components/entity-row-actions';
+
+// Callbacks an investment row/card needs. Passed down from the table so the row
+// and card components can live at module scope (no remount-on-render).
+interface InvestmentRowHandlers {
+  onGrowth: (investment: Investment) => void;
+  onPit: (investment: Investment) => void;
+  onEdit: (investment: Investment) => void;
+  onDelete: (investment: Investment) => void;
+}
+
+const investmentActions = (
+  investment: Investment,
+  handlers: InvestmentRowHandlers
+): RowAction[] => [
+  {
+    icon: <TrendingUp />,
+    title: 'View Growth Schedule',
+    onClick: () => handlers.onGrowth(investment),
+  },
+  {
+    icon: <Calculate />,
+    title: 'Point-in-Time Calculator',
+    onClick: () => handlers.onPit(investment),
+  },
+  {
+    icon: <Edit />,
+    title: 'Edit Investment',
+    onClick: () => handlers.onEdit(investment),
+  },
+  {
+    icon: <Delete />,
+    title: 'Delete Investment',
+    onClick: () => handlers.onDelete(investment),
+    color: 'error',
+  },
+];
+
+const formatContribution = (investment: Investment): string => {
+  if (!investment.RecurringContribution) return 'None';
+  const base = formatCurrency(investment.RecurringContribution);
+  if (
+    !investment.ContributionStepUpType ||
+    !investment.ContributionStepUpAmount
+  )
+    return base;
+  const stepUp =
+    investment.ContributionStepUpType === StepUpType.Flat
+      ? `+${formatCurrency(investment.ContributionStepUpAmount)}/yr`
+      : `+${investment.ContributionStepUpAmount}%/yr`;
+  return `${base} (${stepUp})`;
+};
+
+const getCompoundingText = (period: CompoundingFrequency) => {
+  switch (period) {
+    case CompoundingFrequency.Monthly:
+      return 'Monthly';
+    case CompoundingFrequency.Quarterly:
+      return 'Quarterly';
+    case CompoundingFrequency.Annually:
+      return 'Annually';
+    default:
+      return period;
+  }
+};
+
+const InvestmentCard = ({
+  investment,
+  handlers,
+  isMobile,
+}: {
+  investment: Investment;
+  handlers: InvestmentRowHandlers;
+  isMobile: boolean;
+}) => (
+  <Card sx={{ marginBottom: 2 }}>
+    <CardContent>
+      <Typography variant="h6" component="div">
+        {investment.Name}
+      </Typography>
+      <Typography
+        sx={{
+          color: 'text.secondary',
+          mb: 1.5,
+        }}
+      >
+        {investment.Provider}
+      </Typography>
+      <Box sx={{ marginBottom: 1 }}>
+        <Grid container spacing={2}>
+          <Grid
+            size={{
+              xs: 12,
+              sm: 6,
+            }}
+          >
+            <Typography variant="body2">
+              <strong>Starting Balance:</strong>
+            </Typography>
+            <Typography variant="body2">
+              {formatCurrency(investment.StartingBalance)}
+            </Typography>
+          </Grid>
+          <Grid
+            size={{
+              xs: 12,
+              sm: 6,
+            }}
+          >
+            <Typography variant="body2">
+              <strong>Return Rate:</strong>
+            </Typography>
+            <Typography variant="body2">
+              {formatPercent(investment.AverageReturnRate, 3)}
+            </Typography>
+          </Grid>
+          <Grid
+            size={{
+              xs: 12,
+              sm: 6,
+            }}
+          >
+            <Typography variant="body2">
+              <strong>Compounding:</strong>
+            </Typography>
+            <Typography variant="body2">
+              {getCompoundingText(investment.CompoundingPeriod)}
+            </Typography>
+          </Grid>
+          <Grid
+            size={{
+              xs: 12,
+              sm: 6,
+            }}
+          >
+            <Typography variant="body2">
+              <strong>Recurring:</strong>
+            </Typography>
+            <Typography variant="body2">
+              {formatContribution(investment)}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          flexDirection: { xs: 'column', sm: 'row' },
+          gap: { xs: 1, sm: 0 },
+        }}
+      >
+        <Typography variant="body2">
+          <strong>Periods:</strong> {getInvestmentPeriods(investment)}
+        </Typography>
+        <EntityRowActions
+          actions={investmentActions(investment, handlers)}
+          isMobile={isMobile}
+        />
+      </Box>
+    </CardContent>
+  </Card>
+);
 
 export const InvestmentTable = (props: InvestmentTableProps) => {
   const [selectedPit, setSelectedPit] = useState<Investment | undefined>();
@@ -35,170 +198,12 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-  const formatContribution = (investment: Investment): string => {
-    if (!investment.RecurringContribution) return 'None';
-    const base = formatCurrency(investment.RecurringContribution);
-    if (
-      !investment.ContributionStepUpType ||
-      !investment.ContributionStepUpAmount
-    )
-      return base;
-    const stepUp =
-      investment.ContributionStepUpType === StepUpType.Flat
-        ? `+${formatCurrency(investment.ContributionStepUpAmount)}/yr`
-        : `+${investment.ContributionStepUpAmount}%/yr`;
-    return `${base} (${stepUp})`;
+  const handlers: InvestmentRowHandlers = {
+    onGrowth: setSelectedGrowth,
+    onPit: setSelectedPit,
+    onEdit: props.onInvestmentEdit,
+    onDelete: props.onInvestmentDelete,
   };
-
-  const getCompoundingText = (period: CompoundingFrequency) => {
-    switch (period) {
-      case CompoundingFrequency.Monthly:
-        return 'Monthly';
-      case CompoundingFrequency.Quarterly:
-        return 'Quarterly';
-      case CompoundingFrequency.Annually:
-        return 'Annually';
-      default:
-        return period;
-    }
-  };
-
-  const InvestmentActions = ({
-    investment,
-    isMobile = false,
-  }: {
-    investment: Investment;
-    isMobile?: boolean;
-  }) => (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: isMobile ? 'space-around' : 'flex-start',
-        gap: isMobile ? 0 : 1,
-      }}
-    >
-      <IconButton
-        onClick={() => setSelectedGrowth(investment)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="View Growth Schedule"
-      >
-        <TrendingUp />
-      </IconButton>
-      <IconButton
-        onClick={() => setSelectedPit(investment)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="Point-in-Time Calculator"
-      >
-        <Calculate />
-      </IconButton>
-      <IconButton
-        onClick={() => props.onInvestmentEdit(investment)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="Edit Investment"
-      >
-        <Edit />
-      </IconButton>
-      <IconButton
-        onClick={() => props.onInvestmentDelete(investment)}
-        color="error"
-        size={isMobile ? 'medium' : 'small'}
-        title="Delete Investment"
-      >
-        <Delete />
-      </IconButton>
-    </Box>
-  );
-
-  const InvestmentCard = ({ investment }: { investment: Investment }) => (
-    <Card sx={{ marginBottom: 2 }}>
-      <CardContent>
-        <Typography variant="h6" component="div">
-          {investment.Name}
-        </Typography>
-        <Typography
-          sx={{
-            color: 'text.secondary',
-            mb: 1.5,
-          }}
-        >
-          {investment.Provider}
-        </Typography>
-        <Box sx={{ marginBottom: 1 }}>
-          <Grid container spacing={2}>
-            <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-              }}
-            >
-              <Typography variant="body2">
-                <strong>Starting Balance:</strong>
-              </Typography>
-              <Typography variant="body2">
-                {formatCurrency(investment.StartingBalance)}
-              </Typography>
-            </Grid>
-            <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-              }}
-            >
-              <Typography variant="body2">
-                <strong>Return Rate:</strong>
-              </Typography>
-              <Typography variant="body2">
-                {formatPercent(investment.AverageReturnRate, 3)}
-              </Typography>
-            </Grid>
-            <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-              }}
-            >
-              <Typography variant="body2">
-                <strong>Compounding:</strong>
-              </Typography>
-              <Typography variant="body2">
-                {getCompoundingText(investment.CompoundingPeriod)}
-              </Typography>
-            </Grid>
-            <Grid
-              size={{
-                xs: 12,
-                sm: 6,
-              }}
-            >
-              <Typography variant="body2">
-                <strong>Recurring:</strong>
-              </Typography>
-              <Typography variant="body2">
-                {formatContribution(investment)}
-              </Typography>
-            </Grid>
-          </Grid>
-        </Box>
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            flexDirection: { xs: 'column', sm: 'row' },
-            gap: { xs: 1, sm: 0 },
-          }}
-        >
-          <Typography variant="body2">
-            <strong>Periods:</strong> {getInvestmentPeriods(investment)}
-          </Typography>
-          <InvestmentActions investment={investment} isMobile={isMobile} />
-        </Box>
-      </CardContent>
-    </Card>
-  );
 
   return (
     <>
@@ -218,7 +223,12 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
       {isMobile ? (
         <Box>
           {props.investments.map((investment) => (
-            <InvestmentCard key={investment.Id} investment={investment} />
+            <InvestmentCard
+              key={investment.Id}
+              investment={investment}
+              handlers={handlers}
+              isMobile={isMobile}
+            />
           ))}
         </Box>
       ) : (
@@ -249,7 +259,9 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                   </TableCell>
                   <TableCell>{formatContribution(row)}</TableCell>
                   <TableCell>
-                    <InvestmentActions investment={row} isMobile={false} />
+                    <EntityRowActions
+                      actions={investmentActions(row, handlers)}
+                    />
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -21,6 +21,7 @@ import {
   StepUpType,
 } from '../models/investment-model';
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
+import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { Calculate, Edit, TrendingUp } from '@mui/icons-material';
 import { useState } from 'react';
 import { PitPopout } from './pit-popout';
@@ -33,17 +34,6 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
   >();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-  const formatCurrency = (amount: number) => {
-    return amount.toLocaleString(undefined, {
-      style: 'currency',
-      currency: 'USD',
-    });
-  };
-
-  const formatPercent = (rate: number) => {
-    return `${rate.toFixed(3)}%`;
-  };
 
   const formatContribution = (investment: Investment): string => {
     if (!investment.RecurringContribution) return 'None';
@@ -153,7 +143,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                 <strong>Return Rate:</strong>
               </Typography>
               <Typography variant="body2">
-                {formatPercent(investment.AverageReturnRate)}
+                {formatPercent(investment.AverageReturnRate, 3)}
               </Typography>
             </Grid>
             <Grid
@@ -243,7 +233,9 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                   <TableCell>{row.Name}</TableCell>
                   <TableCell>{row.Provider}</TableCell>
                   <TableCell>{formatCurrency(row.StartingBalance)}</TableCell>
-                  <TableCell>{formatPercent(row.AverageReturnRate)}</TableCell>
+                  <TableCell>
+                    {formatPercent(row.AverageReturnRate, 3)}
+                  </TableCell>
                   <TableCell>
                     {getCompoundingText(row.CompoundingPeriod)}
                   </TableCell>

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -22,7 +22,7 @@ import {
 } from '../models/investment-model';
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
-import { Calculate, Edit, TrendingUp } from '@mui/icons-material';
+import { Calculate, Delete, Edit, TrendingUp } from '@mui/icons-material';
 import { useState } from 'react';
 import { PitPopout } from './pit-popout';
 import { GrowthSchedulePopout } from './growth-schedule-popout';
@@ -100,6 +100,14 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
         title="Edit Investment"
       >
         <Edit />
+      </IconButton>
+      <IconButton
+        onClick={() => props.onInvestmentDelete(investment)}
+        color="error"
+        size={isMobile ? 'medium' : 'small'}
+        title="Delete Investment"
+      >
+        <Delete />
       </IconButton>
     </Box>
   );
@@ -256,4 +264,5 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
 export type InvestmentTableProps = {
   investments: Investment[];
   onInvestmentEdit: (investment: Investment) => void;
+  onInvestmentDelete: (investment: Investment) => void;
 };

--- a/src/investment/pit-popout.tsx
+++ b/src/investment/pit-popout.tsx
@@ -1,8 +1,7 @@
 import {
   Box,
-  Card,
-  CardContent,
-  Popover,
+  DialogContent,
+  DialogTitle,
   Stack,
   TextField,
   Typography,
@@ -19,6 +18,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { getPitInvestmentCalculation } from '../helpers/investment-helpers';
 import { formatCurrency } from '../helpers/format-helpers';
 import { NumericFormat, NumberFormatValues } from 'react-number-format';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const PitPopout = (props: PitPopoutProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(new Date());
@@ -102,76 +102,62 @@ export const PitPopout = (props: PitPopoutProps) => {
   }, [props.investment, selectedDate]);
 
   return (
-    <Popover
-      open={!!props.investment}
-      onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-    >
-      <Card>
-        <CardContent>
-          <Typography variant="h5" gutterBottom>
-            Point-in-Time Calculator
-          </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-            }}
-          >
-            <Stack direction="row">
-              <DatePicker
-                label="Projection Date"
-                value={dayjs(selectedDate)}
-                onChange={(date: Dayjs | null) =>
-                  setSelectedDate(date?.toDate() ?? props.investment.StartDate)
-                }
-                minDate={dayjs(props.investment.StartDate)}
-                views={getDatePickerViews()}
-                openTo={
-                  props.investment.CompoundingPeriod ===
-                  CompoundingFrequency.Annually
-                    ? 'year'
-                    : 'month'
-                }
-                sx={{ flex: 4 }}
-              />
-              <NumericFormat
-                label={getPeriodLabel()}
-                value={getPeriodsFromStart(selectedDate)}
-                thousandSeparator
-                decimalScale={2}
-                customInput={TextField}
-                onValueChange={(vs: NumberFormatValues) => {
-                  handlePeriodChange(Number(vs.value));
-                }}
-                isAllowed={(values) => {
-                  const { floatValue } = values;
-                  return floatValue === undefined || floatValue >= 0;
-                }}
-                sx={{ flex: 2 }}
-              />
-            </Stack>
-            <Typography>{`Total Contributions: ${formatCurrency(
-              pitInvestment.TotalContributions
-            )}`}</Typography>
-            <Typography>{`Total Interest Earned: ${formatCurrency(
-              pitInvestment.TotalInterestEarned
-            )}`}</Typography>
-            <Typography>{`Current Value: ${formatCurrency(
-              pitInvestment.CurrentValue
-            )}`}</Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    </Popover>
+    <ResponsiveDialog open={!!props.investment} onClose={props.onClose}>
+      <DialogTitle>Point-in-Time Calculator</DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            mt: 1,
+          }}
+        >
+          <Stack direction="row">
+            <DatePicker
+              label="Projection Date"
+              value={dayjs(selectedDate)}
+              onChange={(date: Dayjs | null) =>
+                setSelectedDate(date?.toDate() ?? props.investment.StartDate)
+              }
+              minDate={dayjs(props.investment.StartDate)}
+              views={getDatePickerViews()}
+              openTo={
+                props.investment.CompoundingPeriod ===
+                CompoundingFrequency.Annually
+                  ? 'year'
+                  : 'month'
+              }
+              sx={{ flex: 4 }}
+            />
+            <NumericFormat
+              label={getPeriodLabel()}
+              value={getPeriodsFromStart(selectedDate)}
+              thousandSeparator
+              decimalScale={2}
+              customInput={TextField}
+              onValueChange={(vs: NumberFormatValues) => {
+                handlePeriodChange(Number(vs.value));
+              }}
+              isAllowed={(values) => {
+                const { floatValue } = values;
+                return floatValue === undefined || floatValue >= 0;
+              }}
+              sx={{ flex: 2 }}
+            />
+          </Stack>
+          <Typography>{`Total Contributions: ${formatCurrency(
+            pitInvestment.TotalContributions
+          )}`}</Typography>
+          <Typography>{`Total Interest Earned: ${formatCurrency(
+            pitInvestment.TotalInterestEarned
+          )}`}</Typography>
+          <Typography>{`Current Value: ${formatCurrency(
+            pitInvestment.CurrentValue
+          )}`}</Typography>
+        </Box>
+      </DialogContent>
+    </ResponsiveDialog>
   );
 };
 

--- a/src/investment/pit-popout.tsx
+++ b/src/investment/pit-popout.tsx
@@ -17,6 +17,7 @@ import {
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs, { Dayjs } from 'dayjs';
 import { getPitInvestmentCalculation } from '../helpers/investment-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
 import { NumericFormat, NumberFormatValues } from 'react-number-format';
 
 export const PitPopout = (props: PitPopoutProps) => {
@@ -158,32 +159,14 @@ export const PitPopout = (props: PitPopoutProps) => {
                 sx={{ flex: 2 }}
               />
             </Stack>
-            <Typography>{`Total Contributions: ${pitInvestment.TotalContributions.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Total Contributions: ${formatCurrency(
+              pitInvestment.TotalContributions
             )}`}</Typography>
-            <Typography>{`Total Interest Earned: ${pitInvestment.TotalInterestEarned.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Total Interest Earned: ${formatCurrency(
+              pitInvestment.TotalInterestEarned
             )}`}</Typography>
-            <Typography>{`Current Value: ${pitInvestment.CurrentValue.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Current Value: ${formatCurrency(
+              pitInvestment.CurrentValue
             )}`}</Typography>
           </Box>
         </CardContent>

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -20,52 +20,32 @@ import { NumericFormat } from 'react-number-format';
 import { ResponsiveDialog } from '../components/responsive-dialog';
 import {
   isLoanValid,
-  LoanField,
+  LOAN_RATE_WARNING_THRESHOLD,
   validateLoan,
 } from '../helpers/validation-helpers';
 import { fieldHelperText } from '../components/field-helper-text';
+import { useFieldTracking } from '../helpers/use-field-tracking';
 
 export const AddEditLoan = (props: AddEditLoanProps) => {
   const [newLoan, setNewLoan] = useState<Loan>(emptyLoan);
-  // Track which fields the user has interacted with, plus a save-attempt flag,
-  // so an untouched add form doesn't open all-red. A field's error shows once it
-  // is touched OR a save has been attempted.
-  const [touched, setTouched] = useState<Partial<Record<LoanField, boolean>>>(
-    {}
-  );
-  const [submitAttempted, setSubmitAttempted] = useState(false);
 
   const validation = useMemo(() => validateLoan(newLoan), [newLoan]);
   const isFormValid = () => isLoanValid(newLoan);
 
-  const showFor = (field: LoanField) => submitAttempted || touched[field];
-  const touch = (field: LoanField) =>
-    setTouched((prev) => ({ ...prev, [field]: true }));
-  const errorFor = (field: LoanField) =>
-    showFor(field) ? validation.errors[field] : undefined;
-  const warningFor = (field: LoanField) =>
-    showFor(field) ? validation.warnings[field] : undefined;
-
-  const resetTracking = () => {
-    setTouched({});
-    setSubmitAttempted(false);
-  };
-
-  // Why Save is disabled, always visible while invalid. Once the user has
-  // touched fields (or attempted save) we list the specific revealed errors;
-  // before that we show a neutral prompt so the form doesn't open all-red but
-  // the user still knows what's expected.
-  const revealedErrors = (Object.keys(validation.errors) as LoanField[])
-    .filter((field) => showFor(field))
-    .map((field) => validation.errors[field]);
-  const saveDisabledReason =
-    revealedErrors.length > 0
-      ? revealedErrors.join(' ')
-      : 'Fill in all required fields to enable saving.';
+  // Touched / submit-attempt reveal logic + the save-disabled explanation,
+  // shared with the investment form (see use-field-tracking).
+  const {
+    touch,
+    errorFor,
+    warningFor,
+    resetTracking,
+    markSubmitAttempted,
+    saveDisabledReason,
+  } = useFieldTracking(validation);
 
   const onSave = () => {
     if (!isFormValid()) {
-      setSubmitAttempted(true);
+      markSubmitAttempted();
       return;
     }
     props.onSave(newLoan, props.loan);
@@ -81,9 +61,8 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
 
   useEffect(() => {
     setNewLoan(props.loan ?? emptyLoan);
-    setTouched({});
-    setSubmitAttempted(false);
-  }, [props.loan, props.open]);
+    resetTracking();
+  }, [props.loan, props.open, resetTracking]);
 
   useEffect(() => {
     if (
@@ -266,7 +245,10 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
                 valueLabelDisplay="auto"
                 step={0.25}
                 min={0}
-                max={30}
+                // Headroom above the warning threshold so the slider can
+                // actually reach a rate that trips the "unusually high" warning,
+                // and so the ceiling tracks the threshold instead of drifting.
+                max={LOAN_RATE_WARNING_THRESHOLD + 10}
                 sx={{ flex: 5 }}
               />
               <NumericFormat

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -1,9 +1,9 @@
 import {
   Box,
   Button,
-  Card,
-  CardContent,
-  Popover,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Slider,
   Stack,
   TextField,
@@ -15,7 +15,7 @@ import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { getMonthlyPayment, getTerms } from '../helpers/loan-helpers';
 import { NumericFormat } from 'react-number-format';
-import { Delete } from '@mui/icons-material';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const AddEditLoan = (props: AddEditLoanProps) => {
   const [newLoan, setNewLoan] = useState<Loan>(emptyLoan);
@@ -38,14 +38,6 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
       return;
     }
     props.onSave(newLoan, props.loan);
-    props.onClose();
-    setNewLoan(emptyLoan);
-  };
-
-  const onDelete = () => {
-    if (props.loan) {
-      props.onDelete(props.loan);
-    }
     props.onClose();
     setNewLoan(emptyLoan);
   };
@@ -79,227 +71,194 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
   ]);
 
   return (
-    <Popover
-      open={props.open}
-      onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-    >
-      <Card>
-        <CardContent>
-          <Typography
-            variant="h5"
-            gutterBottom
-            sx={{
-              textAlign: 'center',
+    <ResponsiveDialog open={props.open} onClose={props.onClose}>
+      <DialogTitle sx={{ textAlign: 'center' }}>
+        {!props.loan ? 'Add new loan' : 'Edit loan'}
+      </DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            mt: 1,
+          }}
+        >
+          <TextField
+            label="Name"
+            value={newLoan.Name}
+            onChange={(e) => setNewLoan({ ...newLoan, Name: e.target.value })}
+            required
+          />
+          <TextField
+            label="Loan Provider"
+            value={newLoan.Provider}
+            onChange={(e) =>
+              setNewLoan({ ...newLoan, Provider: e.target.value })
+            }
+            required
+          />
+          <NumericFormat
+            label="Principal"
+            value={newLoan.Principal}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              setNewLoan({ ...newLoan, Principal: Number(vs.value) });
             }}
-          >
-            {!props.loan ? 'Add new loan' : 'Edit loan'}
-          </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
+            required
+          />
+          <NumericFormat
+            label="Current Amount"
+            value={newLoan.CurrentAmount}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              setNewLoan({ ...newLoan, CurrentAmount: Number(vs.value) });
             }}
-          >
-            <TextField
-              label="Name"
-              value={newLoan.Name}
-              onChange={(e) => setNewLoan({ ...newLoan, Name: e.target.value })}
-              required
-            />
-            <TextField
-              label="Loan Provider"
-              value={newLoan.Provider}
-              onChange={(e) =>
-                setNewLoan({ ...newLoan, Provider: e.target.value })
-              }
-              required
-            />
-            <NumericFormat
-              label="Principal"
-              value={newLoan.Principal}
-              thousandSeparator
-              decimalScale={2}
-              prefix={'$'}
-              customInput={TextField}
-              onValueChange={(vs) => {
-                setNewLoan({ ...newLoan, Principal: Number(vs.value) });
-              }}
-              required
-            />
-            <NumericFormat
-              label="Current Amount"
-              value={newLoan.CurrentAmount}
-              thousandSeparator
-              decimalScale={2}
-              prefix={'$'}
-              customInput={TextField}
-              onValueChange={(vs) => {
-                setNewLoan({ ...newLoan, CurrentAmount: Number(vs.value) });
-              }}
-              required
-            />
+            required
+          />
+          <DatePicker
+            label="Start Date"
+            value={dayjs(newLoan.StartDate)}
+            onChange={(date) =>
+              setNewLoan({
+                ...newLoan,
+                StartDate: date?.toDate() ?? new Date(),
+              })
+            }
+            views={['year', 'month', 'day']}
+            openTo="day"
+          />
+          <Stack direction="row" spacing={1}>
             <DatePicker
-              label="Start Date"
-              value={dayjs(newLoan.StartDate)}
+              label="End Date"
+              value={dayjs(newLoan.EndDate)}
               onChange={(date) =>
                 setNewLoan({
                   ...newLoan,
-                  StartDate: date?.toDate() ?? new Date(),
+                  EndDate: date?.toDate() ?? new Date(),
                 })
               }
               views={['year', 'month', 'day']}
-              openTo="day"
+              openTo="year"
+              sx={{ flex: 5 }}
             />
-            <Stack direction="row" spacing={1}>
-              <DatePicker
-                label="End Date"
-                value={dayjs(newLoan.EndDate)}
-                onChange={(date) =>
+            <TextField
+              label="Terms"
+              value={getTerms(newLoan)}
+              onChange={(e) =>
+                setNewLoan({
+                  ...newLoan,
+                  EndDate: dayjs(newLoan.StartDate)
+                    .add(Number(e.target.value) - 1, 'months')
+                    .toDate(),
+                })
+              }
+              sx={{ flex: 2 }}
+            />
+          </Stack>
+          <Stack>
+            <Typography gutterBottom>Interest Percentage</Typography>
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                alignItems: 'center',
+              }}
+            >
+              <Slider
+                value={newLoan.InterestRate}
+                onChange={(_e, newValue) =>
                   setNewLoan({
                     ...newLoan,
-                    EndDate: date?.toDate() ?? new Date(),
+                    InterestRate: Array.isArray(newValue)
+                      ? newValue[0]
+                      : newValue,
                   })
                 }
-                views={['year', 'month', 'day']}
-                openTo="year"
+                valueLabelDisplay="auto"
+                step={0.25}
+                min={0}
+                max={30}
                 sx={{ flex: 5 }}
               />
-              <TextField
-                label="Terms"
-                value={getTerms(newLoan)}
-                onChange={(e) =>
-                  setNewLoan({
-                    ...newLoan,
-                    EndDate: dayjs(newLoan.StartDate)
-                      .add(Number(e.target.value) - 1, 'months')
-                      .toDate(),
-                  })
-                }
-                sx={{ flex: 2 }}
-              />
-            </Stack>
-            <Stack>
-              <Typography gutterBottom>Interest Percentage</Typography>
-              <Stack
-                direction="row"
-                spacing={1}
-                sx={{
-                  alignItems: 'center',
-                }}
-              >
-                <Slider
-                  value={newLoan.InterestRate}
-                  onChange={(_e, newValue) =>
-                    setNewLoan({
-                      ...newLoan,
-                      InterestRate: Array.isArray(newValue)
-                        ? newValue[0]
-                        : newValue,
-                    })
-                  }
-                  valueLabelDisplay="auto"
-                  step={0.25}
-                  min={0}
-                  max={30}
-                  sx={{ flex: 5 }}
-                />
-                <NumericFormat
-                  label="Interest Rate"
-                  value={newLoan.InterestRate}
-                  thousandSeparator
-                  decimalScale={3}
-                  suffix={'%'}
-                  customInput={TextField}
-                  onValueChange={(vs) => {
-                    setNewLoan({
-                      ...newLoan,
-                      InterestRate: Number(vs.value),
-                    });
-                  }}
-                  sx={{ flex: 2 }}
-                  required
-                />
-              </Stack>
-            </Stack>
-
-            <Stack direction="row">
               <NumericFormat
-                label="Monthly Payment"
-                value={newLoan.MonthlyPayment}
+                label="Interest Rate"
+                value={newLoan.InterestRate}
                 thousandSeparator
-                decimalScale={2}
-                prefix={'$'}
+                decimalScale={3}
+                suffix={'%'}
                 customInput={TextField}
                 onValueChange={(vs) => {
-                  setNewLoan({ ...newLoan, MonthlyPayment: Number(vs.value) });
-                }}
-                sx={{ flex: 6 }}
-                required
-              />
-              <Button
-                onClick={() =>
                   setNewLoan({
                     ...newLoan,
-                    MonthlyPayment: getMonthlyPayment(
-                      newLoan.Principal,
-                      newLoan.InterestRate,
-                      getTerms(newLoan)
-                    ),
-                  })
-                }
-                sx={{ flex: 1 }}
-              >
-                Reset
-              </Button>
+                    InterestRate: Number(vs.value),
+                  });
+                }}
+                sx={{ flex: 2 }}
+                required
+              />
             </Stack>
-            <Stack direction="row">
-              {props.loan && (
-                <Button
-                  onClick={onDelete}
-                  sx={{ backgroundColor: 'error.main', color: 'white' }}
-                >
-                  <Delete />
-                </Button>
-              )}
-              <Button
-                type="reset"
-                color="secondary"
-                onClick={props.onClose}
-                sx={{ flex: 3 }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="submit"
-                variant="contained"
-                color="primary"
-                onClick={onSave}
-                disabled={!isFormValid()}
-                sx={{ flex: 5 }}
-              >
-                {!props.loan ? 'Add loan' : 'Save loan'}
-              </Button>
-            </Stack>
-          </Box>
-        </CardContent>
-      </Card>
-    </Popover>
+          </Stack>
+
+          <Stack direction="row">
+            <NumericFormat
+              label="Monthly Payment"
+              value={newLoan.MonthlyPayment}
+              thousandSeparator
+              decimalScale={2}
+              prefix={'$'}
+              customInput={TextField}
+              onValueChange={(vs) => {
+                setNewLoan({ ...newLoan, MonthlyPayment: Number(vs.value) });
+              }}
+              sx={{ flex: 6 }}
+              required
+            />
+            <Button
+              onClick={() =>
+                setNewLoan({
+                  ...newLoan,
+                  MonthlyPayment: getMonthlyPayment(
+                    newLoan.Principal,
+                    newLoan.InterestRate,
+                    getTerms(newLoan)
+                  ),
+                })
+              }
+              sx={{ flex: 1 }}
+            >
+              Reset
+            </Button>
+          </Stack>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button type="reset" color="secondary" onClick={props.onClose}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          disabled={!isFormValid()}
+        >
+          {!props.loan ? 'Add loan' : 'Save loan'}
+        </Button>
+      </DialogActions>
+    </ResponsiveDialog>
   );
 };
 
 export interface AddEditLoanProps {
   open: boolean;
   onSave: (newLoan: Loan, oldLoan?: Loan) => void;
-  onDelete: (loan: Loan) => void;
   onClose: () => void;
   loan?: Loan;
 }

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -1,50 +1,89 @@
 import {
+  Alert,
   Box,
   Button,
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormHelperText,
   Slider,
   Stack,
   TextField,
   Typography,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { emptyLoan, Loan } from '../models/loan-model';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { getMonthlyPayment, getTerms } from '../helpers/loan-helpers';
 import { NumericFormat } from 'react-number-format';
 import { ResponsiveDialog } from '../components/responsive-dialog';
+import {
+  isLoanValid,
+  LoanField,
+  validateLoan,
+} from '../helpers/validation-helpers';
+import { fieldHelperText } from '../components/field-helper-text';
 
 export const AddEditLoan = (props: AddEditLoanProps) => {
   const [newLoan, setNewLoan] = useState<Loan>(emptyLoan);
+  // Track which fields the user has interacted with, plus a save-attempt flag,
+  // so an untouched add form doesn't open all-red. A field's error shows once it
+  // is touched OR a save has been attempted.
+  const [touched, setTouched] = useState<Partial<Record<LoanField, boolean>>>(
+    {}
+  );
+  const [submitAttempted, setSubmitAttempted] = useState(false);
 
-  const isFormValid = () => {
-    return (
-      newLoan.Name.trim() !== '' &&
-      newLoan.Provider.trim() !== '' &&
-      newLoan.Principal > 0 &&
-      newLoan.CurrentAmount > 0 &&
-      newLoan.InterestRate > 0 &&
-      newLoan.StartDate &&
-      newLoan.EndDate &&
-      newLoan.StartDate < newLoan.EndDate
-    );
+  const validation = useMemo(() => validateLoan(newLoan), [newLoan]);
+  const isFormValid = () => isLoanValid(newLoan);
+
+  const showFor = (field: LoanField) => submitAttempted || touched[field];
+  const touch = (field: LoanField) =>
+    setTouched((prev) => ({ ...prev, [field]: true }));
+  const errorFor = (field: LoanField) =>
+    showFor(field) ? validation.errors[field] : undefined;
+  const warningFor = (field: LoanField) =>
+    showFor(field) ? validation.warnings[field] : undefined;
+
+  const resetTracking = () => {
+    setTouched({});
+    setSubmitAttempted(false);
   };
+
+  // Why Save is disabled, always visible while invalid. Once the user has
+  // touched fields (or attempted save) we list the specific revealed errors;
+  // before that we show a neutral prompt so the form doesn't open all-red but
+  // the user still knows what's expected.
+  const revealedErrors = (Object.keys(validation.errors) as LoanField[])
+    .filter((field) => showFor(field))
+    .map((field) => validation.errors[field]);
+  const saveDisabledReason =
+    revealedErrors.length > 0
+      ? revealedErrors.join(' ')
+      : 'Fill in all required fields to enable saving.';
 
   const onSave = () => {
     if (!isFormValid()) {
+      setSubmitAttempted(true);
       return;
     }
     props.onSave(newLoan, props.loan);
     props.onClose();
     setNewLoan(emptyLoan);
+    resetTracking();
+  };
+
+  const onCancel = () => {
+    props.onClose();
+    resetTracking();
   };
 
   useEffect(() => {
     setNewLoan(props.loan ?? emptyLoan);
-  }, [props.loan]);
+    setTouched({});
+    setSubmitAttempted(false);
+  }, [props.loan, props.open]);
 
   useEffect(() => {
     if (
@@ -88,6 +127,9 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
             label="Name"
             value={newLoan.Name}
             onChange={(e) => setNewLoan({ ...newLoan, Name: e.target.value })}
+            onBlur={() => touch('Name')}
+            error={Boolean(errorFor('Name'))}
+            helperText={fieldHelperText(errorFor('Name'), warningFor('Name'))}
             required
           />
           <TextField
@@ -96,6 +138,12 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
             onChange={(e) =>
               setNewLoan({ ...newLoan, Provider: e.target.value })
             }
+            onBlur={() => touch('Provider')}
+            error={Boolean(errorFor('Provider'))}
+            helperText={fieldHelperText(
+              errorFor('Provider'),
+              warningFor('Provider')
+            )}
             required
           />
           <NumericFormat
@@ -108,6 +156,12 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
             onValueChange={(vs) => {
               setNewLoan({ ...newLoan, Principal: Number(vs.value) });
             }}
+            onBlur={() => touch('Principal')}
+            error={Boolean(errorFor('Principal'))}
+            helperText={fieldHelperText(
+              errorFor('Principal'),
+              warningFor('Principal')
+            )}
             required
           />
           <NumericFormat
@@ -120,33 +174,61 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
             onValueChange={(vs) => {
               setNewLoan({ ...newLoan, CurrentAmount: Number(vs.value) });
             }}
+            onBlur={() => touch('CurrentAmount')}
+            error={Boolean(errorFor('CurrentAmount'))}
+            helperText={fieldHelperText(
+              errorFor('CurrentAmount'),
+              warningFor('CurrentAmount')
+            )}
             required
           />
           <DatePicker
             label="Start Date"
             value={dayjs(newLoan.StartDate)}
-            onChange={(date) =>
+            onChange={(date) => {
+              touch('StartDate');
               setNewLoan({
                 ...newLoan,
                 StartDate: date?.toDate() ?? new Date(),
-              })
-            }
+              });
+            }}
             views={['year', 'month', 'day']}
             openTo="day"
+            slotProps={{
+              textField: {
+                onBlur: () => touch('StartDate'),
+                error: Boolean(errorFor('StartDate')),
+                helperText: fieldHelperText(
+                  errorFor('StartDate'),
+                  warningFor('StartDate')
+                ),
+              },
+            }}
           />
           <Stack direction="row" spacing={1}>
             <DatePicker
               label="End Date"
               value={dayjs(newLoan.EndDate)}
-              onChange={(date) =>
+              onChange={(date) => {
+                touch('EndDate');
                 setNewLoan({
                   ...newLoan,
                   EndDate: date?.toDate() ?? new Date(),
-                })
-              }
+                });
+              }}
               views={['year', 'month', 'day']}
               openTo="year"
               sx={{ flex: 5 }}
+              slotProps={{
+                textField: {
+                  onBlur: () => touch('EndDate'),
+                  error: Boolean(errorFor('EndDate')),
+                  helperText: fieldHelperText(
+                    errorFor('EndDate'),
+                    warningFor('EndDate')
+                  ),
+                },
+              }}
             />
             <TextField
               label="Terms"
@@ -200,10 +282,20 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
                     InterestRate: Number(vs.value),
                   });
                 }}
+                onBlur={() => touch('InterestRate')}
+                error={Boolean(errorFor('InterestRate'))}
                 sx={{ flex: 2 }}
                 required
               />
             </Stack>
+            {(errorFor('InterestRate') || warningFor('InterestRate')) && (
+              <FormHelperText error={Boolean(errorFor('InterestRate'))}>
+                {fieldHelperText(
+                  errorFor('InterestRate'),
+                  warningFor('InterestRate')
+                )}
+              </FormHelperText>
+            )}
           </Stack>
 
           <Stack direction="row">
@@ -238,8 +330,15 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
           </Stack>
         </Box>
       </DialogContent>
+      <Box sx={{ px: 3 }}>
+        {!isFormValid() && (
+          <Alert severity="info" sx={{ mb: 1 }}>
+            {saveDisabledReason}
+          </Alert>
+        )}
+      </Box>
       <DialogActions>
-        <Button type="reset" color="secondary" onClick={props.onClose}>
+        <Button type="reset" color="secondary" onClick={onCancel}>
           Cancel
         </Button>
         <Button

--- a/src/loan/amortization-popout.tsx
+++ b/src/loan/amortization-popout.tsx
@@ -1,21 +1,20 @@
 import {
-  Card,
-  CardContent,
+  DialogContent,
+  DialogTitle,
   Paper,
-  Popover,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  Typography,
 } from '@mui/material';
 import { Loan } from '../models/loan-model';
 import { generateAmortizationSchedule } from '../helpers/loan-helpers';
 import { formatCurrency } from '../helpers/format-helpers';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const AmortizationPopout = (props: AmortizationPopoutProps) => {
   const schedule = useMemo(
@@ -24,67 +23,49 @@ export const AmortizationPopout = (props: AmortizationPopoutProps) => {
   );
 
   return (
-    <Popover
-      open={!!props.loan}
-      onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      sx={{ maxHeight: '90vh' }}
-    >
-      <Card>
-        <CardContent>
-          <Typography variant="h5" gutterBottom>
-            Amortization Schedule
-          </Typography>
-          <TableContainer component={Paper} sx={{ maxHeight: '75vh' }}>
-            <Table stickyHeader>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Term</TableCell>
-                  <TableCell>Date</TableCell>
-                  <TableCell>Monthly Payment</TableCell>
-                  <TableCell>Principal Portion</TableCell>
-                  <TableCell>Interest Portion</TableCell>
-                  <TableCell>Remaining Principal</TableCell>
+    <ResponsiveDialog open={!!props.loan} onClose={props.onClose} maxWidth="md">
+      <DialogTitle>Amortization Schedule</DialogTitle>
+      <DialogContent>
+        <TableContainer component={Paper}>
+          <Table stickyHeader>
+            <TableHead>
+              <TableRow>
+                <TableCell>Term</TableCell>
+                <TableCell>Date</TableCell>
+                <TableCell>Monthly Payment</TableCell>
+                <TableCell>Principal Portion</TableCell>
+                <TableCell>Interest Portion</TableCell>
+                <TableCell>Remaining Principal</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {schedule.map((entry) => (
+                <TableRow key={entry.Term}>
+                  <TableCell>{entry.Term}</TableCell>
+                  <TableCell>
+                    {dayjs(props.loan.StartDate)
+                      .add(entry.Term - 1, 'months')
+                      .format('YYYY/MM (MMM)')}
+                  </TableCell>
+                  <TableCell>
+                    {formatCurrency(
+                      entry.PrincipalPayment + entry.InterestPayment
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    {formatCurrency(entry.PrincipalPayment)}
+                  </TableCell>
+                  <TableCell>{formatCurrency(entry.InterestPayment)}</TableCell>
+                  <TableCell>
+                    {formatCurrency(entry.RemainingBalance)}
+                  </TableCell>
                 </TableRow>
-              </TableHead>
-              <TableBody>
-                {schedule.map((entry) => (
-                  <TableRow key={entry.Term}>
-                    <TableCell>{entry.Term}</TableCell>
-                    <TableCell>
-                      {dayjs(props.loan.StartDate)
-                        .add(entry.Term - 1, 'months')
-                        .format('YYYY/MM (MMM)')}
-                    </TableCell>
-                    <TableCell>
-                      {formatCurrency(
-                        entry.PrincipalPayment + entry.InterestPayment
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      {formatCurrency(entry.PrincipalPayment)}
-                    </TableCell>
-                    <TableCell>
-                      {formatCurrency(entry.InterestPayment)}
-                    </TableCell>
-                    <TableCell>
-                      {formatCurrency(entry.RemainingBalance)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </CardContent>
-      </Card>
-    </Popover>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </DialogContent>
+    </ResponsiveDialog>
   );
 };
 

--- a/src/loan/amortization-popout.tsx
+++ b/src/loan/amortization-popout.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { Loan } from '../models/loan-model';
 import { generateAmortizationSchedule } from '../helpers/loan-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
@@ -63,38 +64,18 @@ export const AmortizationPopout = (props: AmortizationPopoutProps) => {
                         .format('YYYY/MM (MMM)')}
                     </TableCell>
                     <TableCell>
-                      {(
+                      {formatCurrency(
                         entry.PrincipalPayment + entry.InterestPayment
-                      ).toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      )}
                     </TableCell>
                     <TableCell>
-                      {entry.PrincipalPayment.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      {formatCurrency(entry.PrincipalPayment)}
                     </TableCell>
                     <TableCell>
-                      {entry.InterestPayment.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      {formatCurrency(entry.InterestPayment)}
                     </TableCell>
                     <TableCell>
-                      {entry.RemainingBalance.toLocaleString(undefined, {
-                        style: 'currency',
-                        currency: 'USD',
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
+                      {formatCurrency(entry.RemainingBalance)}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -20,7 +20,7 @@ import { useState } from 'react';
 import { PitPopout } from './pit-popout';
 import { getTerms } from '../helpers/loan-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
-import { Calculate, CalendarMonth, Edit } from '@mui/icons-material';
+import { Calculate, CalendarMonth, Delete, Edit } from '@mui/icons-material';
 import { AmortizationPopout } from './amortization-popout';
 
 export const LoanTable = (props: LoanTableProps) => {
@@ -68,6 +68,14 @@ export const LoanTable = (props: LoanTableProps) => {
         title="Edit Loan"
       >
         <Edit />
+      </IconButton>
+      <IconButton
+        onClick={() => props.onLoanDelete(loan)}
+        color="error"
+        size={isMobile ? 'medium' : 'small'}
+        title="Delete Loan"
+      >
+        <Delete />
       </IconButton>
     </Box>
   );
@@ -189,4 +197,5 @@ export const LoanTable = (props: LoanTableProps) => {
 export type LoanTableProps = {
   loans: Loan[];
   onLoanEdit: (l: Loan) => void;
+  onLoanDelete: (l: Loan) => void;
 };

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -19,6 +19,7 @@ import { Loan } from '../models/loan-model';
 import { useState } from 'react';
 import { PitPopout } from './pit-popout';
 import { getTerms } from '../helpers/loan-helpers';
+import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { Calculate, CalendarMonth, Edit } from '@mui/icons-material';
 import { AmortizationPopout } from './amortization-popout';
 
@@ -29,23 +30,6 @@ export const LoanTable = (props: LoanTableProps) => {
   >();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
-
-  const formatCurrency = (amount: number) => {
-    return amount.toLocaleString(undefined, {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
-  };
-
-  const formatPercent = (rate: number) => {
-    return (rate / 100).toLocaleString(undefined, {
-      style: 'percent',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    });
-  };
 
   const LoanActions = ({
     loan,

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -13,7 +13,6 @@ import {
   Grid,
   useTheme,
   useMediaQuery,
-  IconButton,
 } from '@mui/material';
 import { Loan } from '../models/loan-model';
 import { useState } from 'react';
@@ -22,6 +21,100 @@ import { getTerms } from '../helpers/loan-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { Calculate, CalendarMonth, Delete, Edit } from '@mui/icons-material';
 import { AmortizationPopout } from './amortization-popout';
+import { EntityRowActions, RowAction } from '../components/entity-row-actions';
+
+// Callbacks a loan row/card needs. Passed down from the table so the row and
+// card components can live at module scope (no remount-on-render).
+interface LoanRowHandlers {
+  onAmortization: (loan: Loan) => void;
+  onPit: (loan: Loan) => void;
+  onEdit: (loan: Loan) => void;
+  onDelete: (loan: Loan) => void;
+}
+
+const loanActions = (loan: Loan, handlers: LoanRowHandlers): RowAction[] => [
+  {
+    icon: <CalendarMonth />,
+    title: 'View Amortization Schedule',
+    onClick: () => handlers.onAmortization(loan),
+  },
+  {
+    icon: <Calculate />,
+    title: 'Point-in-Time Calculator',
+    onClick: () => handlers.onPit(loan),
+  },
+  {
+    icon: <Edit />,
+    title: 'Edit Loan',
+    onClick: () => handlers.onEdit(loan),
+  },
+  {
+    icon: <Delete />,
+    title: 'Delete Loan',
+    onClick: () => handlers.onDelete(loan),
+    color: 'error',
+  },
+];
+
+const LoanCard = ({
+  loan,
+  handlers,
+}: {
+  loan: Loan;
+  handlers: LoanRowHandlers;
+}) => (
+  <Card sx={{ marginBottom: 2 }}>
+    <CardContent>
+      <Typography variant="h6" component="div" gutterBottom>
+        {loan.Name}
+      </Typography>
+      <Typography
+        variant="body2"
+        gutterBottom
+        sx={{
+          color: 'text.secondary',
+        }}
+      >
+        {loan.Provider}
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>Principal:</strong> {formatCurrency(loan.Principal)}
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>Current:</strong> {formatCurrency(loan.CurrentAmount)}
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>Interest:</strong> {formatPercent(loan.InterestRate)}
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>Payment:</strong> {formatCurrency(loan.MonthlyPayment || 0)}
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>Terms:</strong> {getTerms(loan)} months
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          <Typography variant="body2">
+            <strong>End Date:</strong> {loan.EndDate.toLocaleDateString()}
+          </Typography>
+        </Grid>
+      </Grid>
+      <Box sx={{ marginTop: 2 }}>
+        <EntityRowActions actions={loanActions(loan, handlers)} isMobile />
+      </Box>
+    </CardContent>
+  </Card>
+);
 
 export const LoanTable = (props: LoanTableProps) => {
   const [selectedPit, setSelectedPit] = useState<Loan | undefined>();
@@ -31,109 +124,12 @@ export const LoanTable = (props: LoanTableProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-  const LoanActions = ({
-    loan,
-    isMobile = false,
-  }: {
-    loan: Loan;
-    isMobile?: boolean;
-  }) => (
-    <Box
-      sx={{
-        display: 'flex',
-        justifyContent: isMobile ? 'space-around' : 'flex-start',
-        gap: isMobile ? 0 : 1,
-      }}
-    >
-      <IconButton
-        onClick={() => setSelectedAmortization(loan)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="View Amortization Schedule"
-      >
-        <CalendarMonth />
-      </IconButton>
-      <IconButton
-        onClick={() => setSelectedPit(loan)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="Point-in-Time Calculator"
-      >
-        <Calculate />
-      </IconButton>
-      <IconButton
-        onClick={() => props.onLoanEdit(loan)}
-        color="primary"
-        size={isMobile ? 'medium' : 'small'}
-        title="Edit Loan"
-      >
-        <Edit />
-      </IconButton>
-      <IconButton
-        onClick={() => props.onLoanDelete(loan)}
-        color="error"
-        size={isMobile ? 'medium' : 'small'}
-        title="Delete Loan"
-      >
-        <Delete />
-      </IconButton>
-    </Box>
-  );
-
-  const LoanCard = ({ loan }: { loan: Loan }) => (
-    <Card sx={{ marginBottom: 2 }}>
-      <CardContent>
-        <Typography variant="h6" component="div" gutterBottom>
-          {loan.Name}
-        </Typography>
-        <Typography
-          variant="body2"
-          gutterBottom
-          sx={{
-            color: 'text.secondary',
-          }}
-        >
-          {loan.Provider}
-        </Typography>
-        <Grid container spacing={2}>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>Principal:</strong> {formatCurrency(loan.Principal)}
-            </Typography>
-          </Grid>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>Current:</strong> {formatCurrency(loan.CurrentAmount)}
-            </Typography>
-          </Grid>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>Interest:</strong> {formatPercent(loan.InterestRate)}
-            </Typography>
-          </Grid>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>Payment:</strong>{' '}
-              {formatCurrency(loan.MonthlyPayment || 0)}
-            </Typography>
-          </Grid>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>Terms:</strong> {getTerms(loan)} months
-            </Typography>
-          </Grid>
-          <Grid size={6}>
-            <Typography variant="body2">
-              <strong>End Date:</strong> {loan.EndDate.toLocaleDateString()}
-            </Typography>
-          </Grid>
-        </Grid>
-        <Box sx={{ marginTop: 2 }}>
-          <LoanActions loan={loan} isMobile={true} />
-        </Box>
-      </CardContent>
-    </Card>
-  );
+  const handlers: LoanRowHandlers = {
+    onAmortization: setSelectedAmortization,
+    onPit: setSelectedPit,
+    onEdit: props.onLoanEdit,
+    onDelete: props.onLoanDelete,
+  };
 
   return (
     <>
@@ -153,7 +149,7 @@ export const LoanTable = (props: LoanTableProps) => {
       {isMobile ? (
         <Box>
           {props.loans.map((loan) => (
-            <LoanCard key={loan.Id} loan={loan} />
+            <LoanCard key={loan.Id} loan={loan} handlers={handlers} />
           ))}
         </Box>
       ) : (
@@ -182,7 +178,7 @@ export const LoanTable = (props: LoanTableProps) => {
                   </TableCell>
                   <TableCell>{getTerms(row)} months</TableCell>
                   <TableCell>
-                    <LoanActions loan={row} />
+                    <EntityRowActions actions={loanActions(row, handlers)} />
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/loan/pit-popout.tsx
+++ b/src/loan/pit-popout.tsx
@@ -1,8 +1,7 @@
 import {
   Box,
-  Card,
-  CardContent,
-  Popover,
+  DialogContent,
+  DialogTitle,
   Stack,
   TextField,
   Typography,
@@ -14,6 +13,7 @@ import dayjs from 'dayjs';
 import { getPitCalculation, getTerms } from '../helpers/loan-helpers';
 import { formatCurrency } from '../helpers/format-helpers';
 import { NumericFormat } from 'react-number-format';
+import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const PitPopout = (props: PitPopoutProps) => {
   const [selectedDate, setSelectedDate] = useState<Date>(props.loan.EndDate);
@@ -40,69 +40,53 @@ export const PitPopout = (props: PitPopoutProps) => {
   }, [props.loan, selectedDate]);
 
   return (
-    <Popover
-      open={!!props.loan}
-      onClose={props.onClose}
-      anchorOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'center',
-        horizontal: 'center',
-      }}
-    >
-      <Card>
-        <CardContent>
-          <Typography variant="h5" gutterBottom>
-            Point-in-Time Calculator
-          </Typography>
-          <Box
-            sx={{
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 2,
-            }}
-          >
-            <Stack direction="row">
-              <DatePicker
-                label="Start Date"
-                value={dayjs(selectedDate)}
-                onChange={(date) =>
-                  setSelectedDate(date?.toDate() ?? new Date())
-                }
-                minDate={dayjs(props.loan.StartDate).add(-1, 'month')}
-                maxDate={dayjs(props.loan.EndDate)}
-                views={['year', 'month']}
-                sx={{ flex: 4 }}
-              />
-              <NumericFormat
-                label="Terms"
-                value={getTerms(props.loan, selectedDate)}
-                thousandSeparator
-                decimalScale={0}
-                customInput={TextField}
-                onValueChange={(vs) => {
-                  handleTermsChange(Number(vs.value));
-                }}
-                sx={{ flex: 2 }}
-              />
-            </Stack>
-            <Typography>{`Paid Terms: ${pitLoan.PaidTerms}`}</Typography>
-            <Typography>{`Remaining Terms: ${pitLoan.RemainingTerms}`}</Typography>
-            <Typography>{`Paid Principal: ${formatCurrency(
-              pitLoan.PaidPrincipal
-            )}`}</Typography>
-            <Typography>{`Paid Interest: ${formatCurrency(
-              pitLoan.PaidInterest
-            )}`}</Typography>
-            <Typography>{`Remaining Principal: ${formatCurrency(
-              pitLoan.RemainingPrincipal
-            )}`}</Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    </Popover>
+    <ResponsiveDialog open={!!props.loan} onClose={props.onClose}>
+      <DialogTitle>Point-in-Time Calculator</DialogTitle>
+      <DialogContent>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 2,
+            mt: 1,
+          }}
+        >
+          <Stack direction="row">
+            <DatePicker
+              label="Start Date"
+              value={dayjs(selectedDate)}
+              onChange={(date) => setSelectedDate(date?.toDate() ?? new Date())}
+              minDate={dayjs(props.loan.StartDate).add(-1, 'month')}
+              maxDate={dayjs(props.loan.EndDate)}
+              views={['year', 'month']}
+              sx={{ flex: 4 }}
+            />
+            <NumericFormat
+              label="Terms"
+              value={getTerms(props.loan, selectedDate)}
+              thousandSeparator
+              decimalScale={0}
+              customInput={TextField}
+              onValueChange={(vs) => {
+                handleTermsChange(Number(vs.value));
+              }}
+              sx={{ flex: 2 }}
+            />
+          </Stack>
+          <Typography>{`Paid Terms: ${pitLoan.PaidTerms}`}</Typography>
+          <Typography>{`Remaining Terms: ${pitLoan.RemainingTerms}`}</Typography>
+          <Typography>{`Paid Principal: ${formatCurrency(
+            pitLoan.PaidPrincipal
+          )}`}</Typography>
+          <Typography>{`Paid Interest: ${formatCurrency(
+            pitLoan.PaidInterest
+          )}`}</Typography>
+          <Typography>{`Remaining Principal: ${formatCurrency(
+            pitLoan.RemainingPrincipal
+          )}`}</Typography>
+        </Box>
+      </DialogContent>
+    </ResponsiveDialog>
   );
 };
 

--- a/src/loan/pit-popout.tsx
+++ b/src/loan/pit-popout.tsx
@@ -12,6 +12,7 @@ import { defaultPit, Loan, PitLoan } from '../models/loan-model';
 import { DatePicker } from '@mui/x-date-pickers';
 import dayjs from 'dayjs';
 import { getPitCalculation, getTerms } from '../helpers/loan-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
 import { NumericFormat } from 'react-number-format';
 
 export const PitPopout = (props: PitPopoutProps) => {
@@ -89,32 +90,14 @@ export const PitPopout = (props: PitPopoutProps) => {
             </Stack>
             <Typography>{`Paid Terms: ${pitLoan.PaidTerms}`}</Typography>
             <Typography>{`Remaining Terms: ${pitLoan.RemainingTerms}`}</Typography>
-            <Typography>{`Paid Principal: ${pitLoan.PaidPrincipal.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Paid Principal: ${formatCurrency(
+              pitLoan.PaidPrincipal
             )}`}</Typography>
-            <Typography>{`Paid Interest: ${pitLoan.PaidInterest.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Paid Interest: ${formatCurrency(
+              pitLoan.PaidInterest
             )}`}</Typography>
-            <Typography>{`Remaining Principal: ${pitLoan.RemainingPrincipal.toLocaleString(
-              undefined,
-              {
-                style: 'currency',
-                currency: 'USD',
-                minimumFractionDigits: 2,
-                maximumFractionDigits: 2,
-              }
+            <Typography>{`Remaining Principal: ${formatCurrency(
+              pitLoan.RemainingPrincipal
             )}`}</Typography>
           </Box>
         </CardContent>

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -17,9 +17,13 @@ export interface FinanceDataContextValue {
   addLoan: (loan: Loan) => void;
   updateLoan: (loan: Loan) => void;
   deleteLoan: (id: string) => void;
+  // Undo a loan delete by restoring it at its original index (roadmap 0.7).
+  insertLoanAt: (loan: Loan, index: number) => void;
   addInvestment: (investment: Investment) => void;
   updateInvestment: (investment: Investment) => void;
   deleteInvestment: (id: string) => void;
+  // Undo an investment delete by restoring it at its original index.
+  insertInvestmentAt: (investment: Investment, index: number) => void;
   importMerge: (loans: Loan[], investments: Investment[]) => void;
   enableTestData: (loans: Loan[], investments: Investment[]) => void;
   disableTestData: () => void;
@@ -43,6 +47,8 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         }),
       updateLoan: (loan: Loan) => dispatch({ type: 'UpdateLoan', loan }),
       deleteLoan: (id: string) => dispatch({ type: 'DeleteLoan', id }),
+      insertLoanAt: (loan: Loan, index: number) =>
+        dispatch({ type: 'InsertLoanAt', loan, index }),
       addInvestment: (investment: Investment) =>
         dispatch({
           type: 'AddInvestment',
@@ -52,6 +58,8 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'UpdateInvestment', investment }),
       deleteInvestment: (id: string) =>
         dispatch({ type: 'DeleteInvestment', id }),
+      insertInvestmentAt: (investment: Investment, index: number) =>
+        dispatch({ type: 'InsertInvestmentAt', investment, index }),
       importMerge: (loans: Loan[], investments: Investment[]) =>
         dispatch({ type: 'ImportMerge', loans, investments }),
       enableTestData: (loans: Loan[], investments: Investment[]) =>

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -36,10 +36,12 @@ export const FinanceDataContext = createContext<
 export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(financeReducer, initialFinanceState);
 
-  const value = useMemo<FinanceDataContextValue>(
+  // The action creators close over only the stable `dispatch` (and their own
+  // arguments), so build them once. Stable identities mean a consumer that reads
+  // a single method off the context isn't re-rendered by every unrelated state
+  // change — only the `value` object below re-memoizes when `state` changes.
+  const actions = useMemo(
     () => ({
-      state,
-      dispatch,
       addLoan: (loan: Loan) =>
         dispatch({
           type: 'AddLoan',
@@ -66,7 +68,12 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'LoadSampleData', loans, investments }),
       clearSampleData: () => dispatch({ type: 'ClearSampleData' }),
     }),
-    [state]
+    []
+  );
+
+  const value = useMemo<FinanceDataContextValue>(
+    () => ({ state, dispatch, ...actions }),
+    [state, actions]
   );
 
   return (

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -25,8 +25,8 @@ export interface FinanceDataContextValue {
   // Undo an investment delete by restoring it at its original index.
   insertInvestmentAt: (investment: Investment, index: number) => void;
   importMerge: (loans: Loan[], investments: Investment[]) => void;
-  enableTestData: (loans: Loan[], investments: Investment[]) => void;
-  disableTestData: () => void;
+  loadSampleData: (loans: Loan[], investments: Investment[]) => void;
+  clearSampleData: () => void;
 }
 
 export const FinanceDataContext = createContext<
@@ -62,9 +62,9 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'InsertInvestmentAt', investment, index }),
       importMerge: (loans: Loan[], investments: Investment[]) =>
         dispatch({ type: 'ImportMerge', loans, investments }),
-      enableTestData: (loans: Loan[], investments: Investment[]) =>
-        dispatch({ type: 'EnableTestData', loans, investments }),
-      disableTestData: () => dispatch({ type: 'DisableTestData' }),
+      loadSampleData: (loans: Loan[], investments: Investment[]) =>
+        dispatch({ type: 'LoadSampleData', loans, investments }),
+      clearSampleData: () => dispatch({ type: 'ClearSampleData' }),
     }),
     [state]
   );

--- a/src/state/finance-reducer.test.ts
+++ b/src/state/finance-reducer.test.ts
@@ -341,51 +341,51 @@ describe('financeReducer', () => {
     });
   });
 
-  describe('Test data toggle (issue #47)', () => {
-    it('EnableTestData stashes user data and shows fake data', () => {
+  describe('Sample data load/clear (roadmap 0.9)', () => {
+    it('LoadSampleData stashes user data and shows sample data', () => {
       const userLoans = [makeLoan('user-1')];
       const userInvestments = [makeInvestment('user-inv-1')];
       const start = stateWith({
         loans: userLoans,
         investments: userInvestments,
       });
-      const fakeLoans = [makeLoan('fake-1')];
-      const fakeInvestments = [makeInvestment('fake-inv-1')];
+      const sampleLoans = [makeLoan('sample-1')];
+      const sampleInvestments = [makeInvestment('sample-inv-1')];
 
       const next = financeReducer(start, {
-        type: 'EnableTestData',
-        loans: fakeLoans,
-        investments: fakeInvestments,
+        type: 'LoadSampleData',
+        loans: sampleLoans,
+        investments: sampleInvestments,
       });
 
-      expect(next.testDataEnabled).toBe(true);
-      expect(next.loans).toEqual(fakeLoans);
-      expect(next.investments).toEqual(fakeInvestments);
+      expect(next.sampleDataLoaded).toBe(true);
+      expect(next.loans).toEqual(sampleLoans);
+      expect(next.investments).toEqual(sampleInvestments);
       expect(next.stashedLoans).toEqual(userLoans);
       expect(next.stashedInvestments).toEqual(userInvestments);
     });
 
-    it('DisableTestData restores the stashed user data and clears fake data', () => {
+    it('ClearSampleData restores the stashed user data and clears sample data', () => {
       const userLoans = [makeLoan('user-1')];
       const userInvestments = [makeInvestment('user-inv-1')];
-      const enabled = stateWith({
-        testDataEnabled: true,
-        loans: [makeLoan('fake-1')],
-        investments: [makeInvestment('fake-inv-1')],
+      const loaded = stateWith({
+        sampleDataLoaded: true,
+        loans: [makeLoan('sample-1')],
+        investments: [makeInvestment('sample-inv-1')],
         stashedLoans: userLoans,
         stashedInvestments: userInvestments,
       });
 
-      const next = financeReducer(enabled, { type: 'DisableTestData' });
+      const next = financeReducer(loaded, { type: 'ClearSampleData' });
 
-      expect(next.testDataEnabled).toBe(false);
+      expect(next.sampleDataLoaded).toBe(false);
       expect(next.loans).toEqual(userLoans);
       expect(next.investments).toEqual(userInvestments);
       expect(next.stashedLoans).toBeNull();
       expect(next.stashedInvestments).toBeNull();
     });
 
-    it('round-trips: enable then disable restores the exact original data', () => {
+    it('round-trips: load then clear restores the exact original data', () => {
       const userLoans = [makeLoan('a'), makeLoan('b')];
       const userInvestments = [makeInvestment('x')];
       const start = stateWith({
@@ -393,75 +393,75 @@ describe('financeReducer', () => {
         investments: userInvestments,
       });
 
-      const enabled = financeReducer(start, {
-        type: 'EnableTestData',
-        loans: [makeLoan('fake')],
-        investments: [makeInvestment('fake-inv')],
+      const loaded = financeReducer(start, {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample')],
+        investments: [makeInvestment('sample-inv')],
       });
-      const disabled = financeReducer(enabled, { type: 'DisableTestData' });
+      const cleared = financeReducer(loaded, { type: 'ClearSampleData' });
 
-      expect(disabled.testDataEnabled).toBe(false);
-      expect(disabled.loans).toEqual(userLoans);
-      expect(disabled.investments).toEqual(userInvestments);
+      expect(cleared.sampleDataLoaded).toBe(false);
+      expect(cleared.loans).toEqual(userLoans);
+      expect(cleared.investments).toEqual(userInvestments);
     });
 
-    it('test data never destroys user data even when starting empty', () => {
+    it('sample data never destroys user data even when starting empty', () => {
       const start = initialFinanceState;
-      const enabled = financeReducer(start, {
-        type: 'EnableTestData',
-        loans: [makeLoan('fake')],
+      const loaded = financeReducer(start, {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample')],
         investments: [],
       });
-      const disabled = financeReducer(enabled, { type: 'DisableTestData' });
-      expect(disabled.loans).toEqual([]);
-      expect(disabled.investments).toEqual([]);
+      const cleared = financeReducer(loaded, { type: 'ClearSampleData' });
+      expect(cleared.loans).toEqual([]);
+      expect(cleared.investments).toEqual([]);
     });
 
-    it('edits made while test data is enabled are discarded on disable (stash wins)', () => {
+    it('edits made while sample data is loaded are discarded on clear (stash wins)', () => {
       const userLoans = [makeLoan('real')];
       const start = stateWith({ loans: userLoans });
 
-      // Enable test data, then the user fiddles with the fake data.
-      const enabled = financeReducer(start, {
-        type: 'EnableTestData',
-        loans: [makeLoan('fake')],
+      // Load sample data, then the user fiddles with the samples.
+      const loaded = financeReducer(start, {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample')],
         investments: [],
       });
-      const edited = financeReducer(enabled, {
+      const edited = financeReducer(loaded, {
         type: 'AddLoan',
-        loan: makeLoan('added-while-fake'),
+        loan: makeLoan('added-while-sample'),
       });
       expect(edited.loans.map((l) => l.Id)).toEqual([
-        'fake',
-        'added-while-fake',
+        'sample',
+        'added-while-sample',
       ]);
 
-      // Disabling discards those edits and restores the real data.
-      const disabled = financeReducer(edited, { type: 'DisableTestData' });
-      expect(disabled.loans).toEqual(userLoans);
-      expect(disabled.stashedLoans).toBeNull();
+      // Clearing discards those edits and restores the real data.
+      const cleared = financeReducer(edited, { type: 'ClearSampleData' });
+      expect(cleared.loans).toEqual(userLoans);
+      expect(cleared.stashedLoans).toBeNull();
     });
 
-    it('EnableTestData is idempotent and does not overwrite an existing stash', () => {
+    it('LoadSampleData is idempotent and does not overwrite an existing stash', () => {
       const userLoans = [makeLoan('real')];
-      const enabled = financeReducer(stateWith({ loans: userLoans }), {
-        type: 'EnableTestData',
-        loans: [makeLoan('fake-1')],
+      const loaded = financeReducer(stateWith({ loans: userLoans }), {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample-1')],
         investments: [],
       });
-      const enabledAgain = financeReducer(enabled, {
-        type: 'EnableTestData',
-        loans: [makeLoan('fake-2')],
+      const loadedAgain = financeReducer(loaded, {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample-2')],
         investments: [],
       });
-      // Stash must still hold the original user data, not fake-1.
-      expect(enabledAgain.stashedLoans).toEqual(userLoans);
-      expect(enabledAgain).toBe(enabled);
+      // Stash must still hold the original user data, not sample-1.
+      expect(loadedAgain.stashedLoans).toEqual(userLoans);
+      expect(loadedAgain).toBe(loaded);
     });
 
-    it('DisableTestData is a no-op when test data is already off', () => {
+    it('ClearSampleData is a no-op when sample data is not loaded', () => {
       const start = stateWith({ loans: [makeLoan('a')] });
-      const next = financeReducer(start, { type: 'DisableTestData' });
+      const next = financeReducer(start, { type: 'ClearSampleData' });
       expect(next).toBe(start);
     });
   });

--- a/src/state/finance-reducer.test.ts
+++ b/src/state/finance-reducer.test.ts
@@ -115,6 +115,82 @@ describe('financeReducer', () => {
     });
   });
 
+  describe('InsertLoanAt (delete soft-undo, roadmap 0.7)', () => {
+    it('delete then undo restores the identical loan at its original index', () => {
+      const a = makeLoan('a');
+      const b = makeLoan('b', { Name: 'Middle', Principal: 42 });
+      const c = makeLoan('c');
+      const start = stateWith({ loans: [a, b, c] });
+
+      // Delete the middle loan, remembering its index (1).
+      const index = start.loans.findIndex((l) => l.Id === 'b');
+      const deleted = financeReducer(start, { type: 'DeleteLoan', id: 'b' });
+      expect(deleted.loans.map((l) => l.Id)).toEqual(['a', 'c']);
+
+      // Undo restores it at the same position, byte-for-byte identical.
+      const undone = financeReducer(deleted, {
+        type: 'InsertLoanAt',
+        loan: b,
+        index,
+      });
+      expect(undone.loans.map((l) => l.Id)).toEqual(['a', 'b', 'c']);
+      expect(undone.loans[1]).toEqual(b);
+    });
+
+    it('inserts at the front when index is 0', () => {
+      const start = stateWith({ loans: [makeLoan('b'), makeLoan('c')] });
+      const next = financeReducer(start, {
+        type: 'InsertLoanAt',
+        loan: makeLoan('a'),
+        index: 0,
+      });
+      expect(next.loans.map((l) => l.Id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('clamps an out-of-range index by appending (list shrank meanwhile)', () => {
+      // Original index was 5, but the list only has one item now.
+      const start = stateWith({ loans: [makeLoan('a')] });
+      const next = financeReducer(start, {
+        type: 'InsertLoanAt',
+        loan: makeLoan('z'),
+        index: 5,
+      });
+      expect(next.loans.map((l) => l.Id)).toEqual(['a', 'z']);
+    });
+
+    it('restores into an emptied list', () => {
+      const restored = makeLoan('only');
+      const next = financeReducer(initialFinanceState, {
+        type: 'InsertLoanAt',
+        loan: restored,
+        index: 0,
+      });
+      expect(next.loans).toEqual([restored]);
+    });
+
+    it('is a no-op when the same Id is already present (double undo)', () => {
+      const start = stateWith({ loans: [makeLoan('a'), makeLoan('b')] });
+      const next = financeReducer(start, {
+        type: 'InsertLoanAt',
+        loan: makeLoan('a', { Name: 'Dup' }),
+        index: 0,
+      });
+      expect(next).toBe(start);
+    });
+
+    it('does not mutate the input state', () => {
+      const start = stateWith({ loans: [makeLoan('a')] });
+      const snapshot = start.loans;
+      financeReducer(start, {
+        type: 'InsertLoanAt',
+        loan: makeLoan('b'),
+        index: 0,
+      });
+      expect(start.loans).toBe(snapshot);
+      expect(start.loans).toHaveLength(1);
+    });
+  });
+
   describe('AddInvestment', () => {
     it('appends an investment, preserving order', () => {
       const start = stateWith({
@@ -161,6 +237,50 @@ describe('financeReducer', () => {
         id: 'b',
       });
       expect(next.investments.map((i) => i.Id)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('InsertInvestmentAt (delete soft-undo, roadmap 0.7)', () => {
+    it('delete then undo restores the identical investment at its original index', () => {
+      const x = makeInvestment('x');
+      const y = makeInvestment('y', { Name: 'Middle', StartingBalance: 7 });
+      const z = makeInvestment('z');
+      const start = stateWith({ investments: [x, y, z] });
+
+      const index = start.investments.findIndex((i) => i.Id === 'y');
+      const deleted = financeReducer(start, {
+        type: 'DeleteInvestment',
+        id: 'y',
+      });
+      expect(deleted.investments.map((i) => i.Id)).toEqual(['x', 'z']);
+
+      const undone = financeReducer(deleted, {
+        type: 'InsertInvestmentAt',
+        investment: y,
+        index,
+      });
+      expect(undone.investments.map((i) => i.Id)).toEqual(['x', 'y', 'z']);
+      expect(undone.investments[1]).toEqual(y);
+    });
+
+    it('clamps an out-of-range index by appending', () => {
+      const start = stateWith({ investments: [makeInvestment('x')] });
+      const next = financeReducer(start, {
+        type: 'InsertInvestmentAt',
+        investment: makeInvestment('z'),
+        index: 9,
+      });
+      expect(next.investments.map((i) => i.Id)).toEqual(['x', 'z']);
+    });
+
+    it('is a no-op when the same Id is already present', () => {
+      const start = stateWith({ investments: [makeInvestment('x')] });
+      const next = financeReducer(start, {
+        type: 'InsertInvestmentAt',
+        investment: makeInvestment('x', { Name: 'Dup' }),
+        index: 0,
+      });
+      expect(next).toBe(start);
     });
   });
 

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -32,12 +32,26 @@ export type FinanceAction =
   | { type: 'AddLoan'; loan: Loan }
   | { type: 'UpdateLoan'; loan: Loan }
   | { type: 'DeleteLoan'; id: string }
+  // Soft-undo for delete (roadmap 0.7): restore an entity at the position it
+  // held before deletion. The delete call site remembers the original index and
+  // replays it here on UNDO, so the list looks untouched. The index is clamped,
+  // so an out-of-range index (e.g. the list shrank meanwhile) appends sanely
+  // instead of throwing or leaving a hole.
+  | { type: 'InsertLoanAt'; loan: Loan; index: number }
   | { type: 'AddInvestment'; investment: Investment }
   | { type: 'UpdateInvestment'; investment: Investment }
   | { type: 'DeleteInvestment'; id: string }
+  | { type: 'InsertInvestmentAt'; investment: Investment; index: number }
   | { type: 'ImportMerge'; loans: Loan[]; investments: Investment[] }
   | { type: 'EnableTestData'; loans: Loan[]; investments: Investment[] }
   | { type: 'DisableTestData' };
+
+// Insert `item` into `list` at `index`, clamping the index into [0, length].
+// Pure helper: returns a new array and never mutates the input.
+const insertAt = <T>(list: T[], item: T, index: number): T[] => {
+  const clamped = Math.max(0, Math.min(index, list.length));
+  return [...list.slice(0, clamped), item, ...list.slice(clamped)];
+};
 
 export const financeReducer = (
   state: FinanceState,
@@ -63,6 +77,17 @@ export const financeReducer = (
         loans: state.loans.filter((loan) => loan.Id !== action.id),
       };
 
+    case 'InsertLoanAt':
+      // Restore a deleted loan at its original index (undo). If the same Id is
+      // somehow already present (e.g. re-added meanwhile), don't duplicate it.
+      if (state.loans.some((loan) => loan.Id === action.loan.Id)) {
+        return state;
+      }
+      return {
+        ...state,
+        loans: insertAt(state.loans, action.loan, action.index),
+      };
+
     case 'AddInvestment':
       return {
         ...state,
@@ -86,6 +111,20 @@ export const financeReducer = (
         ...state,
         investments: state.investments.filter(
           (investment) => investment.Id !== action.id
+        ),
+      };
+
+    case 'InsertInvestmentAt':
+      // Restore a deleted investment at its original index (undo).
+      if (state.investments.some((inv) => inv.Id === action.investment.Id)) {
+        return state;
+      }
+      return {
+        ...state,
+        investments: insertAt(
+          state.investments,
+          action.investment,
+          action.index
         ),
       };
 

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -4,15 +4,15 @@ import { mergeData } from '../helpers/data-helpers';
 
 // State shape for the finance data context (D2).
 //
-// `loans`/`investments` are the data currently shown to the user. When the
-// "Test Data" dev toggle is on, these hold the fake data and the user's real
-// data is parked in `stashedLoans`/`stashedInvestments` until the toggle is
-// turned off again (issue #47). `testDataEnabled` mirrors the toggle.
+// `loans`/`investments` are the data currently shown to the user. While sample
+// data is loaded (roadmap 0.9), these hold the sample entities and the user's
+// real data is parked in `stashedLoans`/`stashedInvestments` until sample data
+// is cleared again. `sampleDataLoaded` mirrors that state.
 export interface FinanceState {
   loans: Loan[];
   investments: Investment[];
-  testDataEnabled: boolean;
-  // User data stashed while test data is enabled; null when test data is off.
+  sampleDataLoaded: boolean;
+  // User data stashed while sample data is loaded; null otherwise.
   stashedLoans: Loan[] | null;
   stashedInvestments: Investment[] | null;
 }
@@ -20,7 +20,7 @@ export interface FinanceState {
 export const initialFinanceState: FinanceState = {
   loans: [],
   investments: [],
-  testDataEnabled: false,
+  sampleDataLoaded: false,
   stashedLoans: null,
   stashedInvestments: null,
 };
@@ -43,8 +43,8 @@ export type FinanceAction =
   | { type: 'DeleteInvestment'; id: string }
   | { type: 'InsertInvestmentAt'; investment: Investment; index: number }
   | { type: 'ImportMerge'; loans: Loan[]; investments: Investment[] }
-  | { type: 'EnableTestData'; loans: Loan[]; investments: Investment[] }
-  | { type: 'DisableTestData' };
+  | { type: 'LoadSampleData'; loans: Loan[]; investments: Investment[] }
+  | { type: 'ClearSampleData' };
 
 // Insert `item` into `list` at `index`, clamping the index into [0, length].
 // Pure helper: returns a new array and never mutates the input.
@@ -142,16 +142,16 @@ export const financeReducer = (
       };
     }
 
-    case 'EnableTestData': {
-      // Toggling on: stash the user's real data and show fake data instead.
-      // Real data is never destroyed (issue #47). Idempotent — re-enabling
-      // while already on does not overwrite an existing stash.
-      if (state.testDataEnabled) {
+    case 'LoadSampleData': {
+      // Loading sample data: stash the user's real data and show the samples
+      // instead. Real data is never destroyed. Idempotent — loading again while
+      // already showing samples does not overwrite an existing stash.
+      if (state.sampleDataLoaded) {
         return state;
       }
       return {
         ...state,
-        testDataEnabled: true,
+        sampleDataLoaded: true,
         stashedLoans: state.loans,
         stashedInvestments: state.investments,
         loans: action.loans,
@@ -159,15 +159,15 @@ export const financeReducer = (
       };
     }
 
-    case 'DisableTestData': {
-      // Toggling off: discard whatever is currently shown (the fake data, plus
-      // any edits made while test data was enabled) and restore the stash.
-      if (!state.testDataEnabled) {
+    case 'ClearSampleData': {
+      // Clearing sample data: discard whatever is currently shown (the samples,
+      // plus any edits made while they were loaded) and restore the stash.
+      if (!state.sampleDataLoaded) {
         return state;
       }
       return {
         ...state,
-        testDataEnabled: false,
+        sampleDataLoaded: false,
         loans: state.stashedLoans ?? [],
         investments: state.stashedInvestments ?? [],
         stashedLoans: null,

--- a/src/state/sample-data.ts
+++ b/src/state/sample-data.ts
@@ -1,0 +1,66 @@
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+// Sample data for the onboarding empty state (roadmap 0.9).
+//
+// These are realistic, pedagogically useful examples — a mortgage, a car loan,
+// and a couple of investments — so a first-time visitor can see what PathWise
+// does without typing anything. Each Name is prefixed with "Sample:" so the
+// rows are unmistakably demo data, and the in-app banner offers a one-click
+// "Clear sample data". The reducer stashes any real user data while these are
+// loaded, so nothing the user typed is ever lost (see finance-reducer.ts).
+//
+// This is a plain UI seed, not state: the provider copies it into the reducer
+// via LoadSampleData. Stable Ids keep load/clear idempotent.
+
+export const sampleLoans: Loan[] = [
+  {
+    Id: '00000000-0000-0000-0000-000000000001',
+    Name: 'Sample: Mortgage',
+    Provider: 'Sample Bank',
+    InterestRate: 6.25,
+    Principal: 350000,
+    CurrentAmount: 332500,
+    MonthlyPayment: 2155.18,
+    StartDate: new Date('2023-05-01'),
+    EndDate: new Date('2053-05-01'),
+  },
+  {
+    Id: '00000000-0000-0000-0000-000000000002',
+    Name: 'Sample: Car Loan',
+    Provider: 'Sample Credit Union',
+    InterestRate: 4.9,
+    Principal: 28000,
+    CurrentAmount: 19500,
+    MonthlyPayment: 527.63,
+    StartDate: new Date('2024-02-15'),
+    EndDate: new Date('2029-02-15'),
+  },
+];
+
+export const sampleInvestments: Investment[] = [
+  {
+    Id: '00000000-0000-0000-0000-000000000003',
+    Name: 'Sample: Index Fund (brokerage)',
+    Provider: 'Sample Brokerage',
+    StartingBalance: 15000,
+    CurrentValue: 22000,
+    AverageReturnRate: 7,
+    CompoundingPeriod: CompoundingFrequency.Monthly,
+    StartDate: new Date('2021-01-01'),
+    RecurringContribution: 500,
+    ContributionFrequency: CompoundingFrequency.Monthly,
+  },
+  {
+    Id: '00000000-0000-0000-0000-000000000004',
+    Name: 'Sample: 401(k)',
+    Provider: 'Sample Retirement',
+    StartingBalance: 40000,
+    CurrentValue: 58000,
+    AverageReturnRate: 6.5,
+    CompoundingPeriod: CompoundingFrequency.Monthly,
+    StartDate: new Date('2019-06-01'),
+    RecurringContribution: 800,
+    ContributionFrequency: CompoundingFrequency.Monthly,
+  },
+];

--- a/src/theme/color-mode-toggle.tsx
+++ b/src/theme/color-mode-toggle.tsx
@@ -25,7 +25,9 @@ export const ColorModeToggle = () => {
         onClick={handleToggle}
         color="inherit"
         aria-label="Toggle light/dark mode"
-        sx={{ margin: '5px' }}
+        // Pushed to the trailing edge of the command bar; when the Toolbar wraps
+        // on narrow viewports this keeps the toggle at the end of its row.
+        sx={{ marginLeft: 'auto' }}
       >
         {isDark ? <LightMode /> : <DarkMode />}
       </IconButton>

--- a/src/theme/color-mode-toggle.tsx
+++ b/src/theme/color-mode-toggle.tsx
@@ -1,0 +1,34 @@
+import { IconButton, Tooltip } from '@mui/material';
+import { useColorScheme } from '@mui/material/styles';
+import { DarkMode, LightMode } from '@mui/icons-material';
+
+// Light/dark toggle for the command bar. Backed by MUI 9's color-scheme API:
+// `useColorScheme()` reads/writes `mode`, which MUI persists to localStorage
+// (key `mui-mode`) and applies via the `data-mui-color-scheme` attribute, so the
+// preference survives reloads with no flash.
+export const ColorModeToggle = () => {
+  const { mode, systemMode, setMode } = useColorScheme();
+
+  // `mode` can be 'system' on first visit; resolve to the effective scheme so
+  // the button shows the icon for the mode the user would switch TO.
+  const resolved = mode === 'system' ? systemMode : mode;
+  const isDark = resolved === 'dark';
+
+  // Avoid a hydration/SSR mismatch: until mode is known, render a stable button.
+  const handleToggle = () => {
+    setMode(isDark ? 'light' : 'dark');
+  };
+
+  return (
+    <Tooltip title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}>
+      <IconButton
+        onClick={handleToggle}
+        color="inherit"
+        aria-label="Toggle light/dark mode"
+        sx={{ margin: '5px' }}
+      >
+        {isDark ? <LightMode /> : <DarkMode />}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,2 @@
+export { theme, brandGradient, brandGradientReversed } from './theme';
+export { ColorModeToggle } from './color-mode-toggle';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,2 +1,8 @@
-export { theme, brandGradient, brandGradientReversed } from './theme';
+export {
+  theme,
+  brandGradient,
+  brandGradientReversed,
+  SECTION_GAP,
+  PAPER_PADDING,
+} from './theme';
 export { ColorModeToggle } from './color-mode-toggle';

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -22,6 +22,14 @@ const brandBlueMid = '#2a5298';
 export const brandGradient = `linear-gradient(135deg, ${brandBlueDark} 0%, ${brandBlueMid} 100%)`;
 export const brandGradientReversed = `linear-gradient(135deg, ${brandBlueMid} 0%, ${brandBlueDark} 100%)`;
 
+// Spacing (roadmap 0.10): the page used a repeated `marginBottom: '20px'` on the
+// section Papers and the sample-data alert. Express it once as theme spacing
+// units (2.5 * 8px = 20px) so the gutter between the AppBar pill, the section
+// Papers, and the page is consistent and tweakable in one place.
+export const SECTION_GAP = 2.5;
+// Padding inside the section Papers (was an ad-hoc `padding: '5px'`).
+export const PAPER_PADDING = 1;
+
 export const theme = createTheme({
   // Enable CSS theme variables (theme.vars) so color-scheme switching is a CSS
   // class/attribute swap, not a React re-render — no flash on toggle/reload.
@@ -67,11 +75,24 @@ export const theme = createTheme({
         position: 'static',
       },
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           borderRadius: 30,
-          marginTop: 15,
-          marginBottom: 15,
+          marginTop: theme.spacing(SECTION_GAP),
+          marginBottom: theme.spacing(SECTION_GAP),
           overflow: 'hidden',
+        }),
+      },
+    },
+    // Command-bar Toolbar: lay the action buttons out with a consistent gap and
+    // let them wrap cleanly on narrow viewports (roadmap 0.10) instead of
+    // overflowing or squashing at ~360px. The dark-mode toggle is pushed to the
+    // right within the same flow so the bar stays single-row when it fits.
+    MuiToolbar: {
+      styleOverrides: {
+        root: {
+          flexWrap: 'wrap',
+          gap: 8,
+          rowGap: 4,
         },
       },
     },
@@ -84,9 +105,9 @@ export const theme = createTheme({
         },
       },
     },
-    // Command-bar buttons all carried `margin: '5px'`. Keep that as the default
-    // so Body/DataManager stop repeating it; `disableElevation` flattens the
-    // contained save buttons to match the previous flat look.
+    // Command-bar buttons previously each carried an ad-hoc `margin: '5px'`;
+    // their spacing now comes from the Toolbar `gap` above (roadmap 0.10).
+    // `disableElevation` flattens the contained buttons to match the flat look.
     MuiButton: {
       defaultProps: {
         disableElevation: true,

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -12,15 +12,20 @@ import { createTheme } from '@mui/material/styles';
 // data-attribute selector lets `useColorScheme()` / InitColorSchemeScript flip
 // `data-mui-color-scheme` on <html> without a flash or re-render of the tree.
 
-// The PathWise brand blues — taken from the original header/footer gradients
-// (#1e3c72 -> #2a5298) and the MUI default primary the AppBar already used.
-const brandBlueDark = '#1e3c72';
-const brandBlueMid = '#2a5298';
+// The PathWise brand greens (roadmap 0.7 rebrand): a fintech "money green"
+// identity — deep forest/emerald foundations for brand surfaces (AppBar pill,
+// header/footer gradient) and a vivid emerald primary for buttons/links/icons.
+// `brandGreenDeep` -> `brandGreenRich` is the deep-to-brighter brand gradient;
+// the emerald primaries live in each colorScheme below.
+const brandGreenDeep = '#0b3d2e';
+const brandGreenRich = '#14532d';
 
 // Reusable header/footer gradient. Exported so Header/Footer can pull the brand
-// gradient from the theme rather than hard-coding it in CSS.
-export const brandGradient = `linear-gradient(135deg, ${brandBlueDark} 0%, ${brandBlueMid} 100%)`;
-export const brandGradientReversed = `linear-gradient(135deg, ${brandBlueMid} 0%, ${brandBlueDark} 100%)`;
+// gradient from the theme rather than hard-coding it in CSS. The same deep-green
+// gradient also backs the AppBar pill (see MuiAppBar styleOverrides) so the
+// command bar, header, and footer share one brand surface in both modes.
+export const brandGradient = `linear-gradient(135deg, ${brandGreenDeep} 0%, ${brandGreenRich} 100%)`;
+export const brandGradientReversed = `linear-gradient(135deg, ${brandGreenRich} 0%, ${brandGreenDeep} 100%)`;
 
 // Spacing (roadmap 0.10): the page used a repeated `marginBottom: '20px'` on the
 // section Papers and the sample-data alert. Express it once as theme spacing
@@ -39,23 +44,29 @@ export const theme = createTheme({
   colorSchemes: {
     light: {
       palette: {
-        primary: { main: brandBlueMid, dark: brandBlueDark },
-        secondary: { main: '#9c27b0' },
+        // Emerald "money green" primary — passes contrast as a button/link/icon
+        // color on white surfaces; `dark` is the deep brand green for hovers.
+        primary: { main: '#00875a', dark: brandGreenDeep },
+        // Complementary teal-leaning green accent (no blue reintroduced).
+        secondary: { main: '#0f766e' },
         background: {
-          // The body previously sat on a pale blue-grey gradient; flatten it to
-          // a solid surface that reads the same but themes cleanly.
-          default: '#eef1f6',
+          // Clean, faintly green-tinted light surface (was a pale blue-grey).
+          default: '#eef5f1',
           paper: '#ffffff',
         },
       },
     },
     dark: {
       palette: {
-        primary: { main: '#5b8def', dark: brandBlueMid },
-        secondary: { main: '#ce93d8' },
+        // Bright spring-green primary so dark mode reads "dark but bright green";
+        // `dark` keeps the deep brand green for pressed/hover states.
+        primary: { main: '#00e676', dark: brandGreenRich },
+        secondary: { main: '#2dd4bf' },
         background: {
-          default: '#121417',
-          paper: '#1c2128',
+          // Very dark green-tinted background (not pure grey/black) + a slightly
+          // lifted green-cast paper, so the whole app carries a money-green cast.
+          default: '#0c1512',
+          paper: '#13201a',
         },
       },
     },
@@ -80,6 +91,13 @@ export const theme = createTheme({
           marginTop: theme.spacing(SECTION_GAP),
           marginBottom: theme.spacing(SECTION_GAP),
           overflow: 'hidden',
+          // The pill is a brand surface, not the (now bright-emerald) primary:
+          // back it with the deep-green brand gradient so the command bar shares
+          // the Header/Footer identity in BOTH modes, with white content on top.
+          // The `contained color="inherit"` Add buttons render as light/white
+          // surfaces that contrast against this deep green in light and dark.
+          backgroundImage: brandGradient,
+          color: '#ffffff',
         }),
       },
     },

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -1,0 +1,107 @@
+import { createTheme } from '@mui/material/styles';
+
+// Central MUI theme for PathWise.
+//
+// Goal (roadmap 0.6): codify the EXISTING look into a real theme — palette,
+// typography, spacing, and component default props / styleOverrides — so the
+// repeated ad-hoc `sx` styling across Body/tables/popouts is expressed once and
+// every later phase consumes it. This is not a redesign; the visual result
+// should match what shipped before, in both light and dark mode.
+//
+// Dark mode uses MUI 9's CSS-variables color-schemes API: `cssVariables` with a
+// data-attribute selector lets `useColorScheme()` / InitColorSchemeScript flip
+// `data-mui-color-scheme` on <html> without a flash or re-render of the tree.
+
+// The PathWise brand blues — taken from the original header/footer gradients
+// (#1e3c72 -> #2a5298) and the MUI default primary the AppBar already used.
+const brandBlueDark = '#1e3c72';
+const brandBlueMid = '#2a5298';
+
+// Reusable header/footer gradient. Exported so Header/Footer can pull the brand
+// gradient from the theme rather than hard-coding it in CSS.
+export const brandGradient = `linear-gradient(135deg, ${brandBlueDark} 0%, ${brandBlueMid} 100%)`;
+export const brandGradientReversed = `linear-gradient(135deg, ${brandBlueMid} 0%, ${brandBlueDark} 100%)`;
+
+export const theme = createTheme({
+  // Enable CSS theme variables (theme.vars) so color-scheme switching is a CSS
+  // class/attribute swap, not a React re-render — no flash on toggle/reload.
+  cssVariables: {
+    colorSchemeSelector: 'data-mui-color-scheme',
+  },
+  colorSchemes: {
+    light: {
+      palette: {
+        primary: { main: brandBlueMid, dark: brandBlueDark },
+        secondary: { main: '#9c27b0' },
+        background: {
+          // The body previously sat on a pale blue-grey gradient; flatten it to
+          // a solid surface that reads the same but themes cleanly.
+          default: '#eef1f6',
+          paper: '#ffffff',
+        },
+      },
+    },
+    dark: {
+      palette: {
+        primary: { main: '#5b8def', dark: brandBlueMid },
+        secondary: { main: '#ce93d8' },
+        background: {
+          default: '#121417',
+          paper: '#1c2128',
+        },
+      },
+    },
+  },
+  shape: {
+    borderRadius: 8,
+  },
+  typography: {
+    fontFamily: 'Inter, system-ui, Avenir, Helvetica, Arial, sans-serif',
+    h4: { fontWeight: 400 },
+    h5: { fontWeight: 500 },
+  },
+  components: {
+    // Pill AppBar used as the command bar in Body.
+    MuiAppBar: {
+      defaultProps: {
+        position: 'static',
+      },
+      styleOverrides: {
+        root: {
+          borderRadius: 30,
+          marginTop: 15,
+          marginBottom: 15,
+          overflow: 'hidden',
+        },
+      },
+    },
+    // The two section Papers (Loans / Investments) in Body shared
+    // `marginBottom: '20px', padding: '5px'`.
+    MuiPaper: {
+      styleOverrides: {
+        root: {
+          backgroundImage: 'none',
+        },
+      },
+    },
+    // Command-bar buttons all carried `margin: '5px'`. Keep that as the default
+    // so Body/DataManager stop repeating it; `disableElevation` flattens the
+    // contained save buttons to match the previous flat look.
+    MuiButton: {
+      defaultProps: {
+        disableElevation: true,
+      },
+      styleOverrides: {
+        root: {
+          textTransform: 'none',
+        },
+      },
+    },
+    // Table action / popout icon buttons defaulted to the primary color.
+    MuiIconButton: {
+      defaultProps: {
+        color: 'primary',
+      },
+    },
+  },
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="vite/client" />
-declare const APP_VERSION: string;
+
+// Injected at build time from package.json via vite.config.ts `define`
+// (roadmap 0.10). Displayed in the footer.
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,22 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { createRequire } from 'node:module';
+
+// Read the app version straight from package.json so the footer shows the right
+// version regardless of how the build is invoked (roadmap 0.10). The previous
+// `process.env.npm_package_version` is only populated when run through an npm
+// script; reading the file is the conventional Vite approach and works always.
+const require = createRequire(import.meta.url);
+const { version: appVersion } = require('./package.json') as {
+  version: string;
+};
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/finance-calculator/',
   plugins: [react()],
   define: {
-    APP_VERSION: JSON.stringify(process.env.npm_package_version),
+    __APP_VERSION__: JSON.stringify(appVersion),
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary

The complete **Phase 0 UX overhaul** (roadmap items 0.6–0.10) plus a green brand refresh — one commit per item, each landed green through the full check suite. Test suite grew 202 → **235 passing**; lint, format, and build green at every step.

| Commit | Item | What it does |
| --- | --- | --- |
| `5739b31` | **0.6 Theme system** | Proper MUI 9 theme in `src/theme/` codifying the existing look (palette, typography, component defaults replacing repeated ad-hoc `sx`); **persisted dark mode** via the color-schemes API with `InitColorSchemeScript` (no first-paint flash); centralized `formatCurrency`/`formatPercent` in a pure `src/helpers/format-helpers.ts` replacing six inline duplicates with byte-for-byte identical output (14 parity-guarding tests) |
| `45e22e1` | **0.7 Dialogs** | All six Popover-as-modal surfaces converted to a shared `ResponsiveDialog` (full-screen on mobile, proper focus trap/Escape); delete moved out of the edit form to the table-row actions behind a confirmation dialog; **snackbar soft-undo** restores the deleted entity at its original index via new pure reducer actions (9 tests incl. list-shrank and double-undo edge cases) |
| `af62a88` | **0.8 Validation UX** | Field-level error messages with touched/submit-attempt tracking (empty add form doesn't open all-red) and an always-visible explanation of why Save is disabled; **non-blocking cross-field sanity warnings** (CurrentAmount > Principal, rates > 30%/20% thresholds, contribution cadence finer than compounding). All rules in one pure `validation-helpers.ts` (24 tests) that `isFormValid()` derives from — save semantics unchanged |
| `dbfb636` | **0.9 Empty states & sample data** | "Welcome to PathWise" onboarding state with Add/Load-sample CTAs; lighter per-section empty states; realistic `Sample:`-prefixed entities (mortgage, car loan, index fund, 401(k)) in `src/state/sample-data.ts`; dismissible "Showing sample data" banner with one-click clear; **Test Data dev switch removed** from the command bar. Reducer stash/restore guarantees preserved under renamed `LoadSampleData`/`ClearSampleData` actions |
| `6bd27df` | **0.10 Layout polish** | Command-bar hierarchy (contained Add buttons as primary; tooltipped import/export as secondary); toolbar wraps cleanly at ~360px via theme override; repeated px spacing replaced with theme tokens; footer gains GitHub link + app version injected from package.json via Vite `define` |
| `de531c4` | **Green rebrand** | Brand identity moved from blue to a finance green palette, contained entirely in `src/theme/theme.ts`: emerald primary (`#00875a` light / `#00e676` dark), deep forest gradient (`#0b3d2e → #14532d`) on the AppBar pill/Header/Footer, green-tinted dark backgrounds (`#0c1512`). Error/warning semantics left standard so validation and delete affordances still read as alerts |

## Notes for review

- **Known follow-up**: the logo PNGs in `src/assets/` are still the navy/cyan originals — they sit on a white card so nothing breaks, but the mark reads off-brand against the green identity. Needs the asset re-exported in the green palette (not addressable in code).
- Dark mode is worth a look in the deployed preview: green-cast near-black surfaces with bright `#00e676` accents, per the "dark but bright green" direction.
- No new dependencies anywhere in the stack; version stays 0.7.0 (the Phase 0 target).
- With this merged, Phase 0 is done except **0.11 (Math Verification Suite)** — the Charter implementation, planned as its own 2–3 PR sequence since it adds dev tooling (fast-check, Stryker, coverage gates).

https://claude.ai/code/session_01J8KWM4siLf8tAZL5ot2qqn

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8KWM4siLf8tAZL5ot2qqn)_