### PR TITLE
Math Verification Suite + D7 boundary: implement the Math Correctness Charter (roadmap 0.11)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,11 +25,17 @@ src/
 ├── models/              # TypeScript interfaces and types
 │   ├── loan-model.ts
 │   └── investment-model.ts
-├── helpers/             # Business logic and calculations
+├── helpers/             # Pure business logic and calculations (the math core)
 │   ├── loan-helpers.ts
-│   ├── loan-helpers.test.ts
 │   ├── investment-helpers.ts
-│   └── investment-helpers.test.ts
+│   ├── forecast-helpers.ts
+│   ├── *.test.ts             # Co-located unit tests
+│   ├── math-reference.test.ts    # Charter layer 1: oracle tests (Excel/hand-derived)
+│   ├── forecast-consistency.test.ts # Charter layer 2: engine-vs-schedule
+│   ├── math-properties.test.ts   # Charter layer 3: fast-check invariants
+│   ├── math-edge-cases.test.ts   # Charter layer 4: edge catalog
+│   └── PRECISION.md              # Charter layer 5: rounding & consistency policy
+├── hooks/               # Reusable React hooks (UI state, e.g. use-field-tracking)
 ├── loan/                # Loan-related components
 │   ├── loan-table.tsx
 │   ├── add-edit-loan.tsx
@@ -102,6 +108,8 @@ npm run build      # Build for production (TypeScript compilation + Vite build)
 npm test           # Run tests once
 npm run test:watch # Run tests in watch mode (re-runs on file changes)
 npm run test:ui    # Run tests with UI
+npm run test:coverage  # Run tests + enforce 100% coverage gate on src/helpers/**
+npm run test:mutation  # Run Stryker mutation testing over src/helpers/**
 npm run preview    # Preview production build locally
 npm run deploy     # Deploy to GitHub Pages
 ```
@@ -127,6 +135,7 @@ npm run deploy     # Deploy to GitHub Pages
 - The app is deployed to GitHub Pages with base path `/finance-calculator/`
 - No backend or database; all data is managed in client-side state
 - Models are input-only: derived data (amortization schedules, growth projections, forecasts) is computed on demand by helpers and never stored on models or serialized into exports
+- **Core/UI boundary (decision D7)**: `src/helpers/**` and `src/models/**` are a pure, framework-free layer (TypeScript + dayjs only). An ESLint rule forbids them from importing React, MUI, emotion, or any UI component (`*.tsx`). UI depends on the core, never the reverse — put React hooks in `src/hooks/`, not `src/helpers/`.
 - Future plans include file upload/export for data persistence
 - Test data can be toggled in the UI for development purposes
 
@@ -175,11 +184,29 @@ The project uses **Vitest** as its testing framework, configured with globals en
 - Comprehensive test coverage exists for business logic in helpers
 - Tests use Vitest's `describe`, `it`, and `expect` APIs (Jest-like syntax)
 
+### Math Correctness Charter (non-negotiable for `src/helpers/**`)
+
+Financial math must be provably correct, with the proof executable. Any PR
+touching helper math must uphold all of:
+
+- **100% line + branch coverage** on `src/helpers/**`, enforced as a hard CI
+  gate (`npm run test:coverage`, thresholds in `vite.config.ts`).
+- **Reference tests** for every formula against ≥2 independent external sources
+  (spreadsheet PMT/FV/IPMT/CUMIPMT or hand derivations), with the source cited.
+- **Property/invariant tests** (fast-check) and an **edge-case catalog**.
+- **Rounding** follows `src/helpers/PRECISION.md` (cents, round-half-up); assert
+  exact values where the policy defines them, justify every `toBeCloseTo`.
+- A math bug gets a **failing regression test committed before the fix**.
+- **Mutation testing** (Stryker, `npm run test:mutation`) runs on a schedule;
+  surviving mutants are triaged to zero or waived with a comment.
+- UI never re-implements math — helpers are the single source of truth.
+
 ### Testing Best Practices
 
 - **Always write tests** for new business logic in helpers
 - Test edge cases and invalid inputs
-- Use `toBeCloseTo()` for floating-point comparisons
+- Prefer exact assertions (`toBe`); use `toBeCloseTo()` only with a justifying
+  comment (see PRECISION.md)
 - Group related tests using `describe` blocks
 - Write descriptive test names that explain what is being tested
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Check formatting
         run: npm run check:format
 
-      - name: Test
-        run: npm test
+      - name: Test (with math-core coverage gate)
+        # Runs the full suite and enforces the Math Correctness Charter's 100%
+        # line+branch coverage threshold on src/helpers/** (configured in
+        # vite.config.ts). Any PR dropping below it fails here.
+        run: npm run test:coverage
 
       - name: Build
         run: npm run build

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,40 @@
+name: Mutation testing
+
+# Math Correctness Charter §4: Stryker mutation testing over src/helpers/**.
+# Run on a schedule (weekly) and on demand, NOT on every PR — a full mutation
+# run is far slower than the unit suite. Coverage proves the lines ran; this
+# proves the tests would actually catch a flipped sign or off-by-one.
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Stryker
+        run: npm run test:mutation
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report
+          path: reports/mutation
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ dist-ssr
 # Build artifacts
 tsconfig.app.tsbuildinfo
 tsconfig.node.tsbuildinfo
+
+# Coverage and mutation reports
+coverage
+reports
+.stryker-tmp

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+coverage
+reports
+.stryker-tmp

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage', 'reports', '.stryker-tmp'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,5 +39,54 @@ export default tseslint.config(
         },
       ],
     },
+  },
+  {
+    // D7 core/UI boundary (roadmap 0.11). The math core — src/helpers/** and
+    // src/models/** — is a pure, framework-free layer: TypeScript + dayjs only,
+    // fully unit-testable in Node and the subject of the Math Correctness
+    // Charter's 100% coverage gate. These rules make that purity a build
+    // failure rather than a convention: the core may never import React, MUI,
+    // emotion, any other UI runtime, or a UI component (every component is a
+    // `.tsx` file, so importing one is forbidden outright). UI calls helpers,
+    // never the reverse. This keeps the engine worker-safe (Phase 5/7) and
+    // makes a future package extraction a file move, not a refactor.
+    files: ['src/helpers/**/*.ts', 'src/models/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              message:
+                'The math core (src/helpers, src/models) must stay framework-free (D7). Move React-dependent code into a UI folder or src/hooks.',
+            },
+            {
+              name: 'react-dom',
+              message:
+                'The math core (src/helpers, src/models) must stay framework-free (D7).',
+            },
+            {
+              name: 'react-number-format',
+              message:
+                'The math core (src/helpers, src/models) must stay framework-free (D7).',
+            },
+          ],
+          patterns: [
+            {
+              group: [
+                'react/*',
+                'react-dom/*',
+                '@mui/*',
+                '@emotion/*',
+                '**/*.tsx',
+              ],
+              message:
+                'The math core (src/helpers, src/models) must not import UI code or UI libraries (D7). UI depends on the core, never the reverse.',
+            },
+          ],
+        },
+      ],
+    },
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.11.1",
+        "@stryker-mutator/core": "^9.6.1",
+        "@stryker-mutator/vitest-runner": "^9.6.1",
         "@types/node": "^22.7.5",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -39,37 +41,24 @@
         "vitest": "^4.1.8"
       }
     },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
-        "picocolors": "^1.0.0"
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.8.tgz",
-      "integrity": "sha512-ZsysZyXY4Tlx+Q53XdnOFmqwfB9QDTHYxaZYajWRoBLuLEAwI2UIbtxOjWh/cFaa9IKUlcB+DDuoskLuKu56JA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -77,22 +66,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.8.tgz",
-      "integrity": "sha512-Oixnb+DzmRT30qu9d3tJSQkxuygWm32DFykT4bRoORPa9hZ/L4KhVB/XiRm6KG+roIEM7DBQlmg27kw2HZkdZg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helpers": "^7.25.7",
-        "@babel/parser": "^7.25.8",
-        "@babel/template": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.8",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -108,29 +97,43 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.7",
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
-      "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.29.7.tgz",
+      "integrity": "sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.7",
-        "@babel/helper-validator-option": "^7.25.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -139,30 +142,20 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-      "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
-      "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.7.tgz",
+      "integrity": "sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.7",
-        "@babel/helper-simple-access": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/helper-replace-supers": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -171,15 +164,110 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
-      "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.29.7.tgz",
+      "integrity": "sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.29.7.tgz",
+      "integrity": "sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.29.7.tgz",
+      "integrity": "sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.29.7",
+        "@babel/helper-optimise-call-expression": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.29.7.tgz",
+      "integrity": "sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -204,9 +292,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
-      "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -214,29 +302,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -257,6 +330,163 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-proposal-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.7.tgz",
+      "integrity": "sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-syntax-decorators": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-decorators": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
+      "integrity": "sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-destructuring": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.29.7.tgz",
+      "integrity": "sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.29.7.tgz",
+      "integrity": "sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/plugin-transform-destructuring": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+      "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.29.7.tgz",
+      "integrity": "sha512-jK52h8LaLc7JarhQV2ofeFMts4H7vnOXnqZNA6fYglBTZewRBE51KWt3BUltW1P+KoPsYkHoJeXePuz4zo2LMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.29.7",
+        "@babel/helper-create-class-features-plugin": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.29.7",
+        "@babel/plugin-syntax-typescript": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
@@ -267,44 +497,35 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
@@ -728,33 +949,375 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+      "integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+      "integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+      "integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+      "integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/external-editor": "^3.0.3",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+      "integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+      "integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+      "integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+      "integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+      "integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+      "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.1",
+        "@inquirer/confirm": "^6.1.1",
+        "@inquirer/editor": "^5.2.2",
+        "@inquirer/expand": "^5.1.1",
+        "@inquirer/input": "^5.1.2",
+        "@inquirer/number": "^4.1.1",
+        "@inquirer/password": "^5.1.1",
+        "@inquirer/rawlist": "^5.3.1",
+        "@inquirer/search": "^4.2.1",
+        "@inquirer/select": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+      "integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+      "integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+      "integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^11.2.1",
+        "@inquirer/figures": "^2.0.7",
+        "@inquirer/type": "^4.0.7"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+      "integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1505,12 +2068,275 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.1.tgz",
+      "integrity": "sha512-g8VNoFWQWbx0pdal3Vt8jVCZW+v3sc3gi94iI0GVtVgUGTqphAjJF6EAruPTx0lqvtonsaAxn5TD36hcG1d6Wg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.1.tgz",
+      "integrity": "sha512-WMgnvf+Wyh/yiruhNZwc8w8DlzmmjXhPjSn5MR8RhAXzlnWji8TQrUYgBUkHk9bEgSaIlB3KZHm37iiU5Q2cLQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/instrumenter": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "ajv": "~8.18.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.7.3",
+        "mutation-testing-metrics": "3.7.3",
+        "mutation-testing-report-schema": "3.7.3",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.1.tgz",
+      "integrity": "sha512-5K8wH4Pthly25c2uKKik4Dfcoeou7sbJdFS6u3QIYHlulgFVDJwtEMWTZGkZfs7IiUEXIDNa0keRACq5jn5AvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~7.29.0",
+        "@babel/generator": "~7.29.0",
+        "@babel/parser": "~7.29.0",
+        "@babel/plugin-proposal-decorators": "~7.29.0",
+        "@babel/plugin-transform-explicit-resource-management": "^7.28.0",
+        "@babel/preset-typescript": "~7.28.0",
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "angular-html-parser": "~10.4.0",
+        "semver": "~7.7.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~1.3.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.1.tgz",
+      "integrity": "sha512-Lk/ALVctJjFv1vvwR+CFoKzDCWvsBlq7flDUnmnpuwTrGbm156EdZD1Jjq4o8KdOap0ezUZqQNE9OAI1m2+pUQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stryker-mutator/vitest-runner": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-9.6.1.tgz",
+      "integrity": "sha512-eyUHTCf3Ui+SUn/tpFJwzw6MV391kyBLZk/cDHFUfKFELqKMLbvd7e81axArlApKqO6cOnLfrxlwED+2SRN0ow==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "9.6.1",
+        "@stryker-mutator/util": "9.6.1",
+        "semver": "^7.7.4",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "9.6.1",
+        "vitest": ">=2.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/vitest-runner/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -2079,16 +2905,14 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+    "node_modules/angular-html-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
+      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
       "engines": {
-        "node": ">=4"
+        "node": ">= 14"
       }
     },
     "node_modules/argparse": {
@@ -2166,6 +2990,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2191,9 +3028,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -2211,16 +3048,48 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -2233,9 +3102,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001668",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001668.tgz",
-      "integrity": "sha512-nWLrdxqCdblixUO+27JtGJJE/txpJlyUy5YN1u53wLZkP0emYCo5zgS6QYft7VUYR42LGgi/S5hdLZTrnyIddw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2263,18 +3132,21 @@
         "node": ">=18"
       }
     },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
       "engines": {
-        "node": ">=4"
+        "node": ">= 12"
       }
     },
     "node_modules/clsx": {
@@ -2285,21 +3157,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
     },
     "node_modules/commander": {
       "version": "11.1.0",
@@ -2408,6 +3265,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2417,6 +3285,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -2441,10 +3316,25 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.36",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.36.tgz",
-      "integrity": "sha512-HYTX8tKge/VNp6FGO+f/uVDmUkq+cEfcxYhKf15Akc4M5yxt5YmorwlAitKWjWhWQnKcDRBAQKXkhqqXMqcrjw==",
+      "version": "1.5.372",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+      "integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2452,6 +3342,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-5.0.0.tgz",
       "integrity": "sha512-4OIPYlA6JXqtVn8zpHpGiI7vE6EQOAg16aGnDMIAlZVinnoZ8208tW1hAbjWydgN/4PLTT9q+O1K6AH/vALJGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2464,12 +3361,45 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2485,6 +3415,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -2773,6 +3704,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2857,6 +3815,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -2873,6 +3875,22 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -3039,6 +4057,62 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gh-pages": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.2.0.tgz",
@@ -3109,6 +4183,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3123,13 +4210,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3183,6 +4274,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3218,6 +4336,13 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -3271,6 +4396,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -3371,6 +4535,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3413,6 +4584,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -3762,6 +4940,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3829,6 +5014,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3852,6 +5047,13 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3882,6 +5084,53 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.3.tgz",
+      "integrity": "sha512-SMeIPxngJpfjfNYctFpYQQtlBlZaVO0aoB3FKdwrI8Ee/2bkyUuCZzAOCLv1U9fnmfA37dPFq0Owduoxs2XgGQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.3.tgz",
+      "integrity": "sha512-B8QrP0ZomErzTPNlhrzKWPNBln+3afwBZPHv0Q7N8wZZTYxMptzb/Gdm3ExXVmioVYrtZAtsDs7W/T/b2AixOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.7.3"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.3.tgz",
+      "integrity": "sha512-BHm3MYq+ckO+t5CtlG8zpqxc75rdJCkxVlE+fGuGJM3F7tNCQ/OW2N+TQVHN3BHsYa84+BFc6g3AwDYkUsw2MA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
@@ -3909,11 +5158,44 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3922,6 +5204,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -4023,6 +5318,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4212,6 +5520,32 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4255,6 +5589,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -4328,6 +5678,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -4431,6 +5791,23 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4470,12 +5847,101 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -4535,6 +6001,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4566,18 +6045,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
       "license": "MIT"
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -4689,6 +6156,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -4720,8 +6197,17 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4734,6 +6220,33 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/typescript": {
@@ -4774,12 +6287,32 @@
         }
       }
     },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -4792,9 +6325,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -4813,7 +6346,7 @@
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
-        "picocolors": "^1.1.0"
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -5035,6 +6568,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
+      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5111,6 +6651,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^9.11.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.12",
+        "fast-check": "^4.8.0",
         "gh-pages": "^6.2.0",
         "globals": "^15.9.0",
         "typescript": "^5.5.3",
@@ -2782,6 +2783,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4214,6 +4238,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
+        "@vitest/coverage-v8": "^4.1.8",
         "@vitest/ui": "^4.1.8",
         "eslint": "^9.11.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -184,18 +185,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -241,12 +242,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
-      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.8"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -306,17 +307,26 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.8",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
-      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -756,9 +766,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1862,6 +1872,37 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.8",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
@@ -2075,6 +2116,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3092,6 +3152,13 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3188,6 +3255,97 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -3617,6 +3775,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/make-dir": {
@@ -4453,15 +4623,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",
+    "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "eslint": "^9.11.1",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:coverage": "vitest run --coverage",
+    "test:mutation": "stryker run",
     "preview": "vite preview",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d dist"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint": "^9.11.1",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.12",
+    "fast-check": "^4.8.0",
     "gh-pages": "^6.2.0",
     "globals": "^15.9.0",
     "typescript": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/vitest-runner": "^9.6.1",
     "@types/node": "^22.7.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/src/helpers/PRECISION.md
+++ b/src/helpers/PRECISION.md
@@ -1,0 +1,78 @@
+# Precision & Consistency Policy (Math Correctness Charter §4, layer 5)
+
+This document is the single, authoritative statement of how PathWise's financial
+math rounds, and of how its two projection engines are kept consistent. It exists
+so that rounding is **a decision, not an accident**: every test in the
+`src/helpers/**` suite asserts exact values (`toBe`) where this policy defines
+them, and every `toBeCloseTo` carries a comment justifying its tolerance against
+the rules below.
+
+## 1. Unit and rounding function
+
+- **Money is reasoned about in cents.** The canonical rounding step is
+  `Math.round(value * 100) / 100` (spelled `roundToCents` in the helpers).
+- `Math.round` is **round-half-up toward +∞** (`2.005 → 2.01`, `-2.005 → -2.00`).
+  This is the JavaScript default and is applied uniformly; we do not use
+  banker's rounding.
+- Rates are **not** rounded. An annual percentage is divided to a periodic rate
+  (`rate / 100 / periodsPerYear`) and used at full floating-point precision.
+
+## 2. Where values round (per module)
+
+| Quantity                        | Rounded to cents?        | Notes                                                                                                                                                                                                                |
+| ------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getMonthlyPayment` result      | **Yes**, once, on return | Closed-form PMT, then a single `roundToCents`.                                                                                                                                                                       |
+| Amortization `InterestPayment`  | **Yes**, each term       | `round(balance × monthlyRate)`.                                                                                                                                                                                      |
+| Amortization `PrincipalPayment` | **Yes**, each term       | `round(payment − interest)`, except the final term, which is set to the exact `remainingBalance` so the loan closes at **0** (never negative).                                                                       |
+| Amortization `RemainingBalance` | Derived, floored at 0    | Carries the rounded running balance.                                                                                                                                                                                 |
+| Investment running value        | **No** between periods   | The running `currentValue` accumulates **unrounded**; only the reported `TotalValue` / `InterestEarned` / `ContributionAmount` on each entry are rounded. This keeps long horizons from accumulating rounding drift. |
+| `forecastLoan` balance          | **Yes**, each month      | Balance is re-rounded every month, so the series carries rounded cents.                                                                                                                                              |
+| `forecastInvestment` value      | **No** between months    | Running value is unrounded; each emitted `ForecastPoint.Value` is rounded. Matches the investment-growth policy above.                                                                                               |
+| `forecastNetWorth` value        | **Yes**, per point       | `round(Σ assets − Σ loan balances)` from the already-rounded per-entity points.                                                                                                                                      |
+
+### Intermediate-rounding consequence
+
+Because the amortization helper rounds `interest` and `principal`
+**separately each term**, while `forecastLoan` rounds the **net** balance change
+each month, the two could in principle differ by a cent. In practice they do
+not — see §4 — but any consistency assertion that ever needs slack must justify
+it as "± intra-step rounding order," never as an unexplained fudge factor.
+
+## 3. Exact vs. tolerance in tests
+
+- **Exact (`toBe`)** is required for: `getMonthlyPayment` outputs, every
+  amortization entry field, payoff-to-zero, net-worth additivity, and any value
+  this policy pins to the cent.
+- **`toBeCloseTo`** is permitted only for: comparisons against an externally
+  published figure whose own rounding differs from ours (e.g. a spreadsheet's
+  `CUMIPMT` totals a per-period rounded series differently than we do), and
+  closed-form references evaluated in floating point. Each such use names its
+  source and tolerance.
+
+## 4. Cross-implementation consistency (Charter §4, layer 2)
+
+The forecast engine (`forecast-helpers.ts`) and the term/period schedule helpers
+(`loan-helpers.ts`, `investment-helpers.ts`) compute the same quantities two ways
+and **must not drift**. The enforced, tested guarantees:
+
+- **Loans — exact.** `forecastLoan(loan, EndDate, 0, today = StartDate)` with
+  `CurrentAmount = Principal` reproduces `generateAmortizationSchedule`'s
+  `RemainingBalance` **month-for-month to the cent** (`forecast-consistency.test.ts`).
+- **Investments — exact at compounding boundaries.** `forecastInvestment`
+  anchored at the start matches `generateInvestmentGrowth`'s `TotalValue` **to the
+  cent** at every compounding boundary (month `period × 12 / periodsPerYear`),
+  for monthly/quarterly/annual compounding with monthly/quarterly contributions
+  and **no step-up**.
+
+### Known divergence (documented, not yet reconciled)
+
+With **yearly step-ups enabled**, the two investment engines assign a
+contribution that lands on an anniversary to **different year numbers** (an
+off-by-one in anniversary attribution: the period-indexed
+`generateInvestmentGrowth` first steps up one period later than the monthly-grid
+`forecastInvestment`). Without step-ups the engines are identical to the cent, so
+this is purely a step-up **timing** question, not a compounding error. It is
+called out here and in the consistency suite as a known gap; per the Charter's
+process rule, reconciling it ships as its own PR with a failing regression test
+landed before the fix. Until then, consistency tests cover the no-step-up cases
+that are provably exact and do not assert the step-up case.

--- a/src/helpers/PRECISION.md
+++ b/src/helpers/PRECISION.md
@@ -72,7 +72,12 @@ off-by-one in anniversary attribution: the period-indexed
 `generateInvestmentGrowth` first steps up one period later than the monthly-grid
 `forecastInvestment`). Without step-ups the engines are identical to the cent, so
 this is purely a step-up **timing** question, not a compounding error. It is
-called out here and in the consistency suite as a known gap; per the Charter's
-process rule, reconciling it ships as its own PR with a failing regression test
-landed before the fix. Until then, consistency tests cover the no-step-up cases
-that are provably exact and do not assert the step-up case.
+called out here and — so the suite is not silent about it — encoded as an
+executable tripwire in `forecast-consistency.test.ts`: the test
+_"forecastInvestment and generateInvestmentGrowth diverge with a yearly step-up"_
+uses Vitest's `it.fails` to assert the engines **agree**, which currently throws.
+The day the off-by-one is reconciled that body stops throwing and the test flips
+red, forcing the fixer to convert it into a normal passing `it` — exactly the
+"failing regression test committed before the fix" the Charter's process rule
+requires. Until then, the boundary-consistency tests cover only the no-step-up
+cases that are provably exact.

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -55,8 +55,8 @@ const validateNumericField = (
   field: string,
   entityType: string,
   index: number,
-  predicate: (n: number) => boolean = () => true,
-  rangeDescription = 'a finite number'
+  predicate: (n: number) => boolean,
+  rangeDescription: string
 ): void => {
   if (!isFiniteNumber(value)) {
     throw new Error(
@@ -78,8 +78,8 @@ const validateOptionalNumericField = (
   field: string,
   entityType: string,
   index: number,
-  predicate: (n: number) => boolean = () => true,
-  rangeDescription = 'a finite number'
+  predicate: (n: number) => boolean,
+  rangeDescription: string
 ): void => {
   if (value === undefined || value === null) return;
   validateNumericField(

--- a/src/helpers/defensive-guards.test.ts
+++ b/src/helpers/defensive-guards.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { getTerms } from './loan-helpers';
+import {
+  getPeriodsPerYear,
+  getInvestmentPeriods,
+  generateInvestmentGrowth,
+  getPitInvestmentCalculation,
+} from './investment-helpers';
+import { forecastInvestment } from './forecast-helpers';
+import { importFromJson } from './data-helpers';
+import { validateLoan, validateInvestment } from './validation-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+// Math Correctness Charter §4 enforcement — coverage of the defensive guards.
+//
+// The helpers carry guards for degenerate inputs (missing dates, unknown enum
+// values, no contribution cadence) that the happy-path tests never reach. These
+// pin that defensive behavior so the 100% line+branch gate on src/helpers/**
+// stays honest rather than being met by deleting the guards.
+
+describe('Defensive guards: loan-helpers.getTerms', () => {
+  it('returns 0 when the loan is missing its dates', () => {
+    const loan = {
+      Id: 'L',
+      Provider: '',
+      Name: '',
+      InterestRate: 5,
+      StartDate: undefined,
+      EndDate: undefined,
+      Principal: 1000,
+      CurrentAmount: 1000,
+    } as unknown as Loan;
+    expect(getTerms(loan)).toBe(0);
+  });
+});
+
+describe('Defensive guards: investment-helpers', () => {
+  it('getPeriodsPerYear falls back to 1 for an unknown frequency', () => {
+    expect(getPeriodsPerYear('weekly' as CompoundingFrequency)).toBe(1);
+  });
+
+  it('getInvestmentPeriods returns 0 when StartDate is missing', () => {
+    const investment = {
+      Id: 'I',
+      Provider: '',
+      Name: '',
+      StartDate: undefined,
+      StartingBalance: 1000,
+      AverageReturnRate: 5,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    } as unknown as Investment;
+    expect(getInvestmentPeriods(investment)).toBe(0);
+  });
+});
+
+describe('Defensive guards: getInvestmentPeriods partial-period branches', () => {
+  const inv = (
+    over: Partial<Investment> & { CompoundingPeriod: CompoundingFrequency }
+  ): Investment => ({
+    Id: 'I',
+    Provider: '',
+    Name: '',
+    StartDate: new Date(2020, 0, 15),
+    StartingBalance: 1000,
+    AverageReturnRate: 5,
+    ...over,
+  });
+
+  it('defaults the end date to now when none is supplied', () => {
+    // Hits the `endDate ?? new Date()` fallback; a past start always yields >= 1.
+    const periods = getInvestmentPeriods(
+      inv({
+        StartDate: new Date(2000, 0, 1),
+        CompoundingPeriod: CompoundingFrequency.Monthly,
+      })
+    );
+    expect(periods).toBeGreaterThanOrEqual(1);
+  });
+
+  it('monthly: does not add a partial month before the start day', () => {
+    expect(
+      getInvestmentPeriods(
+        inv({ CompoundingPeriod: CompoundingFrequency.Monthly }),
+        new Date(2020, 2, 10) // day 10 < start day 15
+      )
+    ).toBe(2);
+  });
+
+  it('quarterly: does not add a partial quarter before the quarter start day', () => {
+    expect(
+      getInvestmentPeriods(
+        inv({
+          StartDate: new Date(2020, 0, 20),
+          CompoundingPeriod: CompoundingFrequency.Quarterly,
+        }),
+        new Date(2020, 3, 10) // before the Apr-20 quarter start
+      )
+    ).toBe(1);
+  });
+
+  it('annually: does not add a partial year before the anniversary', () => {
+    expect(
+      getInvestmentPeriods(
+        inv({
+          StartDate: new Date(2020, 5, 15),
+          CompoundingPeriod: CompoundingFrequency.Annually,
+        }),
+        new Date(2021, 2, 1) // before the June anniversary
+      )
+    ).toBe(1);
+  });
+});
+
+describe('Defensive guards: generateInvestmentGrowth / PIT fallbacks', () => {
+  const base = (over: Partial<Investment> = {}): Investment => ({
+    Id: 'I',
+    Provider: '',
+    Name: '',
+    StartDate: new Date(2000, 0, 1),
+    StartingBalance: 10000,
+    AverageReturnRate: 6,
+    CompoundingPeriod: CompoundingFrequency.Monthly,
+    ...over,
+  });
+
+  it('generateInvestmentGrowth defaults the end date to now', () => {
+    // `endDate ?? new Date()`; a 2000 start means many periods by today.
+    expect(generateInvestmentGrowth(base()).length).toBeGreaterThan(1);
+  });
+
+  it('pro-rates the final partial compounding period (mid-month horizon)', () => {
+    const growth = generateInvestmentGrowth(base(), new Date(2000, 2, 15));
+    // Last period is partial (Mar 1 -> Mar 15 of a Mar 1 -> Apr 1 period).
+    expect(growth.length).toBeGreaterThan(1);
+    expect(growth[growth.length - 1].TotalValue).toBeGreaterThan(0);
+  });
+
+  it('PIT defaults the date and falls back to the starting balance before the start', () => {
+    // date ?? new Date() default-date branch.
+    expect(getPitInvestmentCalculation(base()).CurrentValue).toBeGreaterThan(0);
+
+    // Empty-growth + zero-contribution branches: a future-dated, zero-balance
+    // investment queried before it starts.
+    const future = base({
+      StartDate: new Date(2099, 0, 1),
+      StartingBalance: 0,
+    });
+    const pit = getPitInvestmentCalculation(future, new Date(2098, 0, 1));
+    expect(pit.CurrentValue).toBe(0);
+    expect(pit.ProjectedAnnualReturn).toBe(0);
+  });
+});
+
+describe('Defensive guards: forecastInvestment without a contribution cadence', () => {
+  it('treats an absent recurring amount as zero when a frequency is set', () => {
+    // Hits `RecurringContribution ?? 0` on the frequency-set branch.
+    const inv: Investment = {
+      Id: 'I',
+      Provider: '',
+      Name: '',
+      StartDate: new Date(2020, 0, 1),
+      StartingBalance: 10000,
+      AverageReturnRate: 6,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+      // RecurringContribution intentionally omitted
+    };
+    const today = new Date(2024, 0, 1);
+    const horizon = new Date(2026, 0, 1);
+    const noAmount = forecastInvestment(inv, horizon, 0, today);
+    const explicitZero = forecastInvestment(
+      { ...inv, RecurringContribution: 0 },
+      horizon,
+      0,
+      today
+    );
+    expect(noAmount.map((p) => p.Value)).toEqual(
+      explicitZero.map((p) => p.Value)
+    );
+  });
+
+  it('ignores a recurring amount when no ContributionFrequency is set', () => {
+    const base: Investment = {
+      Id: 'I',
+      Provider: '',
+      Name: '',
+      StartDate: new Date(2020, 0, 1),
+      StartingBalance: 10000,
+      AverageReturnRate: 6,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+      RecurringContribution: 500, // present, but no frequency => not applied
+    };
+    const today = new Date(2024, 0, 1);
+    const horizon = new Date(2026, 0, 1);
+    const withAmountNoFreq = forecastInvestment(base, horizon, 0, today);
+    const lumpSumOnly = forecastInvestment(
+      { ...base, RecurringContribution: 0 },
+      horizon,
+      0,
+      today
+    );
+    expect(withAmountNoFreq.map((p) => p.Value)).toEqual(
+      lumpSumOnly.map((p) => p.Value)
+    );
+  });
+});
+
+describe('Defensive guards: import date validation', () => {
+  it('rejects an investment whose StartDate is invalid even when loans are valid', () => {
+    const json = JSON.stringify({
+      schemaVersion: 2,
+      loans: [],
+      investments: [
+        {
+          Id: 'I',
+          Provider: 'Broker',
+          Name: 'Bad date',
+          StartDate: 'not-a-date',
+          StartingBalance: 1000,
+          AverageReturnRate: 5,
+          CompoundingPeriod: CompoundingFrequency.Monthly,
+        },
+      ],
+    });
+    expect(() => importFromJson(json)).toThrow(/Invalid date in investment/);
+  });
+});
+
+describe('Defensive guards: validation-helpers required-date errors', () => {
+  it('flags a loan missing its start and end dates', () => {
+    const loan = {
+      Id: 'L',
+      Provider: 'Bank',
+      Name: 'No dates',
+      InterestRate: 5,
+      StartDate: undefined,
+      EndDate: undefined,
+      Principal: 1000,
+      CurrentAmount: 1000,
+      MonthlyPayment: 100,
+    } as unknown as Loan;
+    const result = validateLoan(loan);
+    expect(result.errors.StartDate).toBeTruthy();
+    expect(result.errors.EndDate).toBeTruthy();
+  });
+
+  it('flags an investment missing its start date', () => {
+    const investment = {
+      Id: 'I',
+      Provider: 'Broker',
+      Name: 'No date',
+      StartDate: undefined,
+      StartingBalance: 1000,
+      AverageReturnRate: 5,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    } as unknown as Investment;
+    const result = validateInvestment(investment);
+    expect(result.errors.StartDate).toBeTruthy();
+  });
+});

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateAmortizationSchedule,
+  getMonthlyPayment,
+  getTerms,
+} from './loan-helpers';
+import {
+  generateInvestmentGrowth,
+  getPeriodsPerYear,
+} from './investment-helpers';
+import { forecastLoan, forecastInvestment } from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+// Compare to the cent. The schedule helpers carry an unrounded running balance
+// while the forecast engine re-rounds every step (PRECISION.md §2), so raw
+// doubles can differ by float epsilon (~1e-12) while representing the same cent
+// value. Integer cents is the precise statement of "agrees to the cent".
+const cents = (value: number): number => Math.round(value * 100);
+
+// Math Correctness Charter §4, layer 2 — Cross-implementation consistency.
+//
+// The forecast engine (date-indexed, anchored to today) and the term/period
+// schedule helpers compute the same quantities two different ways. Run from the
+// start with the anchor equal to the original principal/balance, they must not
+// drift. Guarantees and the one documented exception are spelled out in
+// PRECISION.md §4.
+
+const makeLoan = (over: Partial<Loan>): Loan => ({
+  Id: 'L',
+  Provider: '',
+  Name: '',
+  InterestRate: 5,
+  StartDate: new Date(2020, 0, 1),
+  EndDate: new Date(2025, 0, 1),
+  Principal: 30000,
+  CurrentAmount: 30000,
+  ...over,
+});
+
+const makeInvestment = (over: Partial<Investment>): Investment => ({
+  Id: 'I',
+  Provider: '',
+  Name: '',
+  StartDate: new Date(2020, 0, 1),
+  StartingBalance: 5000,
+  AverageReturnRate: 7,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...over,
+});
+
+describe('Consistency: forecastLoan reproduces the amortization schedule', () => {
+  // forecastLoan(loan, EndDate, 0, StartDate) with CurrentAmount = Principal must
+  // equal generateAmortizationSchedule's RemainingBalance month-for-month, to the
+  // cent. forecast index t (t ≥ 1) is the balance after t payments = schedule
+  // term t's RemainingBalance.
+  const cases: Array<{ name: string; loan: Loan }> = [
+    {
+      name: '30k @ 5% / 5yr',
+      loan: makeLoan({}),
+    },
+    {
+      name: '100k @ 3.5% / 30yr',
+      loan: makeLoan({
+        InterestRate: 3.5,
+        EndDate: new Date(2050, 0, 1),
+        Principal: 100000,
+        CurrentAmount: 100000,
+      }),
+    },
+    {
+      name: '0% / 4yr',
+      loan: makeLoan({
+        InterestRate: 0,
+        EndDate: new Date(2024, 0, 1),
+        Principal: 12000,
+        CurrentAmount: 12000,
+      }),
+    },
+  ];
+
+  cases.forEach(({ name, loan }) => {
+    it(`matches to the cent: ${name}`, () => {
+      const withPayment: Loan = {
+        ...loan,
+        MonthlyPayment: getMonthlyPayment(
+          loan.Principal,
+          loan.InterestRate,
+          getTerms(loan)
+        ),
+      };
+      const schedule = generateAmortizationSchedule(withPayment);
+      const forecast = forecastLoan(
+        withPayment,
+        withPayment.EndDate,
+        0,
+        withPayment.StartDate
+      );
+
+      // Compare over the overlapping range (the schedule's term count and the
+      // monthly forecast horizon differ by the StartDate/EndDate +1-term
+      // convention; the overlap is what must agree).
+      const overlap = Math.min(schedule.length, forecast.length - 1);
+      for (let term = 1; term <= overlap; term++) {
+        expect(cents(forecast[term].Value)).toBe(
+          cents(schedule[term - 1].RemainingBalance)
+        );
+      }
+    });
+  });
+});
+
+describe('Consistency: forecastInvestment matches growth at compounding boundaries', () => {
+  // At each compounding boundary (month = period × 12 / periodsPerYear),
+  // forecastInvestment's value equals generateInvestmentGrowth's TotalValue to
+  // the cent — for the no-step-up cases (see PRECISION.md §4 for the step-up
+  // exception, which is deliberately not asserted here).
+  const start = new Date(2020, 0, 1);
+  const end = new Date(2030, 0, 1);
+  const cases: Array<{ name: string; inv: Investment }> = [
+    {
+      name: 'monthly compounding, monthly contributions',
+      inv: makeInvestment({
+        RecurringContribution: 300,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+      }),
+    },
+    {
+      name: 'quarterly compounding, monthly contributions',
+      inv: makeInvestment({
+        CompoundingPeriod: CompoundingFrequency.Quarterly,
+        RecurringContribution: 300,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+      }),
+    },
+    {
+      name: 'annual compounding, quarterly contributions',
+      inv: makeInvestment({
+        CompoundingPeriod: CompoundingFrequency.Annually,
+        RecurringContribution: 1000,
+        ContributionFrequency: CompoundingFrequency.Quarterly,
+      }),
+    },
+    {
+      name: 'lump sum, no contributions',
+      inv: makeInvestment({
+        CompoundingPeriod: CompoundingFrequency.Quarterly,
+      }),
+    },
+  ];
+
+  cases.forEach(({ name, inv }) => {
+    it(`agrees at every boundary: ${name}`, () => {
+      const growth = generateInvestmentGrowth(inv, end);
+      const forecast = forecastInvestment(inv, end, 0, start);
+      const interval = 12 / getPeriodsPerYear(inv.CompoundingPeriod);
+
+      // Anchor (period 0 / month 0) must match.
+      expect(cents(forecast[0].Value)).toBe(cents(growth[0].TotalValue));
+
+      for (let period = 1; period < growth.length; period++) {
+        const month = period * interval;
+        if (month >= forecast.length) break;
+        expect(cents(forecast[month].Value)).toBe(
+          cents(growth[period].TotalValue)
+        );
+      }
+    });
+  });
+});

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -10,7 +10,11 @@ import {
 } from './investment-helpers';
 import { forecastLoan, forecastInvestment } from './forecast-helpers';
 import { Loan } from '../models/loan-model';
-import { CompoundingFrequency, Investment } from '../models/investment-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
 
 // Compare to the cent. The schedule helpers carry an unrounded running balance
 // while the forecast engine re-rounds every step (PRECISION.md §2), so raw
@@ -167,4 +171,49 @@ describe('Consistency: forecastInvestment matches growth at compounding boundari
       }
     });
   });
+});
+
+describe('Consistency: KNOWN divergence — step-up anniversary attribution', () => {
+  // Charter §4 process rule: "every math bug found gets a failing regression
+  // test committed before the fix." The two investment engines agree to the
+  // cent WITHOUT step-ups (asserted above), but disagree once a yearly step-up
+  // is configured: they attribute an on-anniversary contribution to different
+  // year numbers (an off-by-one). See PRECISION.md §4 "Known divergence".
+  //
+  // This is encoded as `it.fails` so the suite is NOT silent about the bug: the
+  // body asserts the engines AGREE, which currently throws, so `it.fails`
+  // passes. The day the off-by-one is reconciled the body stops throwing and
+  // this test flips red — forcing whoever fixes it to convert this into a normal
+  // passing `it`, exactly the "failing test before the fix" the Charter wants.
+  it.fails(
+    'forecastInvestment and generateInvestmentGrowth diverge with a yearly step-up',
+    () => {
+      const start = new Date(2020, 0, 1);
+      const end = new Date(2030, 0, 1);
+      const inv: Investment = {
+        Id: 'I',
+        Provider: '',
+        Name: '',
+        StartDate: start,
+        StartingBalance: 5000,
+        AverageReturnRate: 7,
+        CompoundingPeriod: CompoundingFrequency.Monthly,
+        RecurringContribution: 500,
+        ContributionFrequency: CompoundingFrequency.Monthly,
+        ContributionStepUpAmount: 5,
+        ContributionStepUpType: StepUpType.Percentage,
+      };
+      const growth = generateInvestmentGrowth(inv, end);
+      const forecast = forecastInvestment(inv, end, 0, start);
+
+      // Monthly compounding => boundary month === period index. They already
+      // diverge at the first anniversary (month 12), where the step-up first
+      // applies. When this assertion starts passing, delete `.fails`.
+      for (let month = 1; month < growth.length; month++) {
+        expect(cents(forecast[month].Value)).toBe(
+          cents(growth[month].TotalValue)
+        );
+      }
+    }
+  );
 });

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -116,8 +116,10 @@ export const getInvestmentPeriods = (
     }
   }
 
-  // Return at least 1 period if the start date is today or in the past
-  return Math.max(periods, start <= end ? 1 : 0);
+  // Return at least 1 period: an investment whose start is today or in the
+  // past has elapsed at least one period. (end < start already returned 0
+  // above, so end >= start holds here.)
+  return Math.max(periods, 1);
 };
 
 // Get the next compounding date based on frequency
@@ -286,15 +288,13 @@ export const generateInvestmentGrowth = (
 
     // Calculate contributions in this period (with step-up if configured)
     let contributionThisPeriod = 0;
-    if (
-      (investment.RecurringContribution || 0) > 0 &&
-      investment.ContributionFrequency
-    ) {
+    const recurringContribution = investment.RecurringContribution ?? 0;
+    if (recurringContribution > 0 && investment.ContributionFrequency) {
       contributionThisPeriod = getContributionsWithStepUp(
         currentDate,
         periodEndDate,
         investment.StartDate,
-        investment.RecurringContribution || 0,
+        recurringContribution,
         investment.ContributionFrequency,
         investment.ContributionStepUpAmount,
         investment.ContributionStepUpType

--- a/src/helpers/math-edge-cases.test.ts
+++ b/src/helpers/math-edge-cases.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateAmortizationSchedule,
+  getMonthlyPayment,
+  getTerms,
+} from './loan-helpers';
+import {
+  getAnniversaryDate,
+  getInvestmentYear,
+  getNextCompoundingDate,
+} from './investment-helpers';
+import { forecastLoan, forecastInvestment } from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+// Math Correctness Charter §4, layer 4 — Edge-case catalog.
+//
+// Named tests for the boundaries that quietly break naive implementations:
+// leap days, month-end rollover, zero/extreme rates, one-month terms, negative
+// amortization, zero/mid-month/50-year horizons, and float accumulation over
+// 600+ months staying within the cents policy (PRECISION.md).
+
+const makeLoan = (over: Partial<Loan>): Loan => ({
+  Id: 'L',
+  Provider: '',
+  Name: '',
+  InterestRate: 5,
+  StartDate: new Date(2020, 0, 1),
+  EndDate: new Date(2025, 0, 1),
+  Principal: 10000,
+  CurrentAmount: 10000,
+  ...over,
+});
+
+const makeInvestment = (over: Partial<Investment>): Investment => ({
+  Id: 'I',
+  Provider: '',
+  Name: '',
+  StartDate: new Date(2020, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...over,
+});
+
+describe('Edge: leap-day anniversaries', () => {
+  it('a Feb-29 start falls back to Feb 28 in non-leap years and keeps Feb 29 in leap years', () => {
+    const leapStart = new Date(2020, 1, 29);
+    expect(getAnniversaryDate(leapStart, 2021)).toEqual(new Date(2021, 1, 28));
+    expect(getAnniversaryDate(leapStart, 2024)).toEqual(new Date(2024, 1, 29));
+    // Century rule: 2100 is not a leap year.
+    expect(getAnniversaryDate(leapStart, 2100)).toEqual(new Date(2100, 1, 28));
+  });
+
+  it('counts a Feb-29 start as having passed its anniversary on Feb 28 of a non-leap year', () => {
+    expect(
+      getInvestmentYear(new Date(2021, 1, 28), new Date(2020, 1, 29))
+    ).toBe(2);
+  });
+});
+
+describe('Edge: month-end date rollover', () => {
+  it('documents the JS Date rollover for Jan 31 + 1 month (lands in March)', () => {
+    // Jan 31 + 1 month overflows February and normalizes into March — a known
+    // Date quirk. Pinned so a future dayjs migration (Phase 6) is a deliberate
+    // behavior change, not a silent one.
+    const next = getNextCompoundingDate(
+      new Date(2021, 0, 31),
+      CompoundingFrequency.Monthly
+    );
+    expect(next.getMonth()).toBe(2); // March
+    expect(next).toEqual(new Date(2021, 2, 3));
+  });
+});
+
+describe('Edge: zero and extreme rates', () => {
+  it('a 0% loan pays equal principal instalments and reaches exactly zero', () => {
+    const loan = makeLoan({
+      InterestRate: 0,
+      Principal: 12000,
+      CurrentAmount: 12000,
+      EndDate: new Date(2021, 0, 1), // 13 terms
+      MonthlyPayment: getMonthlyPayment(
+        12000,
+        0,
+        getTerms(makeLoan({ EndDate: new Date(2021, 0, 1) }))
+      ),
+    });
+    const schedule = generateAmortizationSchedule(loan);
+    expect(schedule.every((e) => e.InterestPayment === 0)).toBe(true);
+    expect(schedule[schedule.length - 1].RemainingBalance).toBe(0);
+  });
+
+  it('an extreme 30% rate still produces a payment above interest-only', () => {
+    const payment = getMonthlyPayment(100000, 30, 360);
+    const interestOnly = (100000 * 30) / 100 / 12;
+    expect(payment).toBeGreaterThan(interestOnly);
+  });
+});
+
+describe('Edge: one-month term', () => {
+  it('a single-term loan is repaid in full with one interest charge', () => {
+    const loan = makeLoan({
+      InterestRate: 6,
+      Principal: 5000,
+      CurrentAmount: 5000,
+      EndDate: new Date(2020, 0, 1), // start == end => 1 term
+      MonthlyPayment: getMonthlyPayment(5000, 6, 1),
+    });
+    expect(loan.MonthlyPayment).toBe(5025); // 5000 · (1 + 0.06/12)
+    expect(generateAmortizationSchedule(loan)).toEqual([
+      {
+        Term: 1,
+        PrincipalPayment: 5000,
+        InterestPayment: 25,
+        RemainingBalance: 0,
+      },
+    ]);
+  });
+});
+
+describe('Edge: negative amortization (payment < interest)', () => {
+  it('balance grows instead of throwing when the payment cannot cover interest', () => {
+    const loan = makeLoan({
+      InterestRate: 12, // 1%/mo => 1000 interest on 100k
+      Principal: 100000,
+      CurrentAmount: 100000,
+      EndDate: new Date(2050, 0, 1),
+      MonthlyPayment: 500, // below the 1000 first-month interest
+    });
+    const series = forecastLoan(
+      loan,
+      new Date(2021, 0, 1),
+      0,
+      new Date(2020, 0, 1)
+    );
+    // Strictly increasing while underwater.
+    for (let m = 1; m < series.length; m++) {
+      expect(series[m].Value).toBeGreaterThan(series[m - 1].Value);
+    }
+    expect(series[1].Value).toBe(100500);
+
+    // The schedule records a negative principal payment in the same situation.
+    expect(generateAmortizationSchedule(loan)[0].PrincipalPayment).toBe(-500);
+  });
+});
+
+describe('Edge: horizon boundaries', () => {
+  it('horizon = today yields a single anchor point', () => {
+    const loan = makeLoan({ MonthlyPayment: 200 });
+    const today = new Date(2024, 5, 10);
+    const series = forecastLoan(loan, today, 0, today);
+    expect(series).toHaveLength(1);
+    expect(series[0].Value).toBe(loan.CurrentAmount);
+  });
+
+  it('a mid-month horizon rounds up to cover the requested end date', () => {
+    const inv = makeInvestment({});
+    const today = new Date(2024, 0, 15);
+    const horizon = new Date(2024, 2, 20); // ~2.16 months out
+    const series = forecastInvestment(inv, horizon, 0, today);
+    // ceil(2.16) = 3 months beyond the anchor.
+    expect(series).toHaveLength(4);
+    expect(series[series.length - 1].Date.getTime()).toBeGreaterThanOrEqual(
+      horizon.getTime() - 1000 * 60 * 60 * 24 * 31
+    );
+  });
+});
+
+describe('Edge: long horizons and float accumulation', () => {
+  it('a 50-year (600+ month) forecast stays clean to the cent with no NaN', () => {
+    const inv = makeInvestment({
+      RecurringContribution: 500,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    });
+    const today = new Date(2024, 0, 1);
+    const horizon = new Date(2074, 0, 1); // 50 years => 600 months
+    const series = forecastInvestment(inv, horizon, 0, today);
+    expect(series.length).toBeGreaterThan(600);
+    for (const point of series) {
+      expect(Number.isFinite(point.Value)).toBe(true);
+      // Every emitted value is rounded to whole cents per PRECISION.md.
+      expect(
+        Math.abs(point.Value * 100 - Math.round(point.Value * 100))
+      ).toBeLessThan(1e-6);
+    }
+    // Monotonically non-decreasing: positive return + positive contributions.
+    for (let m = 1; m < series.length; m++) {
+      expect(series[m].Value).toBeGreaterThanOrEqual(series[m - 1].Value);
+    }
+  });
+});

--- a/src/helpers/math-properties.test.ts
+++ b/src/helpers/math-properties.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import {
+  generateAmortizationSchedule,
+  getMonthlyPayment,
+  getTerms,
+} from './loan-helpers';
+import { getContributionForYear } from './investment-helpers';
+import {
+  forecastLoan,
+  forecastInvestment,
+  forecastNetWorth,
+} from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
+
+// Math Correctness Charter §4, layer 3 — Property / invariant tests.
+//
+// fast-check drives randomized inputs through the helpers and asserts the
+// invariants that must hold no matter the input: money conservation in cents,
+// non-negative balances, monotonicity of extra payments/contributions, and
+// pointwise net-worth additivity. Comparisons are in integer cents per
+// PRECISION.md (raw doubles can differ by float epsilon while agreeing to the
+// cent).
+
+const cents = (value: number): number => Math.round(value * 100);
+
+// Build a loan whose EndDate is `termMonths` after StartDate, with a payment
+// that amortizes the principal over its term.
+const loanArb = fc
+  .record({
+    startYear: fc.integer({ min: 2000, max: 2040 }),
+    startMonth: fc.integer({ min: 0, max: 11 }),
+    termMonths: fc.integer({ min: 1, max: 480 }),
+    principal: fc.integer({ min: 1000, max: 2_000_000 }),
+    rateBps: fc.integer({ min: 0, max: 3000 }), // 0%–30%
+  })
+  .map(({ startYear, startMonth, termMonths, principal, rateBps }): Loan => {
+    const StartDate = new Date(startYear, startMonth, 1);
+    const EndDate = new Date(startYear, startMonth + termMonths, 1);
+    const InterestRate = rateBps / 100;
+    const loan: Loan = {
+      Id: 'L',
+      Provider: '',
+      Name: '',
+      InterestRate,
+      StartDate,
+      EndDate,
+      Principal: principal,
+      CurrentAmount: principal,
+    };
+    return {
+      ...loan,
+      MonthlyPayment: getMonthlyPayment(
+        principal,
+        InterestRate,
+        getTerms(loan)
+      ),
+    };
+  });
+
+const investmentArb = fc
+  .record({
+    startYear: fc.integer({ min: 2000, max: 2030 }),
+    startMonth: fc.integer({ min: 0, max: 11 }),
+    startingBalance: fc.integer({ min: 0, max: 1_000_000 }),
+    rateBps: fc.integer({ min: 0, max: 2000 }),
+    compounding: fc.constantFrom(
+      CompoundingFrequency.Monthly,
+      CompoundingFrequency.Quarterly,
+      CompoundingFrequency.Annually
+    ),
+    contribution: fc.integer({ min: 0, max: 5000 }),
+  })
+  .map(
+    ({
+      startYear,
+      startMonth,
+      startingBalance,
+      rateBps,
+      compounding,
+      contribution,
+    }): Investment => ({
+      Id: 'I',
+      Provider: '',
+      Name: '',
+      StartDate: new Date(startYear, startMonth, 1),
+      StartingBalance: startingBalance,
+      AverageReturnRate: rateBps / 100,
+      CompoundingPeriod: compounding,
+      RecurringContribution: contribution,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    })
+  );
+
+describe('Property: amortization schedule invariants', () => {
+  it('payment splits exactly into principal + interest (non-final terms)', () => {
+    fc.assert(
+      fc.property(loanArb, (loan) => {
+        const schedule = generateAmortizationSchedule(loan);
+        const payment = cents(loan.MonthlyPayment ?? 0);
+        // The final term is set to the exact remaining balance, so it is exempt.
+        for (let i = 0; i < schedule.length - 1; i++) {
+          const entry = schedule[i];
+          if (entry.RemainingBalance <= 0) continue; // already paid off
+          expect(
+            cents(entry.PrincipalPayment) + cents(entry.InterestPayment)
+          ).toBe(payment);
+        }
+      })
+    );
+  });
+
+  it('remaining balance is never negative and never increases', () => {
+    fc.assert(
+      fc.property(loanArb, (loan) => {
+        const schedule = generateAmortizationSchedule(loan);
+        let prev = loan.Principal;
+        for (const entry of schedule) {
+          expect(entry.RemainingBalance).toBeGreaterThanOrEqual(0);
+          expect(entry.RemainingBalance).toBeLessThanOrEqual(prev + 1e-6);
+          prev = entry.RemainingBalance;
+        }
+      })
+    );
+  });
+});
+
+describe('Property: forecastLoan invariants', () => {
+  it('balance never goes negative', () => {
+    fc.assert(
+      fc.property(loanArb, (loan) => {
+        const series = forecastLoan(loan, loan.EndDate, 0, loan.StartDate);
+        for (const point of series) {
+          expect(point.Value).toBeGreaterThanOrEqual(0);
+        }
+      })
+    );
+  });
+
+  it('more extra payment never leaves a higher balance at any month', () => {
+    fc.assert(
+      fc.property(loanArb, fc.integer({ min: 1, max: 2000 }), (loan, extra) => {
+        const base = forecastLoan(loan, loan.EndDate, 0, loan.StartDate);
+        const more = forecastLoan(loan, loan.EndDate, extra, loan.StartDate);
+        for (let m = 0; m < base.length; m++) {
+          expect(cents(more[m].Value)).toBeLessThanOrEqual(
+            cents(base[m].Value)
+          );
+        }
+      })
+    );
+  });
+});
+
+describe('Property: forecastInvestment invariants', () => {
+  it('more extra contribution never yields a lower value at any month', () => {
+    fc.assert(
+      fc.property(
+        investmentArb,
+        fc.integer({ min: 1, max: 3000 }),
+        (inv, extra) => {
+          const horizon = new Date(
+            inv.StartDate.getFullYear() + 20,
+            inv.StartDate.getMonth(),
+            1
+          );
+          const base = forecastInvestment(inv, horizon, 0, inv.StartDate);
+          const more = forecastInvestment(inv, horizon, extra, inv.StartDate);
+          for (let m = 0; m < base.length; m++) {
+            expect(cents(more[m].Value)).toBeGreaterThanOrEqual(
+              cents(base[m].Value)
+            );
+          }
+        }
+      )
+    );
+  });
+});
+
+describe('Property: net worth is pointwise additive', () => {
+  it('forecastNetWorth = Σ investments − Σ loans at every month', () => {
+    fc.assert(
+      fc.property(
+        fc.array(loanArb, { maxLength: 3 }),
+        fc.array(investmentArb, { maxLength: 3 }),
+        (loans, investments) => {
+          // Give every entity a unique id so scenario keys do not collide.
+          loans.forEach((l, i) => (l.Id = `loan-${i}`));
+          investments.forEach((inv, i) => (inv.Id = `inv-${i}`));
+          const today = new Date(2024, 0, 1);
+          const horizon = new Date(2034, 0, 1);
+
+          const netWorth = forecastNetWorth(
+            loans,
+            investments,
+            horizon,
+            undefined,
+            today
+          );
+          const loanSeries = loans.map((l) =>
+            forecastLoan(l, horizon, 0, today)
+          );
+          const investmentSeries = investments.map((inv) =>
+            forecastInvestment(inv, horizon, 0, today)
+          );
+
+          for (let m = 0; m < netWorth.length; m++) {
+            const assets = investmentSeries.reduce(
+              (sum, s) => sum + s[m].Value,
+              0
+            );
+            const debts = loanSeries.reduce((sum, s) => sum + s[m].Value, 0);
+            expect(cents(netWorth[m].Value)).toBe(cents(assets - debts));
+          }
+        }
+      )
+    );
+  });
+});
+
+describe('Property: contribution step-ups', () => {
+  it('year 1 is always the base contribution (no step-up yet)', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 100000 }),
+        fc.integer({ min: 0, max: 100000 }),
+        fc.constantFrom(StepUpType.Flat, StepUpType.Percentage),
+        (base, stepUp, type) => {
+          expect(getContributionForYear(base, 1, stepUp, type)).toBe(
+            Math.round(base * 100) / 100
+          );
+        }
+      )
+    );
+  });
+
+  it('a positive step-up is monotonically non-decreasing across years', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 1, max: 100000 }),
+        fc.integer({ min: 1, max: 5000 }),
+        fc.constantFrom(StepUpType.Flat, StepUpType.Percentage),
+        fc.integer({ min: 1, max: 49 }),
+        (base, stepUp, type, year) => {
+          const thisYear = getContributionForYear(base, year, stepUp, type);
+          const nextYear = getContributionForYear(base, year + 1, stepUp, type);
+          expect(nextYear).toBeGreaterThanOrEqual(thisYear);
+        }
+      )
+    );
+  });
+});

--- a/src/helpers/math-reference.test.ts
+++ b/src/helpers/math-reference.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getMonthlyPayment,
+  generateAmortizationSchedule,
+} from './loan-helpers';
+import {
+  generateInvestmentGrowth,
+  getContributionForYear,
+} from './investment-helpers';
+import { Loan } from '../models/loan-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
+
+// Math Correctness Charter §4, layer 1 — Reference (oracle) tests.
+//
+// Every formula is asserted against externally computed values: spreadsheet
+// functions (PMT/IPMT/CUMIPMT/FV) and closed-form hand derivations, with at
+// least two independent reference points per formula and the source cited next
+// to each. Rounding follows PRECISION.md (cents, round-half-up).
+
+const makeLoan = (over: Partial<Loan>): Loan => ({
+  Id: 'L',
+  Provider: '',
+  Name: '',
+  InterestRate: 0,
+  StartDate: new Date(2020, 0, 1),
+  EndDate: new Date(2020, 0, 1),
+  Principal: 0,
+  CurrentAmount: 0,
+  ...over,
+});
+
+const makeInvestment = (over: Partial<Investment>): Investment => ({
+  Id: 'I',
+  Provider: '',
+  Name: '',
+  StartDate: new Date(2020, 0, 1),
+  StartingBalance: 0,
+  AverageReturnRate: 0,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...over,
+});
+
+describe('Reference: loan monthly payment (Excel PMT)', () => {
+  // PMT = P · r / (1 − (1+r)^−n), r = annualRate/12. Independent re-derivation
+  // of the canonical fully-amortizing payment, cross-checked to spreadsheet PMT.
+  const pmtClosedForm = (P: number, annualPct: number, n: number): number => {
+    const r = annualPct / 100 / 12;
+    if (r === 0) return Math.round((P / n) * 100) / 100;
+    const factor = Math.pow(1 + r, n);
+    return Math.round(((P * (r * factor)) / (factor - 1)) * 100) / 100;
+  };
+
+  it('matches Excel PMT(0.035/12, 360, -100000) = 449.04', () => {
+    // Source: Excel/Google Sheets =PMT(0.035/12,360,-100000) → 449.0387… → 449.04
+    expect(getMonthlyPayment(100000, 3.5, 360)).toBe(449.04);
+    expect(getMonthlyPayment(100000, 3.5, 360)).toBe(
+      pmtClosedForm(100000, 3.5, 360)
+    );
+  });
+
+  it('matches Excel PMT(0.06/12, 360, -200000) = 1199.10', () => {
+    // Source: Excel =PMT(0.06/12,360,-200000) → 1199.101… → 1199.10
+    expect(getMonthlyPayment(200000, 6, 360)).toBe(1199.1);
+    expect(getMonthlyPayment(200000, 6, 360)).toBe(
+      pmtClosedForm(200000, 6, 360)
+    );
+  });
+
+  it('matches Excel PMT(0.045/12, 60, -25000) = 466.08 (auto loan)', () => {
+    // Source: Excel =PMT(0.045/12,60,-25000) → 466.076… → 466.08
+    expect(getMonthlyPayment(25000, 4.5, 60)).toBe(466.08);
+    expect(getMonthlyPayment(25000, 4.5, 60)).toBe(
+      pmtClosedForm(25000, 4.5, 60)
+    );
+  });
+
+  it('reduces to principal/terms for a 0% loan', () => {
+    // Closed form: 12000 / 60 = 200.00 exactly (no interest term).
+    expect(getMonthlyPayment(12000, 0, 60)).toBe(200);
+    expect(getMonthlyPayment(12000, 0, 60)).toBe(pmtClosedForm(12000, 0, 60));
+  });
+});
+
+describe('Reference: amortization schedule (hand-derived, IPMT/CUMIPMT)', () => {
+  // A fully hand-derivable loan: $1,000 at 12%/yr (1%/mo) over 3 months.
+  // PMT = =PMT(0.01,3,-1000) = 340.02. Month-by-month by hand:
+  //   m1: interest 1000·0.01 = 10.00, principal 340.02−10.00 = 330.02, bal 669.98
+  //   m2: interest 669.98·0.01 = 6.70,  principal 340.02−6.70 = 333.32, bal 336.66
+  //   m3: interest 336.66·0.01 = 3.37,  principal = remaining 336.66 (final), bal 0.00
+  const loan = makeLoan({
+    InterestRate: 12,
+    StartDate: new Date(2020, 0, 1),
+    EndDate: new Date(2020, 2, 1), // 3 terms
+    Principal: 1000,
+    CurrentAmount: 1000,
+    MonthlyPayment: getMonthlyPayment(1000, 12, 3),
+  });
+  const schedule = generateAmortizationSchedule(loan);
+
+  it('payment equals Excel PMT(0.01, 3, -1000) = 340.02', () => {
+    expect(loan.MonthlyPayment).toBe(340.02);
+  });
+
+  it('reproduces the hand-derived month-by-month schedule exactly', () => {
+    expect(schedule).toEqual([
+      {
+        Term: 1,
+        PrincipalPayment: 330.02,
+        InterestPayment: 10,
+        RemainingBalance: 669.98,
+      },
+      {
+        Term: 2,
+        PrincipalPayment: 333.32,
+        InterestPayment: 6.7,
+        RemainingBalance: 336.66,
+      },
+      {
+        Term: 3,
+        PrincipalPayment: 336.66,
+        InterestPayment: 3.37,
+        RemainingBalance: 0,
+      },
+    ]);
+  });
+
+  it('first-term interest equals IPMT period 1 (= balance × monthly rate)', () => {
+    // Independent reference: =IPMT(0.035/12,1,360,-100000) = 291.67 (= 100000·0.035/12).
+    const m = makeLoan({
+      InterestRate: 3.5,
+      StartDate: new Date(2020, 0, 1),
+      EndDate: new Date(2050, 0, 1),
+      Principal: 100000,
+      CurrentAmount: 100000,
+      MonthlyPayment: getMonthlyPayment(100000, 3.5, 360),
+    });
+    expect(generateAmortizationSchedule(m)[0].InterestPayment).toBe(291.67);
+  });
+
+  it('total interest matches CUMIPMT within last-term rounding', () => {
+    // CUMIPMT closed form for a level-payment loan: n·PMT − P.
+    //   3 · 340.02 − 1000 = 20.06. Our schedule sets the final term to the exact
+    //   remaining balance (PRECISION.md §2), so the lifetime total is 20.07 —
+    //   one cent above the level-payment ideal. Tolerance = that final-term cent.
+    const totalInterest = schedule.reduce((a, e) => a + e.InterestPayment, 0);
+    expect(totalInterest).toBeCloseTo(3 * 340.02 - 1000, 1); // within $0.05
+    expect(Math.round(totalInterest * 100) / 100).toBe(20.07);
+  });
+});
+
+describe('Reference: investment compound growth (Excel FV)', () => {
+  it('lump sum, annual compounding: FV(0.07, 10, 0, -10000) = 19,671.51', () => {
+    // Source: Excel =FV(0.07,10,0,-10000) → 19671.5136… → 19671.51
+    const inv = makeInvestment({
+      StartingBalance: 10000,
+      AverageReturnRate: 7,
+      CompoundingPeriod: CompoundingFrequency.Annually,
+    });
+    const g = generateInvestmentGrowth(inv, new Date(2030, 0, 1));
+    expect(g[g.length - 1].TotalValue).toBe(19671.51);
+    // Closed form cross-check: 10000 · 1.07^10.
+    expect(g[g.length - 1].TotalValue).toBe(
+      Math.round(10000 * Math.pow(1.07, 10) * 100) / 100
+    );
+  });
+
+  it('lump sum, monthly compounding: FV(0.06/12, 12, 0, -10000) = 10,616.78', () => {
+    // Source: Excel =FV(0.06/12,12,0,-10000) → 10616.778… → 10616.78
+    const inv = makeInvestment({
+      StartingBalance: 10000,
+      AverageReturnRate: 6,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    });
+    const g = generateInvestmentGrowth(inv, new Date(2021, 0, 1));
+    expect(g[g.length - 1].TotalValue).toBe(10616.78);
+  });
+
+  it('annuity-due, annual: FV(0.05, 3, -1000, 0, 1) = 3,310.13', () => {
+    // Recurring contributions land at the start of each period (annuity due).
+    // Source: Excel =FV(0.05,3,-1000,0,1) → 3310.125 → 3310.13. Hand check:
+    //   y1: 1000·1.05 = 1050; y2: (1050+1000)·1.05 = 2152.50; y3: (2152.50+1000)·1.05 = 3310.13
+    const inv = makeInvestment({
+      StartingBalance: 0,
+      AverageReturnRate: 5,
+      CompoundingPeriod: CompoundingFrequency.Annually,
+      RecurringContribution: 1000,
+      ContributionFrequency: CompoundingFrequency.Annually,
+    });
+    const g = generateInvestmentGrowth(inv, new Date(2023, 0, 1));
+    expect(g.map((e) => e.TotalValue)).toEqual([0, 1050, 2152.5, 3310.13]);
+  });
+});
+
+describe('Reference: contribution step-ups (closed form)', () => {
+  it('flat step-up adds a fixed amount per elapsed year', () => {
+    // Year 3 of $500 base with $100/yr flat step-up: 500 + 100·(3−1) = 700.
+    expect(getContributionForYear(500, 3, 100, StepUpType.Flat)).toBe(700);
+    // Year 1 never steps up.
+    expect(getContributionForYear(500, 1, 100, StepUpType.Flat)).toBe(500);
+  });
+
+  it('percentage step-up compounds per elapsed year', () => {
+    // Year 3 of $1000 base with 10%/yr step-up: 1000 · 1.10^(3−1) = 1210.
+    expect(getContributionForYear(1000, 3, 10, StepUpType.Percentage)).toBe(
+      1210
+    );
+    // Year 2: 1000 · 1.10^1 = 1100.
+    expect(getContributionForYear(1000, 2, 10, StepUpType.Percentage)).toBe(
+      1100
+    );
+  });
+});

--- a/src/hooks/use-field-tracking.ts
+++ b/src/hooks/use-field-tracking.ts
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { ValidationResult } from './validation-helpers';
+import { ValidationResult } from '../helpers/validation-helpers';
 
 // Shared form-field reveal/tracking for the add/edit forms (roadmap 0.8).
 //

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -28,7 +28,7 @@ import {
   validateInvestment,
 } from '../helpers/validation-helpers';
 import { fieldHelperText } from '../components/field-helper-text';
-import { useFieldTracking } from '../helpers/use-field-tracking';
+import { useFieldTracking } from '../hooks/use-field-tracking';
 
 export const AddEditInvestment = (props: AddEditInvestmentProps) => {
   const [newInvestment, setNewInvestment] =

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -24,7 +24,7 @@ import {
   validateLoan,
 } from '../helpers/validation-helpers';
 import { fieldHelperText } from '../components/field-helper-text';
-import { useFieldTracking } from '../helpers/use-field-tracking';
+import { useFieldTracking } from '../hooks/use-field-tracking';
 
 export const AddEditLoan = (props: AddEditLoanProps) => {
   const [newLoan, setNewLoan] = useState<Loan>(emptyLoan);

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -8,10 +8,10 @@
   "htmlReporter": {
     "fileName": "reports/mutation/index.html"
   },
-  "_thresholds_comment": "break is a conservative floor so the scheduled run reports a score rather than flaking red; the Charter target is zero surviving mutants, so ratchet break upward as survivors are triaged.",
+  "_thresholds_comment": "Baseline established 2026-06-13 (first full run): overall mutation score 85.33% (844 killed / 147 survived / 11 timeout, 0 no-coverage). Per file: id-helpers 100, loan-helpers 89.6, data-helpers 86.3, investment-helpers 85.2, forecast-helpers 85.1, validation-helpers 82.7, format-helpers 73.3. break is set just below that baseline so the weekly run fails on a regression (giving the layer teeth per §4) without flaking; ratchet break upward toward the Charter's zero-survivors target as survivors are triaged (open-ended triage tracked in ROADMAP §8.1).",
   "thresholds": {
     "high": 90,
     "low": 80,
-    "break": 70
+    "break": 80
   }
 }

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
+  "_comment": "Math Correctness Charter §4: mutation testing over the math core. Coverage proves the lines ran; mutation testing proves the tests would actually catch a flipped sign or off-by-one. Run on a schedule / pre-release (npm run test:mutation), not on every PR. Surviving mutants are triaged to zero or explicitly waived with a comment.",
+  "testRunner": "vitest",
+  "coverageAnalysis": "perTest",
+  "mutate": ["src/helpers/**/*.ts", "!src/helpers/**/*.test.ts"],
+  "reporters": ["html", "clear-text", "progress"],
+  "htmlReporter": {
+    "fileName": "reports/mutation/index.html"
+  },
+  "_thresholds_comment": "break is a conservative floor so the scheduled run reports a score rather than flaking red; the Charter target is zero surviving mutants, so ratchet break upward as survivors are triaged.",
+  "thresholds": {
+    "high": 90,
+    "low": 80,
+    "break": 70
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
+import { configDefaults } from 'vitest/config';
 import { createRequire } from 'node:module';
 
 // Read the app version straight from package.json so the footer shows the right
@@ -21,6 +22,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Keep the default ignores and also skip generated dirs — notably the
+    // Stryker sandbox, whose copied *.test.ts files would otherwise be
+    // discovered and double-counted during a local mutation run.
+    exclude: [...configDefaults.exclude, '**/.stryker-tmp/**', 'coverage/**'],
     coverage: {
       // Math Correctness Charter §4 enforcement: the math core is held to a
       // hard 100% line+branch gate (UI gets pragmatic targets in Phase 6). The

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,22 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    coverage: {
+      // Math Correctness Charter §4 enforcement: the math core is held to a
+      // hard 100% line+branch gate (UI gets pragmatic targets in Phase 6). The
+      // scope is the pure helpers only; test files, type-only models, and the
+      // relocated React hook are out of scope by construction.
+      provider: 'v8',
+      include: ['src/helpers/**/*.ts'],
+      exclude: ['src/helpers/**/*.test.ts'],
+      reporter: ['text', 'html'],
+      thresholds: {
+        lines: 100,
+        branches: 100,
+        functions: 100,
+        statements: 100,
+      },
+    },
   },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } as any);


### PR DESCRIPTION
## Summary

Implements roadmap item **0.11 — the Math Verification Suite**, the final Phase 0 work item and the **gate before Phase 2** puts numbers in front of users. This makes the Math Correctness Charter (§4) executable: every verification layer, the 100% coverage gate, mutation testing, and the D7 core/UI boundary. One commit per subsection (the roadmap's suggested split, chunked into one PR).

Test suite grew **235 → 288**; `src/helpers/**` is at **100% line + branch + function** coverage; lint, format, and build green at every step.

| Commit | Subsection | What it does |
| --- | --- | --- |
| `dda3e2c` | **D7 boundary + hook move** | ESLint `no-restricted-imports` rules scope `src/helpers/**` and `src/models/**` to a framework-free core — no `react`, `react-dom`, `@mui/*`, `@emotion/*`, `react-number-format`, or `*.tsx` (UI component) imports. The lone offender, `useFieldTracking` (a React hook living in `helpers/`), moves to `src/hooks/`. The boundary is now a build failure, not a convention. |
| `9ee0e13` | **Verification suite + precision policy** | Charter layers 1–5: `math-reference.test.ts` (oracle tests vs Excel PMT/IPMT/CUMIPMT/FV and a hand-derived schedule, sources cited), `forecast-consistency.test.ts` (engine reproduces the schedule helpers to the cent), `math-properties.test.ts` (fast-check invariants), `math-edge-cases.test.ts` (leap days, month-end rollover, negative amortization, 600+-month float accumulation, …), and `PRECISION.md` (the one documented rounding/consistency policy). Adds `fast-check`. |
| `0b54022` | **Coverage gate** | v8 coverage scoped to `src/helpers/**` with a hard **100% line+branch threshold** wired into CI (`npm run test:coverage`). Closes the gaps with `defensive-guards.test.ts` rather than weakening the helpers; a few behavior-preserving cleanups remove genuinely dead branches. |
| `4c4931d` | **Mutation testing + docs** | `stryker.config.json` + a **weekly** `mutation.yml` workflow (off the per-PR path; uploads the HTML report). Updates `copilot-instructions.md` with the boundary, the Charter standard, and the new `src/hooks/` location. |

## Verification layers (Charter §4)

1. **Reference (oracle)** — ≥2 independent points per formula, each citing its spreadsheet/closed-form source.
2. **Cross-implementation consistency** — `forecastLoan` reproduces `generateAmortizationSchedule` month-for-month to the cent; `forecastInvestment` matches `generateInvestmentGrowth` to the cent at every compounding boundary.
3. **Property/invariant** (fast-check) — money conservation in cents, non-negative balances, monotonic extra payments/contributions, pointwise net-worth additivity, step-up monotonicity.
4. **Edge-case catalog** — leap-day anniversaries, month-end rollover, zero/extreme rates, one-month terms, negative amortization, horizon=today / mid-month / 50-year.
5. **Precision policy** — `PRECISION.md`: cents, round-half-up, where each module rounds; exact `toBe` where defined, every `toBeCloseTo` justified.

## A finding worth flagging

The cross-implementation tests surfaced a **genuine divergence**: with yearly **step-ups** enabled, the two investment engines attribute an on-anniversary contribution to different year numbers (an off-by-one). Without step-ups they are identical to the cent, so it is purely a step-up *timing* question. It is documented in `PRECISION.md` §4 and the consistency suite asserts only the provably-exact no-step-up cases. Per the Charter's process rule, reconciling it should ship as its own PR with a failing regression test landed before the fix — I did **not** silently change forecast behavior here.

## Notes for review

- No user-facing behavior change; version stays `0.7.0` (the Phase 0 target). The `investment-helpers` tweaks (dead-branch removal, hoisting a redundant `|| 0`) are behavior-preserving and covered by the existing suite.
- New dev deps only: `fast-check`, `@vitest/coverage-v8`, `@stryker-mutator/core` + `vitest-runner`. `npm ci` verified clean under both npm 10 and npm 11 (Node 24).
- The 100% bar is the math core only; UI keeps pragmatic targets (Phase 6), per the Charter.
- **With this merged, Phase 0 is complete** — Phase 1 (persistence, #20) and Phase 2 (charts, #18) are unblocked, and the chart numbers now sit on a verified engine.

https://claude.ai/code/session_013L3NNdNfJM14L9KAnKkG5x

---
_Generated by [Claude Code](https://claude.ai/code/session_013L3NNdNfJM14L9KAnKkG5x)_