### PR TITLE
fix(ui): make Add buttons readable in light mode

### DIFF
--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -39,6 +39,18 @@ type UndoableDelete =
 
 const DELETE_UNDO_DURATION_MS = 6000;
 
+// Command-bar primary actions ("Add Loan" / "Add Investment"): solid white
+// buttons with deep brand-green text. Styled explicitly rather than via
+// `color="inherit"` — a contained inherit button takes its TEXT color from the
+// AppBar (white) but its background from `grey[300]`, rendering white-on-light-
+// grey and unreadable in light mode. White surface + green text stays
+// high-contrast against the deep-green pill in both color schemes.
+const addActionSx = {
+  bgcolor: 'common.white',
+  color: 'primary.dark',
+  '&:hover': { bgcolor: 'grey.200' },
+} as const;
+
 export const Body = () => {
   const {
     state: { loans, investments, sampleDataLoaded },
@@ -160,23 +172,23 @@ export const Body = () => {
     <Container>
       <AppBar>
         {/* Command bar (roadmap 0.10): the two "Add" actions are the primary
-            actions — `contained color="inherit"` renders them as solid light
-            buttons that contrast against the brand-blue pill in both light and
-            dark mode. DataManager's import/export are secondary (text variant
-            with icons + tooltips). The dark-mode toggle is pushed to the right
-            with `marginLeft: 'auto'`; on narrow viewports the Toolbar wraps
-            cleanly (theme `MuiToolbar` flexWrap/gap). */}
+            actions — solid white buttons with deep brand-green text (see
+            `addActionSx`) so they stay readable against the deep-green pill in
+            both light and dark mode. DataManager's import/export are secondary
+            (text variant with icons + tooltips). The dark-mode toggle is pushed
+            to the right with `marginLeft: 'auto'`; on narrow viewports the
+            Toolbar wraps cleanly (theme `MuiToolbar` flexWrap/gap). */}
         <Toolbar>
           <Button
             variant="contained"
-            color="inherit"
+            sx={addActionSx}
             onClick={() => onLoanAddEdit()}
           >
             Add Loan
           </Button>
           <Button
             variant="contained"
-            color="inherit"
+            sx={addActionSx}
             onClick={() => onInvestmentAddEdit()}
           >
             Add Investment


### PR DESCRIPTION
## Summary

The command-bar **Add Loan** / **Add Investment** buttons were unreadable in **light mode** — light/white text on a near-white surface.

## Root cause

Both buttons used `variant="contained" color="inherit"`. On a *contained* button, `color="inherit"` takes the **text** color from the surrounding AppBar — which the theme sets to `#ffffff` — but the **background** from MUI's `grey[300]`. Result: white text on light-grey (~1.3:1 contrast). Dark mode uses `grey[800]`, which is why the bug only showed in light mode.

## Fix

`src/Body.tsx` — style the two CTAs explicitly as solid **white buttons with deep brand-green text** (`primary.dark`) via a shared `addActionSx`:

```jsx
const addActionSx = {
  bgcolor: 'common.white',
  color: 'primary.dark',
  '&:hover': { bgcolor: 'grey.200' },
};
```

This gives ~12:1 contrast (dark-green on white) and reads as a crisp white CTA against the deep-green AppBar pill in **both** light and dark mode — the look the original comment intended before `color="inherit"` quietly whitened the text too. The stale comment is corrected. Scope is just those two buttons (Upload/Export are text buttons; Clear/Undo sit on light Alerts).

## Verification

- `npm run check:lint` — clean
- `npm run check:format` — clean
- `npm run build` — succeeds
- `npm test` — 302 passed (no math/helper code touched)

Visual: white CTA with deep-green label on the green pill, readable in light and dark mode.

https://claude.ai/code/session_01PQgbuH5Q3JXi4ewCpKCbTf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQgbuH5Q3JXi4ewCpKCbTf)_