### PR TITLE
Roadmap implementation — Phases 1–4 complete (v0.8.0–v0.11.0); Phase 5 started

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,8 @@ src/
 │   ├── loan-helpers.ts
 │   ├── investment-helpers.ts
 │   ├── forecast-helpers.ts
+│   ├── storage-helpers.ts       # On-device persistence I/O (save/load/clear, issue #20)
+│   ├── migrate-helpers.ts       # D8 versioned schema-migration ladder
 │   ├── *.test.ts             # Co-located unit tests
 │   ├── math-reference.test.ts    # Charter layer 1: oracle tests (Excel/hand-derived)
 │   ├── forecast-consistency.test.ts # Charter layer 2: engine-vs-schedule
@@ -36,6 +38,9 @@ src/
 │   ├── math-edge-cases.test.ts   # Charter layer 4: edge catalog
 │   └── PRECISION.md              # Charter layer 5: rounding & consistency policy
 ├── hooks/               # Reusable React hooks (UI state, e.g. use-field-tracking)
+├── persistence/         # "Save on this device" toggle + usePersistence hook (Phase 1)
+├── data-manager/        # JSON import/export command-bar actions
+├── state/               # Finance-data context + reducer (D2)
 ├── loan/                # Loan-related components
 │   ├── loan-table.tsx
 │   ├── add-edit-loan.tsx

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,6 +39,7 @@ src/
 │   └── PRECISION.md              # Charter layer 5: rounding & consistency policy
 ├── hooks/               # Reusable React hooks (UI state, e.g. use-field-tracking)
 ├── chart/               # Forecast LineChart, legend, time-range, table fallback (Phase 2)
+├── dashboard/           # Net-worth summary cards, milestones, assumptions panel (Phase 3)
 ├── persistence/         # "Save on this device" toggle + usePersistence hook (Phase 1)
 ├── data-manager/        # JSON import/export command-bar actions
 ├── state/               # Finance-data context + reducer (D2)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,7 @@ src/
 ├── hooks/               # Reusable React hooks (UI state, e.g. use-field-tracking)
 ├── chart/               # Forecast LineChart, legend, time-range, table fallback (Phase 2)
 ├── dashboard/           # Net-worth summary cards, milestones, assumptions panel (Phase 3)
+├── scenario/            # Scenario builder dialog, bar, impact summary (Phase 4)
 ├── persistence/         # "Save on this device" toggle + usePersistence hook (Phase 1)
 ├── data-manager/        # JSON import/export command-bar actions
 ├── state/               # Finance-data context + reducer (D2)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ src/
 │   ├── math-edge-cases.test.ts   # Charter layer 4: edge catalog
 │   └── PRECISION.md              # Charter layer 5: rounding & consistency policy
 ├── hooks/               # Reusable React hooks (UI state, e.g. use-field-tracking)
+├── chart/               # Forecast LineChart, legend, time-range, table fallback (Phase 2)
 ├── persistence/         # "Save on this device" toggle + usePersistence hook (Phase 1)
 ├── data-manager/        # JSON import/export command-bar actions
 ├── state/               # Finance-data context + reducer (D2)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Everything runs in your browser. There's **no backend, no account, and no tracki
 - 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, and overall net worth onto a single shared timeline.
 - 📉 **Interactive forecast chart** — a line per position plus an overall net-worth line, with a show/hide legend, 5Y/10Y/30Y/Full range control, and an accessible "view as table" fallback.
 - 🧮 **Net worth dashboard** — at-a-glance total assets, debt, net worth, and monthly commitments, plus milestone callouts (debt-free date, net worth at +5/+10/+30 years).
+- 🔮 **What-if scenarios** — model extra monthly payments/contributions, overlay them on the chart as dotted lines, and see the impact (net worth at horizon, interest saved, debt-free date moved up).
 - 💾 **On-device persistence** — opt in to "Save on this device" and your data survives a refresh, stored only in your browser's local storage; turning it off clears it.
 - 🔁 **Import / export** — back up and restore your data as JSON, with ID-based smart merge and validation on import.
 - 🌗 **Light & dark mode** — a full Material UI theme with a persisted color-mode toggle.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Everything runs in your browser. There's **no backend, no account, and no tracki
 - 📈 **Investment modeling** — configurable compounding frequencies, recurring contributions, and yearly step-ups (flat or percentage), with a projected-growth schedule.
 - 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, and overall net worth onto a single shared timeline.
 - 📉 **Interactive forecast chart** — a line per position plus an overall net-worth line, with a show/hide legend, 5Y/10Y/30Y/Full range control, and an accessible "view as table" fallback.
+- 🧮 **Net worth dashboard** — at-a-glance total assets, debt, net worth, and monthly commitments, plus milestone callouts (debt-free date, net worth at +5/+10/+30 years).
 - 💾 **On-device persistence** — opt in to "Save on this device" and your data survives a refresh, stored only in your browser's local storage; turning it off clears it.
 - 🔁 **Import / export** — back up and restore your data as JSON, with ID-based smart merge and validation on import.
 - 🌗 **Light & dark mode** — a full Material UI theme with a persisted color-mode toggle.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Everything runs in your browser. There's **no backend, no account, and no tracki
 - 🏦 **Loan modeling** — auto-calculated monthly payment, full amortization schedule, and a point-in-time view of any loan on any date.
 - 📈 **Investment modeling** — configurable compounding frequencies, recurring contributions, and yearly step-ups (flat or percentage), with a projected-growth schedule.
 - 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, and overall net worth onto a single shared timeline.
+- 💾 **On-device persistence** — opt in to "Save on this device" and your data survives a refresh, stored only in your browser's local storage; turning it off clears it.
 - 🔁 **Import / export** — back up and restore your data as JSON, with ID-based smart merge and validation on import.
 - 🌗 **Light & dark mode** — a full Material UI theme with a persisted color-mode toggle.
 - 📱 **Responsive** — data tables on desktop, cards on mobile.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Everything runs in your browser. There's **no backend, no account, and no tracki
 - 🏦 **Loan modeling** — auto-calculated monthly payment, full amortization schedule, and a point-in-time view of any loan on any date.
 - 📈 **Investment modeling** — configurable compounding frequencies, recurring contributions, and yearly step-ups (flat or percentage), with a projected-growth schedule.
 - 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, and overall net worth onto a single shared timeline.
+- 📉 **Interactive forecast chart** — a line per position plus an overall net-worth line, with a show/hide legend, 5Y/10Y/30Y/Full range control, and an accessible "view as table" fallback.
 - 💾 **On-device persistence** — opt in to "Save on this device" and your data survives a refresh, stored only in your browser's local storage; turning it off clears it.
 - 🔁 **Import / export** — back up and restore your data as JSON, with ID-based smart merge and validation on import.
 - 🌗 **Light & dark mode** — a full Material UI theme with a persisted color-mode toggle.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@
 **The destination** (in priority order):
 
 1. See all loans and investments in one place _(done)_
-2. Persist data so it survives a refresh _(issue #20)_
+2. Persist data so it survives a refresh _(issue #20 — done, Phase 1)_
 3. Visualize every position and overall net worth over time _(issue #18)_
 4. Overlay what-if scenarios on those projections _(issue #24)_
 5. **Answer the money question directly**: given $X extra per month, rank allocations — all-in-one _and_ splits across multiple loans/investments — by long-term net worth impact _(the original reason this app exists — not yet an issue)_
@@ -167,9 +167,13 @@ Remaining math-quality follow-ups (step-up reconciliation, dayjs migration, muta
 
 ---
 
-### Phase 1 — Local Persistence — issue #20 (target v0.8.0)
+### Phase 1 — Local Persistence — issue #20 — ✅ COMPLETE (v0.8.0)
 
-_Highest value-to-effort ratio in the backlog; independent of charts._
+_Highest value-to-effort ratio in the backlog; independent of charts. All four
+items shipped: `storage-helpers` + the D8 migration ladder, the "Save on this
+device" toggle (hydrate / debounced auto-save / clear-on-disable / persisted
+preference), the first-visit privacy notice, and the global error boundary with
+an export-my-data escape hatch._
 
 | #   | Work item                                                                                                                                                     | Notes / acceptance                                                                                                                                    |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -349,8 +353,8 @@ Phase 0  Foundations + UX overhaul        ✅ DONE     v0.7.0
          (engine, context, CI, dep modernization,
           theme/dark mode, dialogs, validation, empty states,
           math verification suite + correctness sweep — gate for Phase 2)
-   ├── Phase 1  Persistence (#20)         ← next      v0.8.0   (independent of 2)
-   └── Phase 2  Charts (#18)                          v0.9.0
+   ├── Phase 1  Persistence (#20)         ✅ DONE     v0.8.0   (independent of 2)
+   └── Phase 2  Charts (#18)              ← next      v0.9.0
            └── Phase 3  Dashboard                     v0.10.0
                    └── Phase 4  Scenarios (#24)       v0.11.0
                            └── Phase 5  Optimizer     v1.0.0

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@
 
 1. See all loans and investments in one place _(done)_
 2. Persist data so it survives a refresh _(issue #20 — done, Phase 1)_
-3. Visualize every position and overall net worth over time _(issue #18)_
+3. Visualize every position and overall net worth over time _(issue #18 — done, Phase 2)_
 4. Overlay what-if scenarios on those projections _(issue #24)_
 5. **Answer the money question directly**: given $X extra per month, rank allocations — all-in-one _and_ splits across multiple loans/investments — by long-term net worth impact _(the original reason this app exists — not yet an issue)_
 
@@ -184,9 +184,9 @@ an export-my-data escape hatch._
 
 ---
 
-### Phase 2 — Visualizations — issue #18 (target v0.9.0)
+### Phase 2 — Visualizations — issue #18 — ✅ COMPLETE (v0.9.0)
 
-_The app's centerpiece view. Depends on Phase 0 (engine, context) — and on 0.11, since these charts are the first place users will see the math._
+_The app's centerpiece view. Depends on Phase 0 (engine, context) — and on 0.11, since these charts are the first place users will see the math. Shipped: D1 confirmed (`@mui/x-charts` v9), a `forecast-series` builder whose net-worth line equals `forecastNetWorth` (Charter consistency), the forecast chart section with per-entity + net-worth lines, stable Id-derived colors, an interactive show/hide legend, a 5Y/10Y/30Y/Full time-range control, responsive mobile height, and an accessible "view as table" fallback._
 
 | #   | Work item                                                                                                                                               | Notes / acceptance                                                                                                                                                                                                                                                                |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -354,8 +354,8 @@ Phase 0  Foundations + UX overhaul        ✅ DONE     v0.7.0
           theme/dark mode, dialogs, validation, empty states,
           math verification suite + correctness sweep — gate for Phase 2)
    ├── Phase 1  Persistence (#20)         ✅ DONE     v0.8.0   (independent of 2)
-   └── Phase 2  Charts (#18)              ← next      v0.9.0
-           └── Phase 3  Dashboard                     v0.10.0
+   └── Phase 2  Charts (#18)              ✅ DONE     v0.9.0
+           └── Phase 3  Dashboard         ← next      v0.10.0
                    └── Phase 4  Scenarios (#24)       v0.11.0
                            └── Phase 5  Optimizer     v1.0.0
 Phase 6  Quality items slot in anywhere

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -300,14 +300,14 @@ Declared explicitly so future feature debates have a reference point:
 
 #### H3 — The full net worth picture
 
-| Feature                                    | What & why                                                                                                                                                                                            | Builds on                       |
-| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
-| ★ **Cash accounts (HYSA/CD/checking)**     | Trivial model (balance + APY), big completeness win — most people's net worth includes cash the app currently can't hold.                                                                             | New simple asset type           |
-| ★ **Property + mortgage pairing**          | Home value with an appreciation rate, linked to its mortgage → a **home equity** series on the chart. Makes the net worth line honest for homeowners (currently a mortgage counts as pure liability). | New asset type + entity linking |
-| **Pensions / Social Security / annuities** | Future income streams starting at a date — matters enormously for the retirement-horizon view.                                                                                                        | New income-stream type          |
-| **Custom asset/liability**                 | Catch-all with a simple growth/decline rate: car (depreciating), private loan to a friend, collectibles. Escape hatch so nobody's net worth is blocked on a missing type.                             | New generic type                |
-| **Asset appreciation & enhancement**       | Model scenarios where an existing asset appreciates or is enhanced: add a pool/deck to your house (estimated cost and property value increase), refinish a car, renovation ROI. Pairs with property pairing to answer "is this investment worth it?"                                            | Property model + scenario engine |
-| _(exploratory)_ **Investment context & research** | Optional linked research, news, or articles relevant to holdings — seeded from the investment type/sector but never real-time market data. Shows "Apple news relevant to your AAPL holdings" without requiring data feeds.                                                                       | Investment model               |
+| Feature                                           | What & why                                                                                                                                                                                                                                           | Builds on                        |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| ★ **Cash accounts (HYSA/CD/checking)**            | Trivial model (balance + APY), big completeness win — most people's net worth includes cash the app currently can't hold.                                                                                                                            | New simple asset type            |
+| ★ **Property + mortgage pairing**                 | Home value with an appreciation rate, linked to its mortgage → a **home equity** series on the chart. Makes the net worth line honest for homeowners (currently a mortgage counts as pure liability).                                                | New asset type + entity linking  |
+| **Pensions / Social Security / annuities**        | Future income streams starting at a date — matters enormously for the retirement-horizon view.                                                                                                                                                       | New income-stream type           |
+| **Custom asset/liability**                        | Catch-all with a simple growth/decline rate: car (depreciating), private loan to a friend, collectibles. Escape hatch so nobody's net worth is blocked on a missing type.                                                                            | New generic type                 |
+| **Asset appreciation & enhancement**              | Model scenarios where an existing asset appreciates or is enhanced: add a pool/deck to your house (estimated cost and property value increase), refinish a car, renovation ROI. Pairs with property pairing to answer "is this investment worth it?" | Property model + scenario engine |
+| _(exploratory)_ **Investment context & research** | Optional linked research, news, or articles relevant to holdings — seeded from the investment type/sector but never real-time market data. Shows "Apple news relevant to your AAPL holdings" without requiring data feeds.                           | Investment model                 |
 
 #### H4 — From calculator to plan
 
@@ -321,10 +321,10 @@ Declared explicitly so future feature debates have a reference point:
 
 #### H4b — Multi-scenario forecasting templates
 
-| Feature                             | What & why                                                                                                                                                                                                                                                                                              | Builds on                                    |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| **Allocation strategy presets**      | Pre-built scenario templates that embody different financial philosophies: **debt-focused** (aggressive loan payoff, minimal investing), **invest-focused** (minimum debt payments, maximal contributions), **balanced** (split optimally by rate), and **custom** (user-defined split). Each shows its long-term net worth impact vs. baseline. | Phase 4 scenarios + Phase 5 optimizer        |
-| **Strategy comparison view**         | Side-by-side dashboard comparing all strategies: projected net worth at +5y/+10y/+30y, debt-free date, final asset allocation. Helps users see which philosophy aligns with their values and goals.                                                                                                     | Forecast engine + dashboard                  |
+| Feature                         | What & why                                                                                                                                                                                                                                                                                                                                       | Builds on                             |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| **Allocation strategy presets** | Pre-built scenario templates that embody different financial philosophies: **debt-focused** (aggressive loan payoff, minimal investing), **invest-focused** (minimum debt payments, maximal contributions), **balanced** (split optimally by rate), and **custom** (user-defined split). Each shows its long-term net worth impact vs. baseline. | Phase 4 scenarios + Phase 5 optimizer |
+| **Strategy comparison view**    | Side-by-side dashboard comparing all strategies: projected net worth at +5y/+10y/+30y, debt-free date, final asset allocation. Helps users see which philosophy aligns with their values and goals.                                                                                                                                              | Forecast engine + dashboard           |
 
 #### H5 — Beyond the calculator
 
@@ -343,10 +343,10 @@ Declared explicitly so future feature debates have a reference point:
 
 #### Suggested post-1.0 sequencing
 
-| Release | Theme                  | Contents                                                                      |
-| ------- | ---------------------- | ----------------------------------------------------------------------------- |
+| Release | Theme                  | Contents                                                                     |
+| ------- | ---------------------- | ---------------------------------------------------------------------------- |
 | v1.1    | **Come back monthly**  | Balance check-ins + goals (H4★)                                              |
-| v1.2    | **Whole net worth**    | Cash accounts + property/home equity + appreciation scenarios (H3★)           |
+| v1.2    | **Whole net worth**    | Cash accounts + property/home equity + appreciation scenarios (H3★)          |
 | v1.3    | **Better answers**     | Employer match, lump sums, refinance comparison + strategy presets (H1★/H4b) |
 | v1.4    | **Honest uncertainty** | Monte Carlo fan charts + investment context (H2 / H3)                        |
 | v2.0    | **Beyond personal**    | Household profiles + shareable links (H5)                                    |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@
 1. See all loans and investments in one place _(done)_
 2. Persist data so it survives a refresh _(issue #20 — done, Phase 1)_
 3. Visualize every position and overall net worth over time _(issue #18 — done, Phase 2)_
-4. Overlay what-if scenarios on those projections _(issue #24)_
+4. Overlay what-if scenarios on those projections _(issue #24 — done, Phase 4)_
 5. **Answer the money question directly**: given $X extra per month, rank allocations — all-in-one _and_ splits across multiple loans/investments — by long-term net worth impact _(the original reason this app exists — not yet an issue)_
 
 ---
@@ -110,7 +110,7 @@ Same philosophy as D2: take the architectural discipline now, skip the speculati
 
 ### D8 — One versioned schema-migration ladder
 
-_Status: pending — lands with the first persistence work (Phase 1)._
+_Status: ✅ seeded in Phase 1 (single-version gate); first real migration step (v2 → v3, scenarios) landed in Phase 4.5, and JSON import now routes through the ladder._
 
 The persisted schema bumps at least four times across the plan (export v2 in D5, scenarios in 4.5, snapshots in H4, multi-profile in H5). Rather than each reader carrying its own pairwise "accept v_n" backward-compat branch, define a single `schemaVersion`-keyed `migrate(data): CurrentSchema` step ladder that **every** entry point runs through — JSON import (D5), `localStorage` hydration (D4), and every future bump. Each new version adds exactly one migration step, tested to the same standard as the import validator, so old exports and stale `localStorage` upgrade forward deterministically instead of becoming a combinatorial compatibility hazard. Lands with the first persistence work (Phase 1), where stored data first has to survive a version change.
 
@@ -212,9 +212,9 @@ _Makes the app's stated purpose — net worth — visible at a glance. Shipped: 
 
 ---
 
-### Phase 4 — Scenario Forecasting — issue #24 (target v0.11.0)
+### Phase 4 — Scenario Forecasting — issue #24 — ✅ COMPLETE (v0.11.0)
 
-_The what-if layer. Depends on Phases 0 (engine scenario API) and 2 (chart)._
+_The what-if layer. Shipped: a named-scenario model + reducer state, a scenario builder dialog and selector bar, dotted color-matched chart overlays (originals retained) with a scenario net-worth line, a scenario impact summary (net worth at horizon, interest saved, payoff moved up), and persistence of scenarios via export schema **v3** — the first real D8 migration (v2 → v3), through which JSON import now routes._
 
 | #   | Work item                                                                                                                                  | Notes / acceptance                                                                 |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
@@ -356,8 +356,8 @@ Phase 0  Foundations + UX overhaul        ✅ DONE     v0.7.0
    ├── Phase 1  Persistence (#20)         ✅ DONE     v0.8.0   (independent of 2)
    └── Phase 2  Charts (#18)              ✅ DONE     v0.9.0
            └── Phase 3  Dashboard         ✅ DONE     v0.10.0
-                   └── Phase 4  Scenarios (#24)  ← next   v0.11.0
-                           └── Phase 5  Optimizer     v1.0.0
+                   └── Phase 4  Scenarios (#24)  ✅ DONE  v0.11.0
+                           └── Phase 5  Optimizer  ← next   v1.0.0
 Phase 6  Quality items slot in anywhere
 Phase 7  Future horizons queue up post-1.0 (v1.1 → v2.0 sequencing in §Phase 7)
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -199,9 +199,9 @@ _The app's centerpiece view. Depends on Phase 0 (engine, context) — and on 0.1
 
 ---
 
-### Phase 3 — Net Worth Dashboard (target v0.10.0)
+### Phase 3 — Net Worth Dashboard — ✅ COMPLETE (v0.10.0)
 
-_Makes the app's stated purpose — net worth — visible at a glance. Small phase; could merge into Phase 2 if momentum allows._
+_Makes the app's stated purpose — net worth — visible at a glance. Shipped: summary cards (total assets / debt / net worth / monthly commitments at the engine's today-anchor), milestone callouts (debt-free date + net worth at +5y/+10y/+30y), table upgrades (sortable headers with meaningful defaults, totals rows, loan payoff/current-balance columns + principal-paid progress, per-entity clone), and the stated-assumptions panel._
 
 | #   | Work item                                                                                                                                                                                                                       | Notes / acceptance                                                                                                                                                                     |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -355,8 +355,8 @@ Phase 0  Foundations + UX overhaul        ✅ DONE     v0.7.0
           math verification suite + correctness sweep — gate for Phase 2)
    ├── Phase 1  Persistence (#20)         ✅ DONE     v0.8.0   (independent of 2)
    └── Phase 2  Charts (#18)              ✅ DONE     v0.9.0
-           └── Phase 3  Dashboard         ← next      v0.10.0
-                   └── Phase 4  Scenarios (#24)       v0.11.0
+           └── Phase 3  Dashboard         ✅ DONE     v0.10.0
+                   └── Phase 4  Scenarios (#24)  ← next   v0.11.0
                            └── Phase 5  Optimizer     v1.0.0
 Phase 6  Quality items slot in anywhere
 Phase 7  Future horizons queue up post-1.0 (v1.1 → v2.0 sequencing in §Phase 7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "finance-calculator",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",
         "@mui/icons-material": "^9.1.1",
         "@mui/material": "^9.1.1",
+        "@mui/x-charts": "^9.5.0",
         "@mui/x-date-pickers": "^9.5.0",
         "dayjs": "^1.11.13",
         "prettier": "^3.4.1",
@@ -1643,6 +1644,106 @@
         }
       }
     },
+    "node_modules/@mui/x-charts": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts/-/x-charts-9.5.0.tgz",
+      "integrity": "sha512-+MCvqdBuGBCrRCcUOLx3d2Uc5QRtelaoFHEQyreJsuC5+mmhmkamj6sj5nqZzQ3YhPXHiGYPC7wKnvOvbHwJMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@mui/utils": "9.0.1",
+        "@mui/x-charts-vendor": "^9.4.0",
+        "@mui/x-internal-gestures": "^9.3.0",
+        "@mui/x-internals": "^9.1.0",
+        "bezier-easing": "^3.0.0",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^5.2.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.9.0",
+        "@emotion/styled": "^11.8.1",
+        "@mui/material": "^7.3.0 || ^9.0.0",
+        "@mui/system": "^7.3.0 || ^9.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/x-charts-vendor": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-charts-vendor/-/x-charts-vendor-9.4.0.tgz",
+      "integrity": "sha512-1/p3RmRPGlzCtvpWwjwBCRoxJW1eDoQdml8MWq71Q1Oq0n36mTkFjzPTbcaJ52jigIIIQrMloqTUkhmEXwwBMg==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "@types/d3-array": "^3.2.2",
+        "@types/d3-color": "^3.1.3",
+        "@types/d3-format": "^3.0.4",
+        "@types/d3-geo": "^3.1.0",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-path": "^3.1.1",
+        "@types/d3-scale": "^4.0.9",
+        "@types/d3-shape": "^3.1.8",
+        "@types/d3-time": "^3.0.4",
+        "@types/d3-time-format": "^4.0.3",
+        "@types/d3-timer": "^3.0.2",
+        "d3-array": "^3.2.4",
+        "d3-color": "^3.1.0",
+        "d3-format": "^3.1.2",
+        "d3-geo": "^3.1.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-path": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "d3-time": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "d3-timer": "^3.0.1",
+        "flatqueue": "^3.0.0",
+        "internmap": "^2.0.3"
+      }
+    },
+    "node_modules/@mui/x-charts/node_modules/@mui/utils": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-9.0.1.tgz",
+      "integrity": "sha512-f3UO3jNN1pYg5zxqXC81Bvv8hx5ACcYc0387382ZI7M5ono1heIwHYLrKsz85myguWdeVKPRZGmDdynWUBjK2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@mui/types": "^9.0.0",
+        "@types/prop-types": "^15.7.15",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^19.2.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/x-date-pickers": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-9.5.0.tgz",
@@ -1737,6 +1838,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@mui/x-internal-gestures": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-internal-gestures/-/x-internal-gestures-9.3.0.tgz",
+      "integrity": "sha512-OXgda1tnUKaDF4+6uxERdlyz8uFkhVrqchRbTiT/vWmUtZ3PcicSwp4rqZyaKcoDMgPwCoEEXVBlwZaiLo8Whw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
       }
     },
     "node_modules/@mui/x-internals": {
@@ -2431,6 +2541,84 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2443,6 +2631,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3048,6 +3242,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bezier-easing": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-3.0.0.tgz",
+      "integrity": "sha512-lE85voPXiK99T8NHOfhaUqCZpJdP1gBbbTEvdBDdPB+phyvPZPNWalBe42eb6lKOYchP0qZrtBiRCARtT4edRQ==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
@@ -3278,6 +3478,130 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
@@ -4069,6 +4393,12 @@
         "node": ">=16"
       }
     },
+    "node_modules/flatqueue": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/flatqueue/-/flatqueue-3.1.0.tgz",
+      "integrity": "sha512-Ia4qIYrrsEqIRx3c3XhkT+QDLQuUV5ovsr6ah1rIgKT5wclhoGK3lAMS1bWRAWxlx7wtlTBpV7QXB5d9fOSRxA==",
+      "license": "ISC"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -4411,6 +4741,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@emotion/styled": "^11.13.5",
     "@mui/icons-material": "^9.1.1",
     "@mui/material": "^9.1.1",
+    "@mui/x-charts": "^9.5.0",
     "@mui/x-date-pickers": "^9.5.0",
     "dayjs": "^1.11.13",
     "prettier": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "0.7.2",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import {
   ThemeProvider,
 } from '@mui/material';
 import { FinanceDataProvider } from './state/finance-data-context';
+import { AppErrorBoundary } from './components/app-error-boundary';
 import { theme } from './theme';
 
 function App() {
@@ -24,19 +25,24 @@ function App() {
         <CssBaseline />
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <FinanceDataProvider>
-            <Stack sx={{ height: '100vh', flexDirection: 'column' }}>
-              <Header />
-              <Box
-                sx={{
-                  flexGrow: 1,
-                  display: 'flex',
-                  flexDirection: 'column',
-                }}
-              >
-                <Body />
-              </Box>
-              <Footer />
-            </Stack>
+            {/* App-level error boundary (1.4): a render crash shows a recovery
+                screen with an export-my-data escape hatch + reload, never a
+                white screen. Inside the provider so the fallback can export. */}
+            <AppErrorBoundary>
+              <Stack sx={{ height: '100vh', flexDirection: 'column' }}>
+                <Header />
+                <Box
+                  sx={{
+                    flexGrow: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                  }}
+                >
+                  <Body />
+                </Box>
+                <Footer />
+              </Stack>
+            </AppErrorBoundary>
           </FinanceDataProvider>
         </LocalizationProvider>
       </ThemeProvider>

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -21,6 +21,7 @@ import { PersistenceToggle } from './persistence/persistence-toggle';
 import { FirstVisitNotice } from './persistence/first-visit-notice';
 import { ForecastChart } from './chart/forecast-chart';
 import { NetWorthSummary } from './dashboard/net-worth-summary';
+import { MilestoneCallouts } from './dashboard/milestone-callouts';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -240,6 +241,11 @@ export const Body = () => {
               from. */}
           <Box sx={{ marginBottom: SECTION_GAP }}>
             <NetWorthSummary loans={loans} investments={investments} />
+            {/* Milestone callouts (roadmap 3.2): debt-free date + net worth at
+                +5y/+10y/+30y, cheap reads off the same engine series. */}
+            <Box sx={{ marginTop: 2 }}>
+              <MilestoneCallouts loans={loans} investments={investments} />
+            </Box>
           </Box>
 
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -61,7 +61,13 @@ const addActionSx = {
 
 export const Body = () => {
   const {
-    state: { loans, investments, sampleDataLoaded },
+    state: {
+      loans,
+      investments,
+      sampleDataLoaded,
+      scenarios,
+      activeScenarioId,
+    },
     addLoan,
     updateLoan,
     deleteLoan,
@@ -307,7 +313,11 @@ export const Body = () => {
             {/* Scenario controls (roadmap 4.2): create/select/delete what-if
                 scenarios; the active one overlays the chart (4.3). */}
             <ScenarioBar />
-            <ForecastChart loans={loans} investments={investments} />
+            <ForecastChart
+              loans={loans}
+              investments={investments}
+              scenario={scenarios.find((s) => s.Id === activeScenarioId)}
+            />
             {/* Stated-assumptions panel (roadmap 3.4): always-available note on
                 what the forecast assumes — honest framing for a deterministic
                 projection. */}

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -108,6 +108,12 @@ export const Body = () => {
     setPendingDelete({ kind: 'loan', entity: loan });
   };
 
+  // Clone (roadmap 3.3): copy an entity with a fresh Id (addLoan/addInvestment
+  // assign one when Id is empty) so refinance/what-if candidates don't need
+  // re-typing. Marked "(copy)" so the duplicate is obvious.
+  const onLoanClone = (loan: Loan) =>
+    addLoan({ ...loan, Id: '', Name: `${loan.Name} (copy)` });
+
   const onInvestmentAddEdit = (investment?: Investment) => {
     setEditInvestment(investment);
     setIsAddInvestmentOpen(true);
@@ -133,6 +139,13 @@ export const Body = () => {
   const onInvestmentDelete = (investment: Investment) => {
     setPendingDelete({ kind: 'investment', entity: investment });
   };
+
+  const onInvestmentClone = (investment: Investment) =>
+    addInvestment({
+      ...investment,
+      Id: '',
+      Name: `${investment.Name} (copy)`,
+    });
 
   // Step 2: confirmation accepted — actually delete, remembering the original
   // index so the snackbar can offer an exact-position undo.
@@ -255,6 +268,7 @@ export const Body = () => {
                 loans={loans}
                 onLoanEdit={onLoanAddEdit}
                 onLoanDelete={onLoanDelete}
+                onLoanClone={onLoanClone}
               />
             ) : (
               <SectionEmptyState
@@ -272,6 +286,7 @@ export const Body = () => {
                 investments={investments}
                 onInvestmentEdit={onInvestmentAddEdit}
                 onInvestmentDelete={onInvestmentDelete}
+                onInvestmentClone={onInvestmentClone}
               />
             ) : (
               <SectionEmptyState

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -23,6 +23,7 @@ import { ForecastChart } from './chart/forecast-chart';
 import { NetWorthSummary } from './dashboard/net-worth-summary';
 import { MilestoneCallouts } from './dashboard/milestone-callouts';
 import { AssumptionsPanel } from './dashboard/assumptions-panel';
+import { ScenarioBar } from './scenario/scenario-bar';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -303,6 +304,9 @@ export const Body = () => {
               least one position (the enclosing branch already guarantees it). */}
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Forecast</Divider>
+            {/* Scenario controls (roadmap 4.2): create/select/delete what-if
+                scenarios; the active one overlays the chart (4.3). */}
+            <ScenarioBar />
             <ForecastChart loans={loans} investments={investments} />
             {/* Stated-assumptions panel (roadmap 3.4): always-available note on
                 what the forecast assumes — honest framing for a deterministic

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -22,6 +22,7 @@ import { FirstVisitNotice } from './persistence/first-visit-notice';
 import { ForecastChart } from './chart/forecast-chart';
 import { NetWorthSummary } from './dashboard/net-worth-summary';
 import { MilestoneCallouts } from './dashboard/milestone-callouts';
+import { AssumptionsPanel } from './dashboard/assumptions-panel';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -303,6 +304,10 @@ export const Body = () => {
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Forecast</Divider>
             <ForecastChart loans={loans} investments={investments} />
+            {/* Stated-assumptions panel (roadmap 3.4): always-available note on
+                what the forecast assumes — honest framing for a deterministic
+                projection. */}
+            <AssumptionsPanel />
           </Paper>
         </>
       )}

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -16,6 +16,7 @@ import { AddEditInvestment } from './investment/add-edit-investment';
 import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
+import { PersistenceToggle } from './persistence/persistence-toggle';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -194,6 +195,7 @@ export const Body = () => {
             Add Investment
           </Button>
           <DataManager />
+          <PersistenceToggle />
           <ColorModeToggle />
         </Toolbar>
       </AppBar>

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -1,6 +1,7 @@
 import {
   Alert,
   AppBar,
+  Box,
   Button,
   Container,
   Divider,
@@ -19,6 +20,7 @@ import { DataManager } from './data-manager/data-manager';
 import { PersistenceToggle } from './persistence/persistence-toggle';
 import { FirstVisitNotice } from './persistence/first-visit-notice';
 import { ForecastChart } from './chart/forecast-chart';
+import { NetWorthSummary } from './dashboard/net-worth-summary';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -233,6 +235,13 @@ export const Body = () => {
         </Paper>
       ) : (
         <>
+          {/* Net-worth dashboard summary cards (roadmap 3.1): lead the content
+              with today's totals — the same anchor the forecast chart starts
+              from. */}
+          <Box sx={{ marginBottom: SECTION_GAP }}>
+            <NetWorthSummary loans={loans} investments={investments} />
+          </Box>
+
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Loans</Divider>
             {loans.length > 0 ? (

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -24,6 +24,7 @@ import { NetWorthSummary } from './dashboard/net-worth-summary';
 import { MilestoneCallouts } from './dashboard/milestone-callouts';
 import { AssumptionsPanel } from './dashboard/assumptions-panel';
 import { ScenarioBar } from './scenario/scenario-bar';
+import { ScenarioImpactSummary } from './scenario/scenario-impact-summary';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -194,6 +195,7 @@ export const Body = () => {
 
   const deletedName = undoableDelete?.entity.Name ?? '';
   const bothEmpty = loans.length === 0 && investments.length === 0;
+  const activeScenario = scenarios.find((s) => s.Id === activeScenarioId);
 
   return (
     <Container>
@@ -316,8 +318,17 @@ export const Body = () => {
             <ForecastChart
               loans={loans}
               investments={investments}
-              scenario={scenarios.find((s) => s.Id === activeScenarioId)}
+              scenario={activeScenario}
             />
+            {/* Scenario impact summary (roadmap 4.4): what the active scenario
+                buys vs. baseline — shown only when a scenario is active. */}
+            {activeScenario && (
+              <ScenarioImpactSummary
+                loans={loans}
+                investments={investments}
+                scenario={activeScenario}
+              />
+            )}
             {/* Stated-assumptions panel (roadmap 3.4): always-available note on
                 what the forecast assumes — honest framing for a deterministic
                 projection. */}

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -17,6 +17,7 @@ import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { PersistenceToggle } from './persistence/persistence-toggle';
+import { FirstVisitNotice } from './persistence/first-visit-notice';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -199,6 +200,10 @@ export const Body = () => {
           <ColorModeToggle />
         </Toolbar>
       </AppBar>
+
+      {/* First-visit privacy notice (roadmap 1.3): shown once, explains data
+          stays on-device and points at the "Save on this device" toggle. */}
+      <FirstVisitNotice />
 
       {/* Sample-data indicator (roadmap 0.9): while samples are loaded, keep a
           one-click "Clear sample data" right above the tables, where the user

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -18,6 +18,7 @@ import { InvestmentTable } from './investment/investment-table';
 import { DataManager } from './data-manager/data-manager';
 import { PersistenceToggle } from './persistence/persistence-toggle';
 import { FirstVisitNotice } from './persistence/first-visit-notice';
+import { ForecastChart } from './chart/forecast-chart';
 import { useFinanceData } from './state/use-finance-data';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
@@ -264,6 +265,14 @@ export const Body = () => {
                 onAction={() => onInvestmentAddEdit()}
               />
             )}
+          </Paper>
+
+          {/* Forecast chart (roadmap 2.2): per-loan, per-investment, and overall
+              net-worth lines from the shared engine. Shown whenever there is at
+              least one position (the enclosing branch already guarantees it). */}
+          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
+            <Divider>Forecast</Divider>
+            <ForecastChart loans={loans} investments={investments} />
           </Paper>
         </>
       )}

--- a/src/chart/chart-legend.tsx
+++ b/src/chart/chart-legend.tsx
@@ -1,0 +1,76 @@
+import { Box, Button, Chip, Stack } from '@mui/material';
+
+export interface LegendItem {
+  id: string;
+  label: string;
+  color: string;
+}
+
+interface ChartLegendProps {
+  items: LegendItem[];
+  hiddenIds: Set<string>;
+  onToggle: (id: string) => void;
+  onShowAll: () => void;
+}
+
+// Interactive chart legend (Phase 2.3). Each series is a toggle chip: click (or
+// keyboard-activate) to show/hide that line. Chips wrap so 10+ entities stay
+// usable, and a "Show all" affordance appears once anything is hidden. Built as
+// real buttons with `aria-pressed`, so it doubles as the keyboard-operable
+// legend the Phase 6 a11y pass needs.
+export const ChartLegend = ({
+  items,
+  hiddenIds,
+  onToggle,
+  onShowAll,
+}: ChartLegendProps) => {
+  const anyHidden = items.some((item) => hiddenIds.has(item.id));
+
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      useFlexGap
+      sx={{ marginTop: 2, flexWrap: 'wrap', alignItems: 'center' }}
+      role="group"
+      aria-label="Toggle forecast series"
+    >
+      {items.map((item) => {
+        const hidden = hiddenIds.has(item.id);
+        return (
+          <Chip
+            key={item.id}
+            label={item.label}
+            variant="outlined"
+            clickable
+            onClick={() => onToggle(item.id)}
+            aria-pressed={!hidden}
+            icon={
+              <Box
+                component="span"
+                sx={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: '50%',
+                  marginLeft: '8px',
+                  backgroundColor: hidden ? 'action.disabled' : item.color,
+                }}
+              />
+            }
+            sx={{
+              opacity: hidden ? 0.6 : 1,
+              '& .MuiChip-label': {
+                textDecoration: hidden ? 'line-through' : 'none',
+              },
+            }}
+          />
+        );
+      })}
+      {anyHidden && (
+        <Button size="small" onClick={onShowAll}>
+          Show all
+        </Button>
+      )}
+    </Stack>
+  );
+};

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { LineChart } from '@mui/x-charts/LineChart';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { ScenarioInput } from '../models/forecast-model';
+import { getDefaultHorizon } from '../helpers/forecast-helpers';
+import { buildForecastChartData } from '../helpers/forecast-series';
+import {
+  formatCurrency,
+  formatCurrencyCompact,
+} from '../helpers/format-helpers';
+
+interface ForecastChartProps {
+  loans: Loan[];
+  investments: Investment[];
+  scenario?: ScenarioInput;
+  height?: number;
+}
+
+// The forecast line chart (Phase 2). One line per loan (declining balance), one
+// per investment (growth), plus the aggregate net-worth line — all from the
+// shared forecast engine via `buildForecastChartData`. Series are memoized by
+// (positions, horizon, scenario) so re-renders don't recompute identical data.
+export const ForecastChart = ({
+  loans,
+  investments,
+  scenario,
+  height = 400,
+}: ForecastChartProps) => {
+  // Stable "today" per mount so the horizon and the series share one anchor and
+  // the memo key isn't invalidated by every render's new Date().
+  const today = useMemo(() => new Date(), []);
+
+  const { dates, series } = useMemo(() => {
+    const horizon = getDefaultHorizon(loans, investments, today);
+    return buildForecastChartData(loans, investments, horizon, scenario, today);
+  }, [loans, investments, scenario, today]);
+
+  return (
+    <LineChart
+      height={height}
+      xAxis={[
+        {
+          data: dates,
+          scaleType: 'time',
+          valueFormatter: (value: Date) => dayjs(value).format('MMM YYYY'),
+        },
+      ]}
+      yAxis={[
+        { valueFormatter: (value: number) => formatCurrencyCompact(value) },
+      ]}
+      series={series.map((s) => ({
+        id: s.id,
+        data: s.values,
+        label: s.label,
+        showMark: false,
+        valueFormatter: (value: number | null) =>
+          value === null ? '' : formatCurrency(value),
+      }))}
+      margin={{ left: 64 }}
+    />
+  );
+};

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -14,6 +14,7 @@ import { Investment } from '../models/investment-model';
 import { ScenarioInput } from '../models/forecast-model';
 import { getDefaultHorizon } from '../helpers/forecast-helpers';
 import {
+  ForecastChartData,
   NET_WORTH_SERIES_ID,
   buildForecastChartData,
   sliceForecastChartData,
@@ -22,7 +23,11 @@ import {
   formatCurrency,
   formatCurrencyCompact,
 } from '../helpers/format-helpers';
-import { getSeriesColor } from './series-colors';
+import {
+  SCENARIO_SERIES_SUFFIX,
+  baseSeriesId,
+  getSeriesColor,
+} from './series-colors';
 import { ChartLegend } from './chart-legend';
 import { ForecastDataTable } from './forecast-data-table';
 
@@ -72,9 +77,36 @@ export const ForecastChart = ({
   // the memo key isn't invalidated by every render's new Date().
   const today = useMemo(() => new Date(), []);
 
-  const fullData = useMemo(() => {
+  // Baseline (solid) lines always; when a scenario is active, add color-matched
+  // dotted overlay lines (suffix-tagged ids) on top — originals remain (4.3).
+  const fullData = useMemo<ForecastChartData>(() => {
     const horizon = getDefaultHorizon(loans, investments, today);
-    return buildForecastChartData(loans, investments, horizon, scenario, today);
+    const baseline = buildForecastChartData(
+      loans,
+      investments,
+      horizon,
+      undefined,
+      today
+    );
+    if (!scenario) {
+      return baseline;
+    }
+    const overlay = buildForecastChartData(
+      loans,
+      investments,
+      horizon,
+      scenario,
+      today
+    );
+    const scenarioSeries = overlay.series.map((s) => ({
+      ...s,
+      id: s.id + SCENARIO_SERIES_SUFFIX,
+      label: `${s.label} (scenario)`,
+    }));
+    return {
+      dates: baseline.dates,
+      series: [...baseline.series, ...scenarioSeries],
+    };
   }, [loans, investments, scenario, today]);
 
   const [range, setRange] = useState<TimeRange>('full');
@@ -112,6 +144,24 @@ export const ForecastChart = ({
   );
 
   const visibleSeries = series.filter((s) => !hiddenIds.has(s.id));
+
+  // Per-series line styling: thicken any net-worth line, dash scenario overlays.
+  const lineStyles = useMemo(() => {
+    const styles: Record<string, Record<string, number | string>> = {};
+    series.forEach((s) => {
+      const rules: Record<string, number | string> = {};
+      if (baseSeriesId(s.id) === NET_WORTH_SERIES_ID) {
+        rules.strokeWidth = 3;
+      }
+      if (s.id.endsWith(SCENARIO_SERIES_SUFFIX)) {
+        rules.strokeDasharray = '5 4';
+      }
+      if (Object.keys(rules).length > 0) {
+        styles[`& .MuiLineElement-series-${s.id}`] = rules;
+      }
+    });
+    return styles;
+  }, [series]);
 
   const [view, setView] = useState<'chart' | 'table'>('chart');
 
@@ -182,12 +232,7 @@ export const ForecastChart = ({
               value === null ? '' : formatCurrency(value),
           }))}
           margin={{ left: 64 }}
-          // Emphasize the headline net-worth line above the entity lines.
-          sx={{
-            [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
-              strokeWidth: 3,
-            },
-          }}
+          sx={lineStyles}
         />
       )}
       <ChartLegend

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -24,6 +24,7 @@ import {
 } from '../helpers/format-helpers';
 import { getSeriesColor } from './series-colors';
 import { ChartLegend } from './chart-legend';
+import { ForecastDataTable } from './forecast-data-table';
 
 interface ForecastChartProps {
   loans: Loan[];
@@ -112,12 +113,35 @@ export const ForecastChart = ({
 
   const visibleSeries = series.filter((s) => !hiddenIds.has(s.id));
 
+  const [view, setView] = useState<'chart' | 'table'>('chart');
+
   return (
     <Box>
       <Stack
         direction="row"
-        sx={{ marginBottom: 1, justifyContent: 'flex-end' }}
+        sx={{
+          marginBottom: 1,
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+          gap: 1,
+        }}
       >
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={view}
+          onChange={(_, next: 'chart' | 'table' | null) =>
+            next && setView(next)
+          }
+          aria-label="Forecast view"
+        >
+          <ToggleButton value="chart" aria-label="View as chart">
+            Chart
+          </ToggleButton>
+          <ToggleButton value="table" aria-label="View as table">
+            Table
+          </ToggleButton>
+        </ToggleButtonGroup>
         <ToggleButtonGroup
           size="small"
           exclusive
@@ -132,36 +156,40 @@ export const ForecastChart = ({
           ))}
         </ToggleButtonGroup>
       </Stack>
-      <LineChart
-        height={chartHeight}
-        hideLegend
-        xAxis={[
-          {
-            data: dates,
-            scaleType: 'time',
-            valueFormatter: (value: Date) => dayjs(value).format('MMM YYYY'),
-          },
-        ]}
-        yAxis={[
-          { valueFormatter: (value: number) => formatCurrencyCompact(value) },
-        ]}
-        series={visibleSeries.map((s) => ({
-          id: s.id,
-          data: s.values,
-          label: s.label,
-          color: getSeriesColor(s.id),
-          showMark: false,
-          valueFormatter: (value: number | null) =>
-            value === null ? '' : formatCurrency(value),
-        }))}
-        margin={{ left: 64 }}
-        // Emphasize the headline net-worth line above the entity lines.
-        sx={{
-          [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
-            strokeWidth: 3,
-          },
-        }}
-      />
+      {view === 'table' ? (
+        <ForecastDataTable dates={dates} series={visibleSeries} />
+      ) : (
+        <LineChart
+          height={chartHeight}
+          hideLegend
+          xAxis={[
+            {
+              data: dates,
+              scaleType: 'time',
+              valueFormatter: (value: Date) => dayjs(value).format('MMM YYYY'),
+            },
+          ]}
+          yAxis={[
+            { valueFormatter: (value: number) => formatCurrencyCompact(value) },
+          ]}
+          series={visibleSeries.map((s) => ({
+            id: s.id,
+            data: s.values,
+            label: s.label,
+            color: getSeriesColor(s.id),
+            showMark: false,
+            valueFormatter: (value: number | null) =>
+              value === null ? '' : formatCurrency(value),
+          }))}
+          margin={{ left: 64 }}
+          // Emphasize the headline net-worth line above the entity lines.
+          sx={{
+            [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
+              strokeWidth: 3,
+            },
+          }}
+        />
+      )}
       <ChartLegend
         items={legendItems}
         hiddenIds={hiddenIds}

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -1,6 +1,13 @@
 import { useCallback, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import { Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
+import {
+  Box,
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
@@ -52,8 +59,14 @@ export const ForecastChart = ({
   loans,
   investments,
   scenario,
-  height = 400,
+  height,
 }: ForecastChartProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  // Responsive height (2.5): a shorter chart on phones so it fits above the fold
+  // with the legend below; callers can still override explicitly.
+  const chartHeight = height ?? (isMobile ? 280 : 400);
+
   // Stable "today" per mount so the horizon and the series share one anchor and
   // the memo key isn't invalidated by every render's new Date().
   const today = useMemo(() => new Date(), []);
@@ -120,7 +133,7 @@ export const ForecastChart = ({
         </ToggleButtonGroup>
       </Stack>
       <LineChart
-        height={height}
+        height={chartHeight}
         hideLegend
         xAxis={[
           {

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import { Box } from '@mui/material';
+import { Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
@@ -9,6 +9,7 @@ import { getDefaultHorizon } from '../helpers/forecast-helpers';
 import {
   NET_WORTH_SERIES_ID,
   buildForecastChartData,
+  sliceForecastChartData,
 } from '../helpers/forecast-series';
 import {
   formatCurrency,
@@ -23,6 +24,24 @@ interface ForecastChartProps {
   scenario?: ScenarioInput;
   height?: number;
 }
+
+type TimeRange = '5y' | '10y' | '30y' | 'full';
+
+// Months shown per range; 'full' means the whole horizon (Infinity clamps in
+// sliceForecastChartData to the available length).
+const RANGE_MONTHS: Record<TimeRange, number> = {
+  '5y': 60,
+  '10y': 120,
+  '30y': 360,
+  full: Infinity,
+};
+
+const RANGE_LABELS: { value: TimeRange; label: string }[] = [
+  { value: '5y', label: '5Y' },
+  { value: '10y', label: '10Y' },
+  { value: '30y', label: '30Y' },
+  { value: 'full', label: 'Full' },
+];
 
 // The forecast line chart (Phase 2). One line per loan (declining balance), one
 // per investment (growth), plus the aggregate net-worth line — all from the
@@ -39,10 +58,18 @@ export const ForecastChart = ({
   // the memo key isn't invalidated by every render's new Date().
   const today = useMemo(() => new Date(), []);
 
-  const { dates, series } = useMemo(() => {
+  const fullData = useMemo(() => {
     const horizon = getDefaultHorizon(loans, investments, today);
     return buildForecastChartData(loans, investments, horizon, scenario, today);
   }, [loans, investments, scenario, today]);
+
+  const [range, setRange] = useState<TimeRange>('full');
+
+  // Window the full series to the selected range (no recompute — pure slice).
+  const { dates, series } = useMemo(
+    () => sliceForecastChartData(fullData, RANGE_MONTHS[range]),
+    [fullData, range]
+  );
 
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
 
@@ -74,6 +101,24 @@ export const ForecastChart = ({
 
   return (
     <Box>
+      <Stack
+        direction="row"
+        sx={{ marginBottom: 1, justifyContent: 'flex-end' }}
+      >
+        <ToggleButtonGroup
+          size="small"
+          exclusive
+          value={range}
+          onChange={(_, next: TimeRange | null) => next && setRange(next)}
+          aria-label="Forecast time range"
+        >
+          {RANGE_LABELS.map(({ value, label }) => (
+            <ToggleButton key={value} value={value} aria-label={label}>
+              {label}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Stack>
       <LineChart
         height={height}
         hideLegend

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -146,6 +146,8 @@ export const ForecastChart = ({
   const visibleSeries = series.filter((s) => !hiddenIds.has(s.id));
 
   // Per-series line styling: thicken any net-worth line, dash scenario overlays.
+  // x-charts v9 tags each line path with `data-series-id` (there is no per-series
+  // class), so target that attribute under the shared line class.
   const lineStyles = useMemo(() => {
     const styles: Record<string, Record<string, number | string>> = {};
     series.forEach((s) => {
@@ -157,7 +159,7 @@ export const ForecastChart = ({
         rules.strokeDasharray = '5 4';
       }
       if (Object.keys(rules).length > 0) {
-        styles[`& .MuiLineElement-series-${s.id}`] = rules;
+        styles[`& .MuiLineChart-line[data-series-id="${s.id}"]`] = rules;
       }
     });
     return styles;

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
+import { Box } from '@mui/material';
 import { LineChart } from '@mui/x-charts/LineChart';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
@@ -14,6 +15,7 @@ import {
   formatCurrencyCompact,
 } from '../helpers/format-helpers';
 import { getSeriesColor } from './series-colors';
+import { ChartLegend } from './chart-legend';
 
 interface ForecastChartProps {
   loans: Loan[];
@@ -26,6 +28,7 @@ interface ForecastChartProps {
 // per investment (growth), plus the aggregate net-worth line — all from the
 // shared forecast engine via `buildForecastChartData`. Series are memoized by
 // (positions, horizon, scenario) so re-renders don't recompute identical data.
+// An interactive legend (2.3) toggles individual lines on and off.
 export const ForecastChart = ({
   loans,
   investments,
@@ -41,35 +44,72 @@ export const ForecastChart = ({
     return buildForecastChartData(loans, investments, horizon, scenario, today);
   }, [loans, investments, scenario, today]);
 
-  return (
-    <LineChart
-      height={height}
-      xAxis={[
-        {
-          data: dates,
-          scaleType: 'time',
-          valueFormatter: (value: Date) => dayjs(value).format('MMM YYYY'),
-        },
-      ]}
-      yAxis={[
-        { valueFormatter: (value: number) => formatCurrencyCompact(value) },
-      ]}
-      series={series.map((s) => ({
+  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+
+  const toggleSeries = useCallback((id: string) => {
+    setHiddenIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const showAll = useCallback(() => setHiddenIds(new Set()), []);
+
+  const legendItems = useMemo(
+    () =>
+      series.map((s) => ({
         id: s.id,
-        data: s.values,
         label: s.label,
         color: getSeriesColor(s.id),
-        showMark: false,
-        valueFormatter: (value: number | null) =>
-          value === null ? '' : formatCurrency(value),
-      }))}
-      margin={{ left: 64 }}
-      // Emphasize the headline net-worth line above the entity lines.
-      sx={{
-        [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
-          strokeWidth: 3,
-        },
-      }}
-    />
+      })),
+    [series]
+  );
+
+  const visibleSeries = series.filter((s) => !hiddenIds.has(s.id));
+
+  return (
+    <Box>
+      <LineChart
+        height={height}
+        hideLegend
+        xAxis={[
+          {
+            data: dates,
+            scaleType: 'time',
+            valueFormatter: (value: Date) => dayjs(value).format('MMM YYYY'),
+          },
+        ]}
+        yAxis={[
+          { valueFormatter: (value: number) => formatCurrencyCompact(value) },
+        ]}
+        series={visibleSeries.map((s) => ({
+          id: s.id,
+          data: s.values,
+          label: s.label,
+          color: getSeriesColor(s.id),
+          showMark: false,
+          valueFormatter: (value: number | null) =>
+            value === null ? '' : formatCurrency(value),
+        }))}
+        margin={{ left: 64 }}
+        // Emphasize the headline net-worth line above the entity lines.
+        sx={{
+          [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
+            strokeWidth: 3,
+          },
+        }}
+      />
+      <ChartLegend
+        items={legendItems}
+        hiddenIds={hiddenIds}
+        onToggle={toggleSeries}
+        onShowAll={showAll}
+      />
+    </Box>
   );
 };

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -5,11 +5,15 @@ import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
 import { ScenarioInput } from '../models/forecast-model';
 import { getDefaultHorizon } from '../helpers/forecast-helpers';
-import { buildForecastChartData } from '../helpers/forecast-series';
+import {
+  NET_WORTH_SERIES_ID,
+  buildForecastChartData,
+} from '../helpers/forecast-series';
 import {
   formatCurrency,
   formatCurrencyCompact,
 } from '../helpers/format-helpers';
+import { getSeriesColor } from './series-colors';
 
 interface ForecastChartProps {
   loans: Loan[];
@@ -54,11 +58,18 @@ export const ForecastChart = ({
         id: s.id,
         data: s.values,
         label: s.label,
+        color: getSeriesColor(s.id),
         showMark: false,
         valueFormatter: (value: number | null) =>
           value === null ? '' : formatCurrency(value),
       }))}
       margin={{ left: 64 }}
+      // Emphasize the headline net-worth line above the entity lines.
+      sx={{
+        [`& .MuiLineElement-series-${NET_WORTH_SERIES_ID}`]: {
+          strokeWidth: 3,
+        },
+      }}
     />
   );
 };

--- a/src/chart/forecast-data-table.tsx
+++ b/src/chart/forecast-data-table.tsx
@@ -1,0 +1,81 @@
+import dayjs from 'dayjs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import { ForecastSeries } from '../helpers/forecast-series';
+import { formatCurrency } from '../helpers/format-helpers';
+
+interface ForecastDataTableProps {
+  dates: Date[];
+  series: ForecastSeries[];
+}
+
+// Sample one row per year (plus the final point) so the table stays navigable
+// over a 30-year horizon while still spanning the full range.
+const yearlyIndices = (length: number): number[] => {
+  const indices: number[] = [];
+  for (let i = 0; i < length; i += 12) {
+    indices.push(i);
+  }
+  const last = length - 1;
+  if (last >= 0 && indices[indices.length - 1] !== last) {
+    indices.push(last);
+  }
+  return indices;
+};
+
+// Accessible "view as table" fallback (Phase 2.6). A line chart is opaque to
+// screen readers and keyboard-only users; this renders the same forecast series
+// as a real data table (column headers, row scope) consuming the identical
+// values the chart plots. It doubles as a data-inspection view for everyone, and
+// reflects the active time range and legend toggles (it receives the windowed,
+// visible series).
+export const ForecastDataTable = ({
+  dates,
+  series,
+}: ForecastDataTableProps) => {
+  const rows = yearlyIndices(dates.length);
+
+  return (
+    <TableContainer>
+      <Table size="small" aria-label="Forecast values at yearly intervals">
+        <caption>
+          <Typography variant="caption" color="text.secondary">
+            Projected values at yearly intervals — loan balances, investment
+            values, and overall net worth.
+          </Typography>
+        </caption>
+        <TableHead>
+          <TableRow>
+            <TableCell>Date</TableCell>
+            {series.map((s) => (
+              <TableCell key={s.id} align="right">
+                {s.label}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((index) => (
+            <TableRow key={dates[index].getTime()}>
+              <TableCell component="th" scope="row">
+                {dayjs(dates[index]).format('MMM YYYY')}
+              </TableCell>
+              {series.map((s) => (
+                <TableCell key={s.id} align="right">
+                  {formatCurrency(s.values[index])}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/src/chart/series-colors.test.ts
+++ b/src/chart/series-colors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { NET_WORTH_COLOR, getSeriesColor } from './series-colors';
+import {
+  NET_WORTH_COLOR,
+  SCENARIO_SERIES_SUFFIX,
+  baseSeriesId,
+  getSeriesColor,
+} from './series-colors';
 import { NET_WORTH_SERIES_ID } from '../helpers/forecast-series';
 
 describe('getSeriesColor', () => {
@@ -15,5 +20,21 @@ describe('getSeriesColor', () => {
     const color = getSeriesColor('inv-42');
     expect(color).toMatch(/^#[0-9a-f]{6}$/i);
     expect(color).not.toBe(NET_WORTH_COLOR);
+  });
+
+  it('color-matches a scenario overlay to the solid line it shadows', () => {
+    expect(getSeriesColor('loan-1' + SCENARIO_SERIES_SUFFIX)).toBe(
+      getSeriesColor('loan-1')
+    );
+    expect(getSeriesColor(NET_WORTH_SERIES_ID + SCENARIO_SERIES_SUFFIX)).toBe(
+      NET_WORTH_COLOR
+    );
+  });
+});
+
+describe('baseSeriesId', () => {
+  it('strips the scenario suffix, leaving plain ids untouched', () => {
+    expect(baseSeriesId('loan-1' + SCENARIO_SERIES_SUFFIX)).toBe('loan-1');
+    expect(baseSeriesId('loan-1')).toBe('loan-1');
   });
 });

--- a/src/chart/series-colors.test.ts
+++ b/src/chart/series-colors.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { NET_WORTH_COLOR, getSeriesColor } from './series-colors';
+import { NET_WORTH_SERIES_ID } from '../helpers/forecast-series';
+
+describe('getSeriesColor', () => {
+  it('gives the net-worth line its fixed emphasized color', () => {
+    expect(getSeriesColor(NET_WORTH_SERIES_ID)).toBe(NET_WORTH_COLOR);
+  });
+
+  it('is deterministic per id (stable across renders / reordering)', () => {
+    expect(getSeriesColor('loan-1')).toBe(getSeriesColor('loan-1'));
+  });
+
+  it('returns a palette color for entities, distinct from net worth', () => {
+    const color = getSeriesColor('inv-42');
+    expect(color).toMatch(/^#[0-9a-f]{6}$/i);
+    expect(color).not.toBe(NET_WORTH_COLOR);
+  });
+});

--- a/src/chart/series-colors.ts
+++ b/src/chart/series-colors.ts
@@ -1,0 +1,40 @@
+import { NET_WORTH_SERIES_ID } from '../helpers/forecast-series';
+
+// Stable per-entity chart colors (Phase 2.2). Color is derived from the entity's
+// Id, so a given loan/investment keeps the same color across re-renders and as
+// other entities are added or removed — and Phase 4's dotted scenario overlay
+// can reuse the exact color of the solid line it shadows by passing the same Id.
+//
+// The aggregate net-worth line gets a fixed, emphasized brand-green so the
+// headline series stands apart from the entity palette.
+
+export const NET_WORTH_COLOR = '#2e7d32';
+
+// A categorical palette chosen for separation and readable contrast in both
+// light and dark mode. Entities cycle through it by a hash of their Id.
+const ENTITY_PALETTE = [
+  '#1976d2', // blue
+  '#9c27b0', // purple
+  '#ed6c02', // orange
+  '#0288d1', // light blue
+  '#c2185b', // pink
+  '#00796b', // teal
+  '#5d4037', // brown
+  '#7b1fa2', // deep purple
+  '#f9a825', // amber
+  '#455a64', // blue grey
+];
+
+// Deterministic, order-independent hash of an Id so color survives reordering.
+const hashId = (id: string): number => {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+};
+
+export const getSeriesColor = (id: string): string =>
+  id === NET_WORTH_SERIES_ID
+    ? NET_WORTH_COLOR
+    : ENTITY_PALETTE[hashId(id) % ENTITY_PALETTE.length];

--- a/src/chart/series-colors.ts
+++ b/src/chart/series-colors.ts
@@ -10,8 +10,8 @@ import { NET_WORTH_SERIES_ID } from '../helpers/forecast-series';
 
 export const NET_WORTH_COLOR = '#2e7d32';
 
-// Suffix marking a scenario-overlay series (Phase 4.3). Underscores keep the id
-// valid inside the `MuiLineElement-series-<id>` CSS class the chart targets.
+// Suffix marking a scenario-overlay series (Phase 4.3). Kept distinct from any
+// entity Id so the chart can style overlays via their `data-series-id`.
 export const SCENARIO_SERIES_SUFFIX = '__scenario';
 
 // The underlying entity (or net-worth) id behind a series id, with any scenario

--- a/src/chart/series-colors.ts
+++ b/src/chart/series-colors.ts
@@ -10,6 +10,17 @@ import { NET_WORTH_SERIES_ID } from '../helpers/forecast-series';
 
 export const NET_WORTH_COLOR = '#2e7d32';
 
+// Suffix marking a scenario-overlay series (Phase 4.3). Underscores keep the id
+// valid inside the `MuiLineElement-series-<id>` CSS class the chart targets.
+export const SCENARIO_SERIES_SUFFIX = '__scenario';
+
+// The underlying entity (or net-worth) id behind a series id, with any scenario
+// suffix stripped — so a scenario overlay color-matches the solid line it shadows.
+export const baseSeriesId = (id: string): string =>
+  id.endsWith(SCENARIO_SERIES_SUFFIX)
+    ? id.slice(0, -SCENARIO_SERIES_SUFFIX.length)
+    : id;
+
 // A categorical palette chosen for separation and readable contrast in both
 // light and dark mode. Entities cycle through it by a hash of their Id.
 const ENTITY_PALETTE = [
@@ -34,7 +45,9 @@ const hashId = (id: string): number => {
   return Math.abs(hash);
 };
 
-export const getSeriesColor = (id: string): string =>
-  id === NET_WORTH_SERIES_ID
+export const getSeriesColor = (id: string): string => {
+  const base = baseSeriesId(id);
+  return base === NET_WORTH_SERIES_ID
     ? NET_WORTH_COLOR
-    : ENTITY_PALETTE[hashId(id) % ENTITY_PALETTE.length];
+    : ENTITY_PALETTE[hashId(base) % ENTITY_PALETTE.length];
+};

--- a/src/components/app-error-boundary.tsx
+++ b/src/components/app-error-boundary.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react';
+import { ErrorBoundary } from './error-boundary';
+import { AppErrorFallback } from './app-error-fallback';
+import { useFinanceData } from '../state/use-finance-data';
+import { downloadJsonExport } from '../data-manager/export-download';
+
+// App-level error boundary wired to the finance-data context (1.4). Lives inside
+// the provider so the recovery UI's "export my data" escape hatch can serialize
+// the current data. Because this wrapper is the boundary's parent (not its
+// child), a crash below it leaves these props at their last good render — so the
+// export reflects the data as it was just before the error.
+export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
+  const {
+    state: {
+      loans,
+      investments,
+      sampleDataLoaded,
+      stashedLoans,
+      stashedInvestments,
+    },
+  } = useFinanceData();
+
+  // Export the user's real data, not the sample data shown over it.
+  const realLoans = sampleDataLoaded ? (stashedLoans ?? []) : loans;
+  const realInvestments = sampleDataLoaded
+    ? (stashedInvestments ?? [])
+    : investments;
+  const canExport = realLoans.length > 0 || realInvestments.length > 0;
+
+  return (
+    <ErrorBoundary
+      fallback={({ error }) => (
+        <AppErrorFallback
+          error={error}
+          onReload={() => window.location.reload()}
+          onExport={() => downloadJsonExport(realLoans, realInvestments)}
+          canExport={canExport}
+        />
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};

--- a/src/components/app-error-fallback.tsx
+++ b/src/components/app-error-fallback.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Collapse,
+  Container,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import DownloadIcon from '@mui/icons-material/Download';
+
+interface AppErrorFallbackProps {
+  error: Error;
+  // Reload the whole app (a render error usually recurs without a fresh start).
+  onReload: () => void;
+  // Escape hatch: download the last-good data so a crash never traps it.
+  onExport: () => void;
+  // Whether there is any data worth exporting.
+  canExport: boolean;
+}
+
+// App-level recovery UI (1.4). Shown when the global error boundary catches a
+// render exception: an apology, an "export my data" escape hatch so unsaved data
+// is never trapped, and a reload affordance.
+export const AppErrorFallback = ({
+  error,
+  onReload,
+  onExport,
+  canExport,
+}: AppErrorFallbackProps) => {
+  const [exportFailed, setExportFailed] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
+
+  const handleExport = () => {
+    try {
+      onExport();
+      setExportFailed(false);
+    } catch {
+      setExportFailed(true);
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ paddingY: 8 }}>
+      <Paper sx={{ padding: 4 }}>
+        <Stack spacing={2}>
+          <Typography variant="h5" component="h1">
+            Something went wrong
+          </Typography>
+          <Typography color="text.secondary">
+            PathWise hit an unexpected error. Your data isn’t lost — download a
+            backup first, then reload to get back to work.
+          </Typography>
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+            <Button
+              variant="contained"
+              startIcon={<DownloadIcon />}
+              onClick={handleExport}
+              disabled={!canExport}
+            >
+              Download my data
+            </Button>
+            <Button
+              variant="outlined"
+              startIcon={<RefreshIcon />}
+              onClick={onReload}
+            >
+              Reload app
+            </Button>
+          </Stack>
+
+          {!canExport && (
+            <Typography variant="body2" color="text.secondary">
+              There’s no data to download yet.
+            </Typography>
+          )}
+          {exportFailed && (
+            <Alert severity="error">
+              Couldn’t download your data. Try reloading instead.
+            </Alert>
+          )}
+
+          <Box>
+            <Button size="small" onClick={() => setShowDetails((v) => !v)}>
+              {showDetails ? 'Hide' : 'Show'} technical details
+            </Button>
+            <Collapse in={showDetails}>
+              <Typography
+                variant="caption"
+                component="pre"
+                sx={{
+                  whiteSpace: 'pre-wrap',
+                  marginTop: 1,
+                  color: 'text.secondary',
+                }}
+              >
+                {error.message}
+              </Typography>
+            </Collapse>
+          </Box>
+        </Stack>
+      </Paper>
+    </Container>
+  );
+};

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,48 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  // Render-prop fallback so callers control the recovery UI (and can supply an
+  // export/escape-hatch). `reset` clears the caught error to re-attempt a render.
+  fallback: (args: { error: Error; reset: () => void }) => ReactNode;
+  // Optional hook for logging/telemetry.
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+// Generic React error boundary (1.4). A render-time exception anywhere in the
+// subtree is caught here and turned into the caller's fallback UI, so it can
+// never white-screen the whole app. Error boundaries must be class components.
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Surface details for debugging; the user sees the fallback, not this.
+    console.error('PathWise caught a render error:', error, info);
+    this.props.onError?.(error, info);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    if (this.state.error) {
+      return this.props.fallback({
+        error: this.state.error,
+        reset: this.reset,
+      });
+    }
+    return this.props.children;
+  }
+}

--- a/src/dashboard/assumptions-panel.tsx
+++ b/src/dashboard/assumptions-panel.tsx
@@ -1,0 +1,73 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import { ExpandMore, InfoOutlined } from '@mui/icons-material';
+
+// What every forecast in the app assumes. A deterministic 30-year projection
+// implies false precision; stating the assumptions is the honest framing that
+// Monte Carlo (H2) and the inflation/tax toggles (H2/H4) later make statistical.
+const ASSUMPTIONS: { title: string; detail: string }[] = [
+  {
+    title: 'Rates stay constant',
+    detail:
+      'Interest and return rates are held fixed for the whole projection — no rate changes, ARM resets, or promo expiries.',
+  },
+  {
+    title: 'Average, not guaranteed',
+    detail:
+      'Investments grow at a single average rate. Real markets vary year to year; this is a midpoint, not a promise.',
+  },
+  {
+    title: 'No taxes or inflation',
+    detail:
+      'Values are nominal and pre-tax. After-tax and real (inflation-adjusted) views are planned, not yet applied.',
+  },
+  {
+    title: 'Anchored to today',
+    detail:
+      "Each line starts from a position's current balance or value, not a replay from its start date.",
+  },
+];
+
+// Stated-assumptions panel (Phase 3.4): a small, always-available note on what
+// the forecasts assume, collapsed by default so it informs without crowding.
+export const AssumptionsPanel = () => (
+  <Accordion
+    disableGutters
+    elevation={0}
+    sx={{ backgroundColor: 'transparent', '&:before': { display: 'none' } }}
+  >
+    <AccordionSummary expandIcon={<ExpandMore />} sx={{ paddingX: 0 }}>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+      >
+        <InfoOutlined fontSize="inherit" />
+        What these forecasts assume
+      </Typography>
+    </AccordionSummary>
+    <AccordionDetails sx={{ paddingX: 0 }}>
+      <List dense disablePadding>
+        {ASSUMPTIONS.map((assumption) => (
+          <ListItem key={assumption.title} sx={{ paddingX: 0 }}>
+            <ListItemText
+              primary={assumption.title}
+              secondary={assumption.detail}
+              slotProps={{
+                primary: { variant: 'body2', sx: { fontWeight: 600 } },
+                secondary: { variant: 'caption' },
+              }}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </AccordionDetails>
+  </Accordion>
+);

--- a/src/dashboard/milestone-callouts.tsx
+++ b/src/dashboard/milestone-callouts.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
+import { Stack, Typography } from '@mui/material';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { computeMilestones } from '../helpers/milestone-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
+
+interface MilestoneCalloutsProps {
+  loans: Loan[];
+  investments: Investment[];
+}
+
+// Dashboard milestone callouts (Phase 3.2): projected debt-free date and net
+// worth at +5y / +10y / +30y, derived from the forecast engine via
+// computeMilestones. Debt-free is shown only when there are loans.
+export const MilestoneCallouts = ({
+  loans,
+  investments,
+}: MilestoneCalloutsProps) => {
+  const { debtFreeDate, netWorthAt } = useMemo(
+    () => computeMilestones(loans, investments),
+    [loans, investments]
+  );
+
+  return (
+    <Stack
+      direction="row"
+      spacing={3}
+      useFlexGap
+      sx={{ flexWrap: 'wrap', alignItems: 'baseline' }}
+    >
+      {loans.length > 0 && (
+        <Typography variant="body2" color="text.secondary">
+          Debt-free:{' '}
+          <Typography component="span" variant="body2" color="text.primary">
+            {debtFreeDate
+              ? dayjs(debtFreeDate).format('MMM YYYY')
+              : 'beyond forecast'}
+          </Typography>
+        </Typography>
+      )}
+      {netWorthAt.map((milestone) => (
+        <Typography
+          key={milestone.years}
+          variant="body2"
+          color="text.secondary"
+        >
+          Net worth +{milestone.years}y:{' '}
+          <Typography component="span" variant="body2" color="text.primary">
+            {formatCurrency(milestone.value)}
+          </Typography>
+        </Typography>
+      ))}
+    </Stack>
+  );
+};

--- a/src/dashboard/net-worth-summary.tsx
+++ b/src/dashboard/net-worth-summary.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+import { Box, Card, CardContent, Typography } from '@mui/material';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { summarizePositions } from '../helpers/summary-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
+
+interface NetWorthSummaryProps {
+  loans: Loan[];
+  investments: Investment[];
+}
+
+// Net-worth dashboard summary cards (Phase 3.1). Total assets, total debt, net
+// worth, and monthly commitments at today's anchor — the same numbers the
+// forecast chart starts from (via summarizePositions). Net worth is colored by
+// sign so an underwater position reads at a glance.
+export const NetWorthSummary = ({
+  loans,
+  investments,
+}: NetWorthSummaryProps) => {
+  const summary = useMemo(
+    () => summarizePositions(loans, investments),
+    [loans, investments]
+  );
+
+  const cards: {
+    label: string;
+    value: string;
+    color?: string;
+    hint?: string;
+  }[] = [
+    {
+      label: 'Total assets',
+      value: formatCurrency(summary.totalAssets),
+      color: 'success.main',
+    },
+    {
+      label: 'Total debt',
+      value: formatCurrency(summary.totalDebt),
+      color: 'error.main',
+    },
+    {
+      label: 'Net worth',
+      value: formatCurrency(summary.netWorth),
+      color: summary.netWorth < 0 ? 'error.main' : 'success.main',
+    },
+    {
+      label: 'Monthly commitments',
+      value: formatCurrency(summary.monthlyCommitments),
+      hint: 'payments + contributions / mo',
+    },
+  ];
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr 1fr', sm: 'repeat(4, 1fr)' },
+        gap: 2,
+      }}
+    >
+      {cards.map((card) => (
+        <Card key={card.label} variant="outlined">
+          <CardContent>
+            <Typography variant="overline" color="text.secondary">
+              {card.label}
+            </Typography>
+            <Typography
+              variant="h6"
+              sx={{
+                color: card.color,
+                fontWeight: 600,
+                wordBreak: 'break-word',
+              }}
+            >
+              {card.value}
+            </Typography>
+            {card.hint && (
+              <Typography variant="caption" color="text.secondary">
+                {card.hint}
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+};

--- a/src/data-manager/data-manager.tsx
+++ b/src/data-manager/data-manager.tsx
@@ -1,10 +1,7 @@
 import { Button, Alert, Snackbar, Tooltip } from '@mui/material';
 import { useState, useRef } from 'react';
-import {
-  exportToJson,
-  importFromJson,
-  mergeData,
-} from '../helpers/data-helpers';
+import { importFromJson, mergeData } from '../helpers/data-helpers';
+import { downloadJsonExport } from './export-download';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
 import DownloadIcon from '@mui/icons-material/Download';
 import { useFinanceData } from '../state/use-finance-data';
@@ -22,16 +19,7 @@ export const DataManager = () => {
 
   const handleExport = () => {
     try {
-      const jsonData = exportToJson(loans, investments);
-      const blob = new Blob([jsonData], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `pathwise-data-${new Date().toISOString().split('T')[0]}.json`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
+      downloadJsonExport(loans, investments);
       setSuccessMessage('Data exported successfully!');
     } catch (error) {
       // Log full error details for debugging

--- a/src/data-manager/data-manager.tsx
+++ b/src/data-manager/data-manager.tsx
@@ -8,7 +8,7 @@ import { useFinanceData } from '../state/use-finance-data';
 
 export const DataManager = () => {
   const {
-    state: { loans, investments },
+    state: { loans, investments, scenarios },
     importMerge,
   } = useFinanceData();
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -19,7 +19,7 @@ export const DataManager = () => {
 
   const handleExport = () => {
     try {
-      downloadJsonExport(loans, investments);
+      downloadJsonExport(loans, investments, scenarios);
       setSuccessMessage('Data exported successfully!');
     } catch (error) {
       // Log full error details for debugging
@@ -55,8 +55,11 @@ export const DataManager = () => {
     reader.onload = (e) => {
       try {
         const content = e.target?.result as string;
-        const { loans: importedLoans, investments: importedInvestments } =
-          importFromJson(content);
+        const {
+          loans: importedLoans,
+          investments: importedInvestments,
+          scenarios: importedScenarios,
+        } = importFromJson(content);
 
         // Compute merge statistics for the success message. The actual state
         // update is performed by the reducer's ImportMerge action (which runs
@@ -67,7 +70,7 @@ export const DataManager = () => {
           importedInvestments
         );
 
-        importMerge(importedLoans, importedInvestments);
+        importMerge(importedLoans, importedInvestments, importedScenarios);
 
         // Build detailed success message
         const totalLoansProcessed = loansResult.added + loansResult.updated;

--- a/src/data-manager/export-download.ts
+++ b/src/data-manager/export-download.ts
@@ -1,5 +1,6 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
 import { exportToJson } from '../helpers/data-helpers';
 
 // Side-effecting export: serialize inputs (pure, in data-helpers) and trigger a
@@ -8,9 +9,10 @@ import { exportToJson } from '../helpers/data-helpers';
 // drift between them. Throws on failure; callers surface their own feedback.
 export const downloadJsonExport = (
   loans: Loan[],
-  investments: Investment[]
+  investments: Investment[],
+  scenarios: Scenario[] = []
 ): void => {
-  const jsonData = exportToJson(loans, investments);
+  const jsonData = exportToJson(loans, investments, scenarios);
   const blob = new Blob([jsonData], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/src/data-manager/export-download.ts
+++ b/src/data-manager/export-download.ts
@@ -1,0 +1,23 @@
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { exportToJson } from '../helpers/data-helpers';
+
+// Side-effecting export: serialize inputs (pure, in data-helpers) and trigger a
+// browser download. Shared by the DataManager command and the global error
+// boundary's "export my data" escape hatch (1.4) so the download behavior can't
+// drift between them. Throws on failure; callers surface their own feedback.
+export const downloadJsonExport = (
+  loans: Loan[],
+  investments: Investment[]
+): void => {
+  const jsonData = exportToJson(loans, investments);
+  const blob = new Blob([jsonData], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `pathwise-data-${new Date().toISOString().split('T')[0]}.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};

--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -955,3 +955,103 @@ describe('mergeData', () => {
     expect(stats.updated).toBe(0);
   });
 });
+
+describe('scenario import/export (schema v3)', () => {
+  const baseObj = (scenarios: unknown) => ({
+    schemaVersion: EXPORT_SCHEMA_VERSION,
+    loans: [],
+    investments: [],
+    scenarios,
+    exportDate: new Date().toISOString(),
+    version: '0.11.0',
+  });
+
+  it('round-trips scenarios through export and import', () => {
+    const scenarios = [
+      {
+        Id: 's1',
+        Name: 'Aggressive payoff',
+        ExtraLoanPayments: { 'loan-1': 300 },
+        ExtraContributions: { 'inv-1': 100 },
+      },
+    ];
+    const json = exportToJson([], [], scenarios);
+    expect(JSON.parse(json).schemaVersion).toBe(3);
+    expect(importFromJson(json).scenarios).toEqual(scenarios);
+  });
+
+  it('imports a v2 file forward with no scenarios', () => {
+    const v2 = JSON.stringify({
+      schemaVersion: 2,
+      loans: [],
+      investments: [],
+      exportDate: new Date().toISOString(),
+      version: '0.7.0',
+    });
+    expect(importFromJson(v2).scenarios).toEqual([]);
+  });
+
+  it('treats a missing or null scenarios field as none', () => {
+    const omitted = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [],
+      investments: [],
+      exportDate: new Date().toISOString(),
+      version: '0.11.0',
+    });
+    expect(importFromJson(omitted).scenarios).toEqual([]);
+    expect(importFromJson(JSON.stringify(baseObj(null))).scenarios).toEqual([]);
+  });
+
+  it('defaults missing extra-amount maps to empty objects', () => {
+    const json = JSON.stringify(baseObj([{ Id: 's1', Name: 'Bare' }]));
+    expect(importFromJson(json).scenarios[0]).toEqual({
+      Id: 's1',
+      Name: 'Bare',
+      ExtraLoanPayments: {},
+      ExtraContributions: {},
+    });
+  });
+
+  it('rejects scenarios that are not an array', () => {
+    expect(() => importFromJson(JSON.stringify(baseObj({})))).toThrow(
+      'scenarios must be an array'
+    );
+  });
+
+  it('rejects a scenario element that is not a plain object', () => {
+    for (const bad of ['x', null, [1, 2]]) {
+      expect(() => importFromJson(JSON.stringify(baseObj([bad])))).toThrow(
+        'expected an object'
+      );
+    }
+  });
+
+  it('rejects a scenario with a missing Id or empty Name', () => {
+    expect(() =>
+      importFromJson(JSON.stringify(baseObj([{ Name: 'No id' }])))
+    ).toThrow('missing Id in scenario');
+    expect(() =>
+      importFromJson(JSON.stringify(baseObj([{ Id: 's1', Name: '  ' }])))
+    ).toThrow('missing Name in scenario');
+  });
+
+  it('rejects a non-object or non-numeric extra-amounts map', () => {
+    expect(() =>
+      importFromJson(
+        JSON.stringify(
+          baseObj([{ Id: 's1', Name: 'A', ExtraLoanPayments: [1] }])
+        )
+      )
+    ).toThrow('expected an object of amounts');
+    expect(() =>
+      importFromJson(
+        JSON.stringify(
+          baseObj([
+            { Id: 's1', Name: 'A', ExtraContributions: { 'inv-1': 'lots' } },
+          ])
+        )
+      )
+    ).toThrow('expected a finite number');
+  });
+});

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -4,10 +4,14 @@ import {
   CompoundingFrequency,
   StepUpType,
 } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
+import { CURRENT_SCHEMA_VERSION, RawData, migrate } from './migrate-helpers';
 import packageJson from '../../package.json';
 
-// Schema v2: inputs only. v1 files are rejected — only schema v2 is accepted.
-export const EXPORT_SCHEMA_VERSION = 2;
+// Schema v3 (Phase 4.5): inputs only — loans, investments, and named scenarios.
+// v2 files (no scenarios) import forward via the D8 migration ladder; v1 and
+// newer-than-current versions are rejected there.
+export const EXPORT_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION;
 
 // Serialized versions with Date fields converted to strings
 export interface SerializedLoan extends Omit<Loan, 'StartDate' | 'EndDate'> {
@@ -23,6 +27,7 @@ export interface ExportData {
   schemaVersion: number;
   loans: SerializedLoan[];
   investments: SerializedInvestment[];
+  scenarios: Scenario[];
   exportDate: string;
   version: string;
 }
@@ -99,13 +104,83 @@ const VALID_COMPOUNDING_FREQUENCIES: string[] =
 /** Valid StepUpType values derived from the enum */
 const VALID_STEP_UP_TYPES: string[] = Object.values(StepUpType);
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
 /**
- * Serialize loans and investments to JSON string (schema v2, inputs only)
- * Converts Date objects to ISO strings for JSON compatibility
+ * Validate a scenario's extra-amounts map: every value must be a finite number.
+ * A missing map is treated as empty, so partial scenarios import cleanly.
+ */
+const parseNumberRecord = (
+  value: unknown,
+  field: string,
+  scenarioIndex: number
+): Record<string, number> => {
+  if (value === undefined || value === null) return {};
+  if (!isPlainObject(value)) {
+    throw new Error(
+      `Invalid '${field}' in scenario at index ${scenarioIndex}: expected an object of amounts.`
+    );
+  }
+  const result: Record<string, number> = {};
+  for (const [key, amount] of Object.entries(value)) {
+    if (!isFiniteNumber(amount)) {
+      throw new Error(
+        `Invalid amount for '${key}' in '${field}' of scenario at index ${scenarioIndex}: expected a finite number, got ${JSON.stringify(amount)}.`
+      );
+    }
+    result[key] = amount;
+  }
+  return result;
+};
+
+/**
+ * Validate and normalize the scenarios array (schema v3). A missing array
+ * imports as no scenarios; malformed entries throw, matching the strictness of
+ * loan/investment validation.
+ */
+const parseScenarios = (value: unknown): Scenario[] => {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid data format: scenarios must be an array.');
+  }
+  return value.map((raw, index) => {
+    if (!isPlainObject(raw)) {
+      throw new Error(
+        `Invalid scenario at index ${index}: expected an object.`
+      );
+    }
+    if (!isValidId(raw.Id as string | undefined)) {
+      throw new Error(`Invalid or missing Id in scenario at index ${index}.`);
+    }
+    if (typeof raw.Name !== 'string' || raw.Name.trim() === '') {
+      throw new Error(`Invalid or missing Name in scenario at index ${index}.`);
+    }
+    return {
+      Id: raw.Id as string,
+      Name: raw.Name,
+      ExtraLoanPayments: parseNumberRecord(
+        raw.ExtraLoanPayments,
+        'ExtraLoanPayments',
+        index
+      ),
+      ExtraContributions: parseNumberRecord(
+        raw.ExtraContributions,
+        'ExtraContributions',
+        index
+      ),
+    };
+  });
+};
+
+/**
+ * Serialize loans, investments, and scenarios to a JSON string (schema v3,
+ * inputs only). Converts Date objects to ISO strings for JSON compatibility.
  */
 export const exportToJson = (
   loans: Loan[],
-  investments: Investment[]
+  investments: Investment[],
+  scenarios: Scenario[] = []
 ): string => {
   const serializedLoans: SerializedLoan[] = loans.map((loan) => ({
     ...loan,
@@ -124,6 +199,7 @@ export const exportToJson = (
     schemaVersion: EXPORT_SCHEMA_VERSION,
     loans: serializedLoans,
     investments: serializedInvestments,
+    scenarios,
     exportDate: new Date().toISOString(),
     version: packageJson.version,
   };
@@ -132,49 +208,34 @@ export const exportToJson = (
 };
 
 /**
- * Parse JSON string and convert ISO date strings back to Date objects
- * Accepts schema v2 only. Legacy v1 files (no schemaVersion or schemaVersion < 2)
- * are rejected. Throws error if JSON is invalid, missing required fields,
- * or the schema version is not exactly EXPORT_SCHEMA_VERSION.
+ * Parse a JSON string into validated inputs (loans, investments, scenarios) with
+ * Date fields restored. Routes the parsed payload through the D8 migration
+ * ladder (D8/migrate), so v2 files upgrade forward and v1 / newer-than-current
+ * versions are rejected with stable messages. Throws on invalid JSON, an
+ * unmigratable version, or any malformed field.
  */
 export const importFromJson = (
   jsonString: string
-): { loans: Loan[]; investments: Investment[] } => {
+): { loans: Loan[]; investments: Investment[]; scenarios: Scenario[] } => {
   try {
-    const data = JSON.parse(jsonString) as ExportData;
+    const raw = JSON.parse(jsonString) as ExportData;
 
     // Validate the structure
-    if (!data.loans || !data.investments) {
+    if (!raw.loans || !raw.investments) {
       throw new Error(
         'Invalid data format: Expected an object with "loans" and "investments" arrays.'
       );
     }
 
-    if (!Array.isArray(data.loans) || !Array.isArray(data.investments)) {
+    if (!Array.isArray(raw.loans) || !Array.isArray(raw.investments)) {
       throw new Error(
         'Invalid data format: loans and investments must be arrays'
       );
     }
 
-    // Only schema v2 is accepted; v1 files (missing schemaVersion or < 2) are rejected
-    if (data.schemaVersion === undefined) {
-      throw new Error(
-        'Invalid data format: missing schemaVersion. Legacy (v1) files are not supported.'
-      );
-    }
-    if (typeof data.schemaVersion !== 'number') {
-      throw new Error('Invalid data format: schemaVersion must be a number.');
-    }
-    if (data.schemaVersion > EXPORT_SCHEMA_VERSION) {
-      throw new Error(
-        `Unsupported schema version ${data.schemaVersion}: this file was exported by a newer version of the app.`
-      );
-    }
-    if (data.schemaVersion < EXPORT_SCHEMA_VERSION) {
-      throw new Error(
-        `Unsupported schema version ${data.schemaVersion}: legacy files are not supported.`
-      );
-    }
+    // D8 ladder: gate the version and upgrade older schemas (v2 → v3) before
+    // validation. Throws with the stable legacy/unsupported messages.
+    const data = migrate(raw as unknown as RawData) as unknown as ExportData;
 
     // Convert ISO date strings back to Date objects
     const loans: Loan[] = data.loans.map((serializedLoan, index) => {
@@ -416,7 +477,9 @@ export const importFromJson = (
       }
     });
 
-    return { loans, investments };
+    const scenarios = parseScenarios(data.scenarios);
+
+    return { loans, investments, scenarios };
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new Error('Invalid JSON format: unable to parse file');

--- a/src/helpers/forecast-series.test.ts
+++ b/src/helpers/forecast-series.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { NET_WORTH_SERIES_ID, buildForecastChartData } from './forecast-series';
+import { forecastNetWorth } from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+const TODAY = new Date(2025, 0, 1);
+const HORIZON = new Date(2025, 3, 1); // 3 months out — small, deterministic axis
+
+const loan: Loan = {
+  Id: 'loan-1',
+  Provider: 'Bank',
+  Name: 'Car Loan',
+  InterestRate: 6,
+  Principal: 12000,
+  CurrentAmount: 6000,
+  MonthlyPayment: 500,
+  StartDate: new Date(2024, 0, 1),
+  EndDate: new Date(2026, 0, 1),
+};
+
+const investment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  RecurringContribution: 200,
+  ContributionFrequency: CompoundingFrequency.Monthly,
+};
+
+describe('buildForecastChartData', () => {
+  it('returns a shared monthly date axis even with no positions', () => {
+    const { dates, series } = buildForecastChartData(
+      [],
+      [],
+      HORIZON,
+      undefined,
+      TODAY
+    );
+    expect(dates).toHaveLength(4); // today + 3 months
+    expect(dates[0].getTime()).toBe(TODAY.getTime());
+    // Only the aggregate net-worth line, flat at 0.
+    expect(series).toHaveLength(1);
+    expect(series[0].id).toBe(NET_WORTH_SERIES_ID);
+    expect(series[0].values).toEqual([0, 0, 0, 0]);
+  });
+
+  it('orders series loans, then investments, then net worth with correct metadata', () => {
+    const { dates, series } = buildForecastChartData(
+      [loan],
+      [investment],
+      HORIZON,
+      undefined,
+      TODAY
+    );
+    expect(series.map((s) => s.id)).toEqual([
+      'loan-1',
+      'inv-1',
+      NET_WORTH_SERIES_ID,
+    ]);
+    expect(series.map((s) => s.kind)).toEqual([
+      'loan',
+      'investment',
+      'networth',
+    ]);
+    expect(series.map((s) => s.label)).toEqual([
+      'Car Loan',
+      'Index Fund',
+      'Net worth',
+    ]);
+    // Every series is aligned to the date axis.
+    series.forEach((s) => expect(s.values).toHaveLength(dates.length));
+  });
+
+  it('plots loan balances as a declining liability anchored to CurrentAmount', () => {
+    const { series } = buildForecastChartData(
+      [loan],
+      [],
+      HORIZON,
+      undefined,
+      TODAY
+    );
+    const loanSeries = series.find((s) => s.id === 'loan-1')!;
+    expect(loanSeries.values[0]).toBe(6000);
+    // Balance falls as payments exceed interest.
+    expect(loanSeries.values[1]).toBeLessThan(loanSeries.values[0]);
+    // With only a loan, net worth is the negative of its balance.
+    const net = series.find((s) => s.id === NET_WORTH_SERIES_ID)!;
+    expect(net.values[0]).toBe(-6000);
+  });
+
+  it('net-worth line is identical to forecastNetWorth (single source of truth)', () => {
+    const { series } = buildForecastChartData(
+      [loan],
+      [investment],
+      HORIZON,
+      undefined,
+      TODAY
+    );
+    const net = series.find((s) => s.id === NET_WORTH_SERIES_ID)!;
+    const engineNet = forecastNetWorth(
+      [loan],
+      [investment],
+      HORIZON,
+      undefined,
+      TODAY
+    ).map((p) => p.Value);
+    expect(net.values).toEqual(engineNet);
+  });
+
+  it('applies scenario extras to the matching entities', () => {
+    const baseline = buildForecastChartData(
+      [loan],
+      [],
+      HORIZON,
+      undefined,
+      TODAY
+    );
+    const withExtra = buildForecastChartData(
+      [loan],
+      [],
+      HORIZON,
+      { ExtraLoanPayments: { 'loan-1': 1000 } },
+      TODAY
+    );
+    const baseLoan = baseline.series.find((s) => s.id === 'loan-1')!;
+    const extraLoan = withExtra.series.find((s) => s.id === 'loan-1')!;
+    // More toward principal ⇒ a lower balance next month.
+    expect(extraLoan.values[1]).toBeLessThan(baseLoan.values[1]);
+  });
+});

--- a/src/helpers/forecast-series.test.ts
+++ b/src/helpers/forecast-series.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { NET_WORTH_SERIES_ID, buildForecastChartData } from './forecast-series';
+import {
+  NET_WORTH_SERIES_ID,
+  buildForecastChartData,
+  sliceForecastChartData,
+} from './forecast-series';
 import { forecastNetWorth } from './forecast-helpers';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
@@ -130,5 +134,35 @@ describe('buildForecastChartData', () => {
     const extraLoan = withExtra.series.find((s) => s.id === 'loan-1')!;
     // More toward principal ⇒ a lower balance next month.
     expect(extraLoan.values[1]).toBeLessThan(baseLoan.values[1]);
+  });
+});
+
+describe('sliceForecastChartData', () => {
+  const full = buildForecastChartData(
+    [loan],
+    [investment],
+    HORIZON,
+    undefined,
+    TODAY
+  );
+
+  it('keeps the first N month-steps (N+1 points) across every series', () => {
+    const sliced = sliceForecastChartData(full, 2);
+    expect(sliced.dates).toHaveLength(3);
+    sliced.series.forEach((s) => expect(s.values).toHaveLength(3));
+    // Windowed values match the head of the full series (today-anchored).
+    expect(sliced.series[0].values).toEqual(full.series[0].values.slice(0, 3));
+  });
+
+  it('clamps to the full series when asked for more than the horizon', () => {
+    const sliced = sliceForecastChartData(full, 999);
+    expect(sliced.dates).toHaveLength(full.dates.length);
+    expect(sliced.series[0].values).toEqual(full.series[0].values);
+  });
+
+  it('does not mutate the source data', () => {
+    const beforeLength = full.dates.length;
+    sliceForecastChartData(full, 1);
+    expect(full.dates).toHaveLength(beforeLength);
   });
 });

--- a/src/helpers/forecast-series.ts
+++ b/src/helpers/forecast-series.ts
@@ -107,3 +107,23 @@ export const buildForecastChartData = (
 
   return { dates, series };
 };
+
+/**
+ * Window a forecast to the first `months` month-steps (the time-range control,
+ * 2.4). Index 0 is today, so `months` steps means `months + 1` points; the
+ * window is clamped to what exists, so asking for more than the horizon returns
+ * the full series. Pure slice — every series stays aligned to the trimmed axis.
+ */
+export const sliceForecastChartData = (
+  data: ForecastChartData,
+  months: number
+): ForecastChartData => {
+  const count = Math.min(months + 1, data.dates.length);
+  return {
+    dates: data.dates.slice(0, count),
+    series: data.series.map((s) => ({
+      ...s,
+      values: s.values.slice(0, count),
+    })),
+  };
+};

--- a/src/helpers/forecast-series.ts
+++ b/src/helpers/forecast-series.ts
@@ -1,0 +1,109 @@
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { ScenarioInput } from '../models/forecast-model';
+import {
+  forecastInvestment,
+  forecastLoan,
+  forecastNetWorth,
+} from './forecast-helpers';
+
+// Chart-ready shaping of the forecast engine (Phase 2). The engine already
+// produces every series on a shared monthly date axis anchored to today; this
+// turns those into the labelled, aligned arrays a line chart consumes, with the
+// net-worth line guaranteed identical to `forecastNetWorth` (single source of
+// truth — Charter cross-consistency). Pure and framework-free (D7), so the
+// chart, dashboard, and scenario overlays all read the same data.
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export type ForecastSeriesKind = 'loan' | 'investment' | 'networth';
+
+export interface ForecastSeries {
+  // Entity Id for loans/investments, or the literal 'networth'.
+  id: string;
+  label: string;
+  kind: ForecastSeriesKind;
+  // One value per date in `ForecastChartData.dates`, same length and order.
+  values: number[];
+}
+
+export interface ForecastChartData {
+  dates: Date[];
+  series: ForecastSeries[];
+}
+
+// Stable id for the aggregate net-worth line, so consumers (legend, scenario
+// overlays) can reference it without colliding with an entity Id.
+export const NET_WORTH_SERIES_ID = 'networth';
+
+/**
+ * Build the chart series for the given positions over a horizon. Order is
+ * loans, then investments, then the aggregate net-worth line. Loan lines are the
+ * remaining balance (declining to 0 at payoff); investment lines are projected
+ * value; the net-worth line is Σ investments − Σ loans, computed the same way as
+ * `forecastNetWorth` so the chart and any net-worth readout never disagree.
+ */
+export const buildForecastChartData = (
+  loans: Loan[],
+  investments: Investment[],
+  horizon: Date,
+  scenario?: ScenarioInput,
+  today: Date = new Date()
+): ForecastChartData => {
+  const loanForecasts = loans.map((loan) =>
+    forecastLoan(
+      loan,
+      horizon,
+      scenario?.ExtraLoanPayments?.[loan.Id] ?? 0,
+      today
+    )
+  );
+  const investmentForecasts = investments.map((investment) =>
+    forecastInvestment(
+      investment,
+      horizon,
+      scenario?.ExtraContributions?.[investment.Id] ?? 0,
+      today
+    )
+  );
+
+  // A reference series with no entities gives the shared date axis even when
+  // there are no positions yet (an empty forecast is still a date-stamped axis).
+  const reference = forecastNetWorth([], [], horizon, undefined, today);
+  const dates = reference.map((point) => point.Date);
+
+  const netWorthValues = dates.map((_, month) => {
+    const assets = investmentForecasts.reduce(
+      (sum, series) => sum + series[month].Value,
+      0
+    );
+    const debts = loanForecasts.reduce(
+      (sum, series) => sum + series[month].Value,
+      0
+    );
+    return roundToCents(assets - debts);
+  });
+
+  const series: ForecastSeries[] = [
+    ...loans.map((loan, index) => ({
+      id: loan.Id,
+      label: loan.Name,
+      kind: 'loan' as const,
+      values: loanForecasts[index].map((point) => point.Value),
+    })),
+    ...investments.map((investment, index) => ({
+      id: investment.Id,
+      label: investment.Name,
+      kind: 'investment' as const,
+      values: investmentForecasts[index].map((point) => point.Value),
+    })),
+    {
+      id: NET_WORTH_SERIES_ID,
+      label: 'Net worth',
+      kind: 'networth' as const,
+      values: netWorthValues,
+    },
+  ];
+
+  return { dates, series };
+};

--- a/src/helpers/format-helpers.test.ts
+++ b/src/helpers/format-helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { formatCurrency, formatPercent } from './format-helpers';
+import {
+  formatCurrency,
+  formatCurrencyCompact,
+  formatPercent,
+} from './format-helpers';
 
 describe('formatCurrency', () => {
   it('formats a whole-dollar amount with two fraction digits', () => {
@@ -41,6 +45,22 @@ describe('formatCurrency', () => {
       });
       expect(formatCurrency(value)).toBe(expected);
     }
+  });
+});
+
+describe('formatCurrencyCompact', () => {
+  it('abbreviates thousands and millions', () => {
+    expect(formatCurrencyCompact(6000)).toBe('$6K');
+    expect(formatCurrencyCompact(1234567)).toBe('$1.2M');
+  });
+
+  it('formats zero and negatives', () => {
+    expect(formatCurrencyCompact(0)).toBe('$0');
+    expect(formatCurrencyCompact(-6000)).toBe('-$6K');
+  });
+
+  it('leaves small values without an abbreviation suffix', () => {
+    expect(formatCurrencyCompact(500)).toBe('$500');
   });
 });
 

--- a/src/helpers/format-helpers.ts
+++ b/src/helpers/format-helpers.ts
@@ -13,6 +13,19 @@ const usdFormatter = new Intl.NumberFormat('en-US', {
   maximumFractionDigits: 2,
 });
 
+// Compact currency for dense surfaces like chart axes/tooltips, where a full
+// "$1,234,567.00" would overlap: e.g. `1234567` -> `"$1.2M"`, `6000` -> `"$6K"`.
+const usdCompactFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+  notation: 'compact',
+  // Currency style defaults the minimum to 2; with a max of 1 Intl would clamp
+  // the minimum to 1 and render "$6.0K". An explicit 0 minimum drops the
+  // trailing zero so round thousands read "$6K".
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
 // Percent formatters are keyed by fraction-digit count so callers that want a
 // different precision (loans: 2 digits, investments: 3) share cached instances.
 const percentFormatters = new Map<number, Intl.NumberFormat>();
@@ -37,6 +50,13 @@ const getPercentFormatter = (fractionDigits: number): Intl.NumberFormat => {
  */
 export const formatCurrency = (amount: number): string =>
   usdFormatter.format(amount);
+
+/**
+ * Formats a number as compact US dollars for space-constrained surfaces (chart
+ * axis ticks, tooltips), e.g. `1234567` -> `"$1.2M"`, `-6000` -> `"-$6K"`.
+ */
+export const formatCurrencyCompact = (amount: number): string =>
+  usdCompactFormatter.format(amount);
 
 /**
  * Formats a percentage value, where `percent` is the human-facing percent

--- a/src/helpers/migrate-helpers.test.ts
+++ b/src/helpers/migrate-helpers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CURRENT_SCHEMA_VERSION,
+  migrate,
+  VersionedData,
+} from './migrate-helpers';
+import { EXPORT_SCHEMA_VERSION } from './data-helpers';
+
+describe('migrate (D8 migration ladder)', () => {
+  it('exposes the current schema version, anchored to the export schema', () => {
+    // The ladder and the export serializer must agree on what "current" means,
+    // otherwise freshly-saved data could fail its own migration.
+    expect(CURRENT_SCHEMA_VERSION).toBe(EXPORT_SCHEMA_VERSION);
+  });
+
+  it('passes data already at the current version through unchanged', () => {
+    const data = {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      loans: [],
+      investments: [],
+    };
+    // Same reference back out — the single current rung is an identity step.
+    expect(migrate(data)).toBe(data);
+  });
+
+  it('throws when schemaVersion is missing or non-numeric', () => {
+    expect(() => migrate({} as unknown as VersionedData)).toThrow(
+      'schemaVersion must be a number'
+    );
+    expect(() =>
+      migrate({ schemaVersion: '2' } as unknown as VersionedData)
+    ).toThrow('schemaVersion must be a number');
+  });
+
+  it('throws for a version newer than this app understands', () => {
+    expect(() =>
+      migrate({ schemaVersion: CURRENT_SCHEMA_VERSION + 1 })
+    ).toThrow('written by a newer version');
+  });
+
+  it('throws for a legacy version with no migration path', () => {
+    expect(() =>
+      migrate({ schemaVersion: CURRENT_SCHEMA_VERSION - 1 })
+    ).toThrow('no migration path is available');
+  });
+});

--- a/src/helpers/migrate-helpers.test.ts
+++ b/src/helpers/migrate-helpers.test.ts
@@ -1,46 +1,56 @@
 import { describe, it, expect } from 'vitest';
-import {
-  CURRENT_SCHEMA_VERSION,
-  migrate,
-  VersionedData,
-} from './migrate-helpers';
+import { CURRENT_SCHEMA_VERSION, RawData, migrate } from './migrate-helpers';
 import { EXPORT_SCHEMA_VERSION } from './data-helpers';
 
 describe('migrate (D8 migration ladder)', () => {
-  it('exposes the current schema version, anchored to the export schema', () => {
-    // The ladder and the export serializer must agree on what "current" means,
-    // otherwise freshly-saved data could fail its own migration.
+  it('exposes the current schema version, matching the export schema', () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(3);
     expect(CURRENT_SCHEMA_VERSION).toBe(EXPORT_SCHEMA_VERSION);
   });
 
   it('passes data already at the current version through unchanged', () => {
-    const data = {
+    const data: RawData = {
       schemaVersion: CURRENT_SCHEMA_VERSION,
       loans: [],
       investments: [],
+      scenarios: [],
     };
-    // Same reference back out — the single current rung is an identity step.
     expect(migrate(data)).toBe(data);
   });
 
-  it('throws when schemaVersion is missing or non-numeric', () => {
-    expect(() => migrate({} as unknown as VersionedData)).toThrow(
+  it('migrates v2 to v3 by adding an empty scenarios list', () => {
+    const migrated = migrate({ schemaVersion: 2, loans: [], investments: [] });
+    expect(migrated.schemaVersion).toBe(3);
+    expect(migrated.scenarios).toEqual([]);
+  });
+
+  it('preserves a scenarios array already present on a v2 payload', () => {
+    const scenarios = [{ Id: 's1', Name: 'A' }];
+    const migrated = migrate({ schemaVersion: 2, scenarios });
+    expect(migrated.scenarios).toBe(scenarios);
+  });
+
+  it('rejects a missing schemaVersion as a legacy v1 file', () => {
+    expect(() => migrate({} as unknown as RawData)).toThrow(
+      'Legacy (v1) files are not supported'
+    );
+  });
+
+  it('rejects a non-numeric schemaVersion', () => {
+    expect(() => migrate({ schemaVersion: '3' } as unknown as RawData)).toThrow(
       'schemaVersion must be a number'
     );
-    expect(() =>
-      migrate({ schemaVersion: '2' } as unknown as VersionedData)
-    ).toThrow('schemaVersion must be a number');
   });
 
-  it('throws for a version newer than this app understands', () => {
+  it('rejects a version newer than this app understands', () => {
     expect(() =>
       migrate({ schemaVersion: CURRENT_SCHEMA_VERSION + 1 })
-    ).toThrow('written by a newer version');
+    ).toThrow('newer version');
   });
 
-  it('throws for a legacy version with no migration path', () => {
-    expect(() =>
-      migrate({ schemaVersion: CURRENT_SCHEMA_VERSION - 1 })
-    ).toThrow('no migration path is available');
+  it('rejects a legacy version with no migration path', () => {
+    expect(() => migrate({ schemaVersion: 1 })).toThrow(
+      'legacy files are not supported'
+    );
   });
 });

--- a/src/helpers/migrate-helpers.ts
+++ b/src/helpers/migrate-helpers.ts
@@ -1,0 +1,51 @@
+import { EXPORT_SCHEMA_VERSION } from './data-helpers';
+
+// D8 — the single, versioned schema-migration ladder.
+//
+// Every persisted-data entry point runs raw parsed data through `migrate` so
+// older stored schemas upgrade forward deterministically *before* validation.
+// Today that entry point is localStorage hydration (D4 / Phase 1); JSON import
+// (D5) keeps its own inline version gate for now and unifies here at the first
+// real schema bump (scenarios, 4.5), where stored data first has to survive a
+// version change.
+//
+// The ladder currently has a single rung: the only supported version is the
+// current one. Each future `schemaVersion` bump adds exactly one step that
+// upgrades data from the previous version to the next — individually tested to
+// the Charter (§4) standard — at which point this gate becomes a stepwise
+// upgrade loop. Until then, any version below the current one is unsupported,
+// mirroring `importFromJson`'s rejection of legacy v1 files.
+
+export const CURRENT_SCHEMA_VERSION = EXPORT_SCHEMA_VERSION;
+
+/** Minimal shape every persisted/serialized payload shares: a numeric version. */
+export interface VersionedData {
+  schemaVersion: number;
+}
+
+/**
+ * Bring a parsed payload up to {@link CURRENT_SCHEMA_VERSION}, or throw a
+ * descriptive error if it cannot be migrated (missing/non-numeric version, a
+ * version newer than this app understands, or a legacy version with no
+ * migration path). Callers that hydrate untrusted storage should treat a throw
+ * as "discard and start clean" rather than letting it propagate.
+ */
+export const migrate = <T extends VersionedData>(data: T): T => {
+  const { schemaVersion } = data;
+
+  if (typeof schemaVersion !== 'number') {
+    throw new Error('Invalid data format: schemaVersion must be a number.');
+  }
+  if (schemaVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported schema version ${schemaVersion}: this data was written by a newer version of the app.`
+    );
+  }
+  if (schemaVersion < CURRENT_SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported schema version ${schemaVersion}: no migration path is available (legacy data is not supported).`
+    );
+  }
+
+  return data;
+};

--- a/src/helpers/migrate-helpers.ts
+++ b/src/helpers/migrate-helpers.ts
@@ -1,51 +1,67 @@
-import { EXPORT_SCHEMA_VERSION } from './data-helpers';
-
 // D8 — the single, versioned schema-migration ladder.
 //
-// Every persisted-data entry point runs raw parsed data through `migrate` so
-// older stored schemas upgrade forward deterministically *before* validation.
-// Today that entry point is localStorage hydration (D4 / Phase 1); JSON import
-// (D5) keeps its own inline version gate for now and unifies here at the first
-// real schema bump (scenarios, 4.5), where stored data first has to survive a
-// version change.
-//
-// The ladder currently has a single rung: the only supported version is the
-// current one. Each future `schemaVersion` bump adds exactly one step that
-// upgrades data from the previous version to the next — individually tested to
-// the Charter (§4) standard — at which point this gate becomes a stepwise
-// upgrade loop. Until then, any version below the current one is unsupported,
-// mirroring `importFromJson`'s rejection of legacy v1 files.
+// Every persisted-data entry point — JSON import (D5) and localStorage
+// hydration (D4) — runs raw parsed data through `migrate` so older stored
+// schemas upgrade forward deterministically before validation. As of Phase 4.5
+// the ladder has its first real rung (v2 → v3, adding `scenarios`); each future
+// `schemaVersion` bump adds exactly one more step, individually tested to the
+// Charter (§4) standard.
 
-export const CURRENT_SCHEMA_VERSION = EXPORT_SCHEMA_VERSION;
+// The current schema version. data-helpers re-exports this as
+// EXPORT_SCHEMA_VERSION; kept here so the ladder owns the "current" definition.
+export const CURRENT_SCHEMA_VERSION = 3;
 
-/** Minimal shape every persisted/serialized payload shares: a numeric version. */
-export interface VersionedData {
-  schemaVersion: number;
-}
+// A parsed payload: a numeric schemaVersion plus arbitrary other fields the
+// individual migration steps and the downstream validator interpret.
+export type RawData = { schemaVersion: number } & Record<string, unknown>;
+
+// A migration step upgrades data from one version to the next.
+type MigrationStep = (data: RawData) => RawData;
+
+// Keyed by the version each step upgrades FROM. v2 → v3 introduces the
+// `scenarios` array (Phase 4.5); a v2 file simply gains an empty list.
+const MIGRATIONS: Record<number, MigrationStep> = {
+  2: (data) => ({
+    ...data,
+    schemaVersion: 3,
+    scenarios: Array.isArray(data.scenarios) ? data.scenarios : [],
+  }),
+};
 
 /**
- * Bring a parsed payload up to {@link CURRENT_SCHEMA_VERSION}, or throw a
- * descriptive error if it cannot be migrated (missing/non-numeric version, a
- * version newer than this app understands, or a legacy version with no
- * migration path). Callers that hydrate untrusted storage should treat a throw
- * as "discard and start clean" rather than letting it propagate.
+ * Bring a parsed payload up to {@link CURRENT_SCHEMA_VERSION}, applying each
+ * migration step in turn, or throw a descriptive error if it cannot be
+ * migrated. Callers hydrating untrusted storage should treat a throw as
+ * "discard and start clean". Error messages are intentionally stable — the
+ * import boundary relies on them.
  */
-export const migrate = <T extends VersionedData>(data: T): T => {
-  const { schemaVersion } = data;
+export const migrate = (data: RawData): RawData => {
+  const version: unknown = data.schemaVersion;
 
-  if (typeof schemaVersion !== 'number') {
+  if (version === undefined) {
+    throw new Error(
+      'Invalid data format: missing schemaVersion. Legacy (v1) files are not supported.'
+    );
+  }
+  if (typeof version !== 'number') {
     throw new Error('Invalid data format: schemaVersion must be a number.');
   }
-  if (schemaVersion > CURRENT_SCHEMA_VERSION) {
+  if (version > CURRENT_SCHEMA_VERSION) {
     throw new Error(
-      `Unsupported schema version ${schemaVersion}: this data was written by a newer version of the app.`
-    );
-  }
-  if (schemaVersion < CURRENT_SCHEMA_VERSION) {
-    throw new Error(
-      `Unsupported schema version ${schemaVersion}: no migration path is available (legacy data is not supported).`
+      `Unsupported schema version ${version}: this data was written by a newer version of the app.`
     );
   }
 
-  return data;
+  let current = data;
+  while (current.schemaVersion < CURRENT_SCHEMA_VERSION) {
+    const step = MIGRATIONS[current.schemaVersion];
+    if (!step) {
+      throw new Error(
+        `Unsupported schema version ${current.schemaVersion}: legacy files are not supported.`
+      );
+    }
+    current = step(current);
+  }
+
+  return current;
 };

--- a/src/helpers/milestone-helpers.test.ts
+++ b/src/helpers/milestone-helpers.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { computeMilestones } from './milestone-helpers';
+import { forecastNetWorth } from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+const TODAY = new Date(2025, 0, 1);
+
+// Small loan that pays off quickly: 1000 balance, $500/mo, 0% — gone in ~2 months.
+const shortLoan: Loan = {
+  Id: 'loan-short',
+  Provider: 'Bank',
+  Name: 'Small Loan',
+  InterestRate: 0,
+  Principal: 1000,
+  CurrentAmount: 1000,
+  MonthlyPayment: 500,
+  StartDate: new Date(2024, 0, 1),
+  EndDate: new Date(2026, 0, 1),
+};
+
+const investment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  CurrentValue: 10000,
+};
+
+describe('computeMilestones', () => {
+  it('reports net worth at +5y / +10y / +30y from the same engine series', () => {
+    const { netWorthAt } = computeMilestones([], [investment], TODAY);
+    expect(netWorthAt.map((m) => m.years)).toEqual([5, 10, 30]);
+
+    const series = forecastNetWorth(
+      [],
+      [investment],
+      new Date(2055, 0, 1),
+      undefined,
+      TODAY
+    );
+    expect(netWorthAt[0].value).toBe(series[60].Value);
+    expect(netWorthAt[2].value).toBe(series[360].Value);
+    // Positive-return investment grows over 30 years.
+    expect(netWorthAt[2].value).toBeGreaterThan(netWorthAt[0].value);
+  });
+
+  it('projects a debt-free date once loans pay off', () => {
+    const { debtFreeDate } = computeMilestones([shortLoan], [], TODAY);
+    expect(debtFreeDate).toBeInstanceOf(Date);
+    // $1000 at $500/mo, 0% interest → paid off by month 2.
+    expect(debtFreeDate!.getTime()).toBe(new Date(2025, 2, 1).getTime());
+  });
+
+  it('has no debt-free date when there are no loans', () => {
+    const { debtFreeDate } = computeMilestones([], [investment], TODAY);
+    expect(debtFreeDate).toBeUndefined();
+  });
+
+  it('has no debt-free date when a loan never pays off within the horizon', () => {
+    // Payment below interest never amortizes → balance never reaches zero.
+    const neverPays: Loan = {
+      ...shortLoan,
+      Id: 'loan-never',
+      InterestRate: 20,
+      CurrentAmount: 100000,
+      MonthlyPayment: 1,
+      EndDate: new Date(2100, 0, 1),
+    };
+    const { debtFreeDate } = computeMilestones([neverPays], [], TODAY);
+    expect(debtFreeDate).toBeUndefined();
+  });
+});

--- a/src/helpers/milestone-helpers.ts
+++ b/src/helpers/milestone-helpers.ts
@@ -1,0 +1,73 @@
+import dayjs from 'dayjs';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import {
+  forecastLoan,
+  forecastNetWorth,
+  getDefaultHorizon,
+} from './forecast-helpers';
+
+// Dashboard milestone derivations (Phase 3.2): the projected debt-free date and
+// net worth at +5y / +10y / +30y. Cheap reads off the same engine series the
+// chart uses. Pure and framework-free (D7).
+
+export const MILESTONE_YEARS = [5, 10, 30] as const;
+
+export interface NetWorthMilestone {
+  years: number;
+  value: number;
+}
+
+export interface Milestones {
+  // First date Σ loan balances reach zero, or undefined if there are no loans
+  // or none pay off within the horizon.
+  debtFreeDate?: Date;
+  netWorthAt: NetWorthMilestone[];
+}
+
+export const computeMilestones = (
+  loans: Loan[],
+  investments: Investment[],
+  today: Date = new Date()
+): Milestones => {
+  // Extend the horizon to at least 30 years so the +30y milestone always exists,
+  // while still covering a longer loan schedule for the debt-free date.
+  const defaultHorizon = getDefaultHorizon(loans, investments, today);
+  const thirtyYears = dayjs(today).add(30, 'year').toDate();
+  const horizon = dayjs(defaultHorizon).isAfter(thirtyYears)
+    ? defaultHorizon
+    : thirtyYears;
+
+  const netWorth = forecastNetWorth(
+    loans,
+    investments,
+    horizon,
+    undefined,
+    today
+  );
+
+  const netWorthAt = MILESTONE_YEARS.map((years) => ({
+    years,
+    value: netWorth[Math.min(years * 12, netWorth.length - 1)].Value,
+  }));
+
+  // Debt-free: the first month the summed loan balances reach zero.
+  let debtFreeDate: Date | undefined;
+  if (loans.length > 0) {
+    const loanSeries = loans.map((loan) =>
+      forecastLoan(loan, horizon, 0, today)
+    );
+    for (let month = 0; month < netWorth.length; month++) {
+      const totalDebt = loanSeries.reduce(
+        (sum, series) => sum + series[month].Value,
+        0
+      );
+      if (totalDebt <= 0) {
+        debtFreeDate = netWorth[month].Date;
+        break;
+      }
+    }
+  }
+
+  return { debtFreeDate, netWorthAt };
+};

--- a/src/helpers/optimizer-helpers.test.ts
+++ b/src/helpers/optimizer-helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { evaluatePlan } from './optimizer-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+const TODAY = new Date(2025, 0, 1);
+
+const loan: Loan = {
+  Id: 'loan-1',
+  Provider: 'Bank',
+  Name: 'Car Loan',
+  InterestRate: 9,
+  Principal: 20000,
+  CurrentAmount: 12000,
+  MonthlyPayment: 400,
+  StartDate: new Date(2023, 0, 1),
+  EndDate: new Date(2028, 0, 1),
+};
+
+const investment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  CurrentValue: 10000,
+};
+
+describe('evaluatePlan', () => {
+  it('scores an all-to-loan plan by interest saved and earlier payoff', () => {
+    const evaluation = evaluatePlan(
+      [loan],
+      [investment],
+      { label: 'All to Car Loan', allocations: { 'loan-1': 500 } },
+      TODAY
+    );
+    expect(evaluation.interestSaved).toBeGreaterThan(0);
+    expect(evaluation.payoffMonthsEarlier).toBeGreaterThan(0);
+    // Score credits the interest avoided even when the horizon net worth is flat.
+    expect(evaluation.score).toBeGreaterThan(0);
+  });
+
+  it('scores an all-to-investment plan by net worth gained', () => {
+    const evaluation = evaluatePlan(
+      [loan],
+      [investment],
+      { label: 'All to Index Fund', allocations: { 'inv-1': 500 } },
+      TODAY
+    );
+    expect(evaluation.netWorthDelta).toBeGreaterThan(0);
+    expect(evaluation.interestSaved).toBe(0);
+    expect(evaluation.payoffMonthsEarlier).toBe(0);
+    expect(evaluation.score).toBeGreaterThan(0);
+  });
+
+  it('an empty plan has zero impact and score', () => {
+    const evaluation = evaluatePlan(
+      [loan],
+      [investment],
+      { label: 'Nothing', allocations: {} },
+      TODAY
+    );
+    expect(evaluation.score).toBe(0);
+    expect(evaluation.netWorthDelta).toBe(0);
+    expect(evaluation.interestSaved).toBe(0);
+    expect(evaluation.payoffMonthsEarlier).toBe(0);
+  });
+
+  it('ignores non-positive allocations', () => {
+    const evaluation = evaluatePlan(
+      [loan],
+      [investment],
+      { label: 'Zeroes', allocations: { 'loan-1': 0, 'inv-1': -100 } },
+      TODAY
+    );
+    expect(evaluation.score).toBe(0);
+  });
+});

--- a/src/helpers/optimizer-helpers.ts
+++ b/src/helpers/optimizer-helpers.ts
@@ -1,0 +1,76 @@
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { ScenarioInput } from '../models/forecast-model';
+import { computeScenarioImpact } from './scenario-impact-helpers';
+
+// The "Next Dollar" optimizer engine (Phase 5). An allocation plan splits $X/mo
+// across any number of loans/investments; evaluatePlan scores it against the
+// baseline using the same forecast engine the chart and scenarios use. Pure and
+// framework-free (D7) so the Phase 5.2 search can run in a Web Worker.
+//
+// A single-target plan is the degenerate 100%-to-one case. v1 does NOT redirect
+// a loan's freed payment after payoff (the "snowball" mode reserved for later) —
+// see the score note below for how the ranking still values debt payoff.
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export interface AllocationPlan {
+  // Human-readable description, e.g. "All to Car Loan" or "50% Car Loan / 50% 401k".
+  label: string;
+  // Extra $/month per target Id (a loan or an investment).
+  allocations: Record<string, number>;
+}
+
+export interface PlanEvaluation {
+  plan: AllocationPlan;
+  // Net worth at the forecast horizon vs. baseline.
+  netWorthDelta: number;
+  // Lifetime loan interest avoided vs. baseline.
+  interestSaved: number;
+  // Months the projected debt-free date moves earlier.
+  payoffMonthsEarlier: number;
+  // Ranking objective: net worth gained PLUS interest saved. Net worth at the
+  // horizon alone undervalues paying off a loan that's already cleared by then
+  // (v1 doesn't redirect the freed payment), so interest avoided — real money
+  // that stayed with the user — is added so high-rate debt payoff ranks fairly
+  // against investing.
+  score: number;
+}
+
+// Split a plan's allocations into the engine's loan/contribution maps, dropping
+// non-positive amounts. An Id that matches no loan is treated as a contribution
+// target (and simply does nothing if it matches no investment either).
+const planToScenario = (
+  loans: Loan[],
+  allocations: Record<string, number>
+): ScenarioInput => {
+  const loanIds = new Set(loans.map((loan) => loan.Id));
+  const ExtraLoanPayments: Record<string, number> = {};
+  const ExtraContributions: Record<string, number> = {};
+  for (const [id, amount] of Object.entries(allocations)) {
+    if (!(amount > 0)) continue;
+    if (loanIds.has(id)) {
+      ExtraLoanPayments[id] = amount;
+    } else {
+      ExtraContributions[id] = amount;
+    }
+  }
+  return { ExtraLoanPayments, ExtraContributions };
+};
+
+export const evaluatePlan = (
+  loans: Loan[],
+  investments: Investment[],
+  plan: AllocationPlan,
+  today: Date = new Date()
+): PlanEvaluation => {
+  const scenario = planToScenario(loans, plan.allocations);
+  const impact = computeScenarioImpact(loans, investments, scenario, today);
+  return {
+    plan,
+    netWorthDelta: impact.netWorthDelta,
+    interestSaved: impact.interestSaved,
+    payoffMonthsEarlier: impact.payoffMonthsEarlier,
+    score: roundToCents(impact.netWorthDelta + impact.interestSaved),
+  };
+};

--- a/src/helpers/scenario-impact-helpers.test.ts
+++ b/src/helpers/scenario-impact-helpers.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { computeScenarioImpact } from './scenario-impact-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+const TODAY = new Date(2025, 0, 1);
+
+const loan: Loan = {
+  Id: 'loan-1',
+  Provider: 'Bank',
+  Name: 'Car Loan',
+  InterestRate: 6,
+  Principal: 20000,
+  CurrentAmount: 12000,
+  MonthlyPayment: 400,
+  StartDate: new Date(2023, 0, 1),
+  EndDate: new Date(2028, 0, 1),
+};
+
+const investment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  CurrentValue: 10000,
+};
+
+describe('computeScenarioImpact', () => {
+  it('an extra loan payment saves interest and moves up the payoff date', () => {
+    const impact = computeScenarioImpact(
+      [loan],
+      [],
+      { ExtraLoanPayments: { 'loan-1': 300 } },
+      TODAY
+    );
+    expect(impact.interestSaved).toBeGreaterThan(0);
+    expect(impact.payoffMonthsEarlier).toBeGreaterThan(0);
+    // Net worth at the horizon is never worse (both loans are paid off by then,
+    // and freed payments aren't redirected in v1 — so the gain shows as interest
+    // saved + earlier payoff, not a horizon net-worth jump).
+    expect(impact.netWorthDelta).toBeGreaterThanOrEqual(0);
+  });
+
+  it('an extra contribution raises net worth without touching loan metrics', () => {
+    const impact = computeScenarioImpact(
+      [loan],
+      [investment],
+      { ExtraContributions: { 'inv-1': 200 } },
+      TODAY
+    );
+    expect(impact.netWorthDelta).toBeGreaterThan(0);
+    expect(impact.interestSaved).toBe(0);
+    expect(impact.payoffMonthsEarlier).toBe(0);
+  });
+
+  it('an empty scenario has no impact', () => {
+    const impact = computeScenarioImpact([loan], [investment], {}, TODAY);
+    expect(impact.netWorthDelta).toBe(0);
+    expect(impact.interestSaved).toBe(0);
+    expect(impact.payoffMonthsEarlier).toBe(0);
+  });
+
+  it('reports no payoff change when there are no loans', () => {
+    const impact = computeScenarioImpact(
+      [],
+      [investment],
+      { ExtraContributions: { 'inv-1': 100 } },
+      TODAY
+    );
+    expect(impact.payoffMonthsEarlier).toBe(0);
+    expect(impact.interestSaved).toBe(0);
+  });
+});

--- a/src/helpers/scenario-impact-helpers.ts
+++ b/src/helpers/scenario-impact-helpers.ts
@@ -1,0 +1,142 @@
+import dayjs from 'dayjs';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { ScenarioInput } from '../models/forecast-model';
+import {
+  forecastLoan,
+  forecastNetWorth,
+  getDefaultHorizon,
+} from './forecast-helpers';
+
+// Scenario impact vs. baseline (Phase 4.4): what a what-if actually buys you —
+// net worth at the horizon, lifetime loan interest saved, and how much sooner
+// the debt-free date arrives. Pure and framework-free (D7), reading the same
+// engine series the chart draws.
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export interface ScenarioImpact {
+  // Scenario − baseline net worth at the forecast horizon (positive = better).
+  netWorthDelta: number;
+  // Baseline − scenario total loan interest over the loans' lifetimes
+  // (positive = interest saved).
+  interestSaved: number;
+  // Months the projected debt-free date moves earlier (0 if unchanged, or if a
+  // debt-free date can't be determined for both baseline and scenario).
+  payoffMonthsEarlier: number;
+}
+
+// Total interest a loan accrues over the forecast: each month's interest is the
+// prior month's balance times the monthly rate (the engine accrues on the
+// balance before the payment, and a paid-off balance of 0 accrues nothing).
+const totalLoanInterest = (
+  loan: Loan,
+  horizon: Date,
+  extraMonthlyPayment: number,
+  today: Date
+): number => {
+  const series = forecastLoan(loan, horizon, extraMonthlyPayment, today);
+  const monthlyRate = loan.InterestRate / 100 / 12;
+  let total = 0;
+  for (let month = 1; month < series.length; month++) {
+    total += series[month - 1].Value * monthlyRate;
+  }
+  return total;
+};
+
+// First month index at which the summed loan balances reach zero, or undefined
+// if they never do within the horizon.
+const debtFreeMonth = (
+  loans: Loan[],
+  horizon: Date,
+  scenario: ScenarioInput | undefined,
+  today: Date,
+  length: number
+): number | undefined => {
+  if (loans.length === 0) return undefined;
+  const series = loans.map((loan) =>
+    forecastLoan(
+      loan,
+      horizon,
+      scenario?.ExtraLoanPayments?.[loan.Id] ?? 0,
+      today
+    )
+  );
+  for (let month = 0; month < length; month++) {
+    const totalDebt = series.reduce((sum, s) => sum + s[month].Value, 0);
+    if (totalDebt <= 0) return month;
+  }
+  return undefined;
+};
+
+export const computeScenarioImpact = (
+  loans: Loan[],
+  investments: Investment[],
+  scenario: ScenarioInput,
+  today: Date = new Date()
+): ScenarioImpact => {
+  // Net worth compared at the chart's default horizon.
+  const nwHorizon = getDefaultHorizon(loans, investments, today);
+  const baselineNet = forecastNetWorth(
+    loans,
+    investments,
+    nwHorizon,
+    undefined,
+    today
+  );
+  const scenarioNet = forecastNetWorth(
+    loans,
+    investments,
+    nwHorizon,
+    scenario,
+    today
+  );
+  const netWorthDelta = roundToCents(
+    scenarioNet[scenarioNet.length - 1].Value -
+      baselineNet[baselineNet.length - 1].Value
+  );
+
+  // Interest and payoff over a long horizon so full loan lifetimes are captured.
+  const longHorizon = dayjs(today).add(50, 'year').toDate();
+  // The shared month-count of any series over this horizon (an empty net-worth
+  // series is still a date-stamped axis).
+  const length = forecastNetWorth([], [], longHorizon, undefined, today).length;
+
+  const baselineInterest = loans.reduce(
+    (sum, loan) => sum + totalLoanInterest(loan, longHorizon, 0, today),
+    0
+  );
+  const scenarioInterest = loans.reduce(
+    (sum, loan) =>
+      sum +
+      totalLoanInterest(
+        loan,
+        longHorizon,
+        scenario.ExtraLoanPayments?.[loan.Id] ?? 0,
+        today
+      ),
+    0
+  );
+  const interestSaved = roundToCents(baselineInterest - scenarioInterest);
+
+  const baselinePayoff = debtFreeMonth(
+    loans,
+    longHorizon,
+    undefined,
+    today,
+    length
+  );
+  const scenarioPayoff = debtFreeMonth(
+    loans,
+    longHorizon,
+    scenario,
+    today,
+    length
+  );
+  const payoffMonthsEarlier =
+    baselinePayoff !== undefined && scenarioPayoff !== undefined
+      ? Math.max(0, baselinePayoff - scenarioPayoff)
+      : 0;
+
+  return { netWorthDelta, interestSaved, payoffMonthsEarlier };
+};

--- a/src/helpers/sort-helpers.test.ts
+++ b/src/helpers/sort-helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { compareSortValues, sortBy } from './sort-helpers';
+
+describe('compareSortValues', () => {
+  it('orders numbers, strings, and dates ascending', () => {
+    expect(compareSortValues(1, 2)).toBe(-1);
+    expect(compareSortValues(2, 1)).toBe(1);
+    expect(compareSortValues('a', 'b')).toBe(-1);
+    expect(compareSortValues(new Date(2020, 0, 1), new Date(2021, 0, 1))).toBe(
+      -1
+    );
+  });
+
+  it('returns 0 for equal values', () => {
+    expect(compareSortValues(5, 5)).toBe(0);
+    expect(compareSortValues('x', 'x')).toBe(0);
+  });
+});
+
+describe('sortBy', () => {
+  const rows = [
+    { name: 'b', rate: 5 },
+    { name: 'a', rate: 9 },
+    { name: 'c', rate: 5 },
+  ];
+
+  it('sorts ascending and descending by a numeric selector', () => {
+    expect(sortBy(rows, (r) => r.rate, 'asc').map((r) => r.rate)).toEqual([
+      5, 5, 9,
+    ]);
+    expect(sortBy(rows, (r) => r.rate, 'desc').map((r) => r.rate)).toEqual([
+      9, 5, 5,
+    ]);
+  });
+
+  it('is stable for ties (preserves input order)', () => {
+    // b and c both have rate 5; b precedes c in the input and should stay first.
+    expect(sortBy(rows, (r) => r.rate, 'asc').map((r) => r.name)).toEqual([
+      'b',
+      'c',
+      'a',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const original = [...rows];
+    sortBy(rows, (r) => r.rate, 'desc');
+    expect(rows).toEqual(original);
+  });
+});

--- a/src/helpers/sort-helpers.ts
+++ b/src/helpers/sort-helpers.ts
@@ -1,0 +1,35 @@
+// Generic, stable sorting for the data tables (Phase 3.3). Pure and
+// framework-free (D7) so the comparator is unit-tested independently of the
+// table UI. Numbers, strings, and dates are all comparable; callers map a row to
+// one of those via a selector.
+
+export type SortDirection = 'asc' | 'desc';
+export type SortValue = number | string | Date;
+
+const toComparable = (value: SortValue): number | string =>
+  value instanceof Date ? value.getTime() : value;
+
+// -1 / 0 / 1 ordering of two sort values (ascending).
+export const compareSortValues = (a: SortValue, b: SortValue): number => {
+  const ca = toComparable(a);
+  const cb = toComparable(b);
+  if (ca < cb) return -1;
+  if (ca > cb) return 1;
+  return 0;
+};
+
+/**
+ * Return a new array sorted by `selector`. Stable (equal rows keep their input
+ * order), so toggling the sorted column doesn't scramble ties. Never mutates the
+ * input.
+ */
+export const sortBy = <T>(
+  items: T[],
+  selector: (item: T) => SortValue,
+  direction: SortDirection
+): T[] => {
+  const factor = direction === 'asc' ? 1 : -1;
+  return [...items].sort(
+    (a, b) => factor * compareSortValues(selector(a), selector(b))
+  );
+};

--- a/src/helpers/storage-helpers.test.ts
+++ b/src/helpers/storage-helpers.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   STORAGE_DATA_KEY,
   STORAGE_ENABLED_KEY,
+  STORAGE_FIRST_VISIT_KEY,
   saveData,
   loadData,
   clearData,
   isPersistenceEnabled,
   setPersistenceEnabled,
+  hasAcknowledgedFirstVisit,
+  acknowledgeFirstVisit,
 } from './storage-helpers';
-import { exportToJson } from './data-helpers';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
 
@@ -99,11 +101,17 @@ describe('saveData / loadData round-trip', () => {
     expect(inv.StartDate.getTime()).toBe(sampleInvestment.StartDate.getTime());
   });
 
-  it('writes inputs-only schema-v2 JSON (no derived data) under the data key', () => {
+  it('writes inputs-only schema-v2 JSON under the data key', () => {
     saveData([sampleLoan], []);
     const raw = (globalThis.localStorage as Storage).getItem(STORAGE_DATA_KEY);
-    expect(raw).toBe(exportToJson([sampleLoan], []));
-    expect(JSON.parse(raw!).schemaVersion).toBe(2);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    // Same serializer the export path uses: schema v2, derived data stripped.
+    expect(parsed.schemaVersion).toBe(2);
+    expect(parsed.loans).toHaveLength(1);
+    expect(parsed.loans[0].Id).toBe(sampleLoan.Id);
+    // Inputs only — no computed amortization schedule rides along.
+    expect(parsed.loans[0]).not.toHaveProperty('AmortizationSchedule');
   });
 });
 
@@ -227,5 +235,29 @@ describe('persistence preference', () => {
     setStorage(undefined);
     expect(() => setPersistenceEnabled(true)).not.toThrow();
     expect(() => setPersistenceEnabled(false)).not.toThrow();
+  });
+});
+
+describe('first-visit notice acknowledgement', () => {
+  it('reports not-yet-acknowledged by default', () => {
+    expect(hasAcknowledgedFirstVisit()).toBe(false);
+  });
+
+  it('records and reads back the acknowledgement', () => {
+    acknowledgeFirstVisit();
+    expect(
+      (globalThis.localStorage as Storage).getItem(STORAGE_FIRST_VISIT_KEY)
+    ).toBe('true');
+    expect(hasAcknowledgedFirstVisit()).toBe(true);
+  });
+
+  it('treats unreadable storage as not-yet-acknowledged', () => {
+    setStorage(undefined);
+    expect(hasAcknowledgedFirstVisit()).toBe(false);
+  });
+
+  it('ignores storage failures when recording the acknowledgement', () => {
+    setStorage(undefined);
+    expect(() => acknowledgeFirstVisit()).not.toThrow();
   });
 });

--- a/src/helpers/storage-helpers.test.ts
+++ b/src/helpers/storage-helpers.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  STORAGE_DATA_KEY,
+  STORAGE_ENABLED_KEY,
+  saveData,
+  loadData,
+  clearData,
+  isPersistenceEnabled,
+  setPersistenceEnabled,
+} from './storage-helpers';
+import { exportToJson } from './data-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+// The test environment is Node, where `localStorage` does not exist. Install a
+// minimal in-memory Storage so the helpers run exactly as they would in a
+// browser, and restore the original (undefined) global afterwards.
+class MemoryStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.has(key) ? this.store.get(key)! : null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const setStorage = (storage: unknown): void => {
+  (globalThis as { localStorage: unknown }).localStorage = storage;
+};
+
+const sampleLoan: Loan = {
+  Id: 'loan-1',
+  Provider: 'Bank',
+  Name: 'Mortgage',
+  InterestRate: 6.25,
+  Principal: 350000,
+  CurrentAmount: 332500,
+  MonthlyPayment: 2155.18,
+  StartDate: new Date(2023, 4, 1),
+  EndDate: new Date(2053, 4, 1),
+};
+
+const sampleInvestment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 7,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  RecurringContribution: 500,
+  ContributionFrequency: CompoundingFrequency.Monthly,
+};
+
+let originalLocalStorage: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  originalLocalStorage = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'localStorage'
+  );
+  setStorage(new MemoryStorage());
+});
+
+afterEach(() => {
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+  } else {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+  vi.restoreAllMocks();
+});
+
+describe('saveData / loadData round-trip', () => {
+  it('persists inputs and hydrates them back to equivalent entities', () => {
+    expect(saveData([sampleLoan], [sampleInvestment])).toBe('saved');
+
+    const loaded = loadData();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.loans).toHaveLength(1);
+    expect(loaded!.investments).toHaveLength(1);
+
+    const loan = loaded!.loans[0];
+    expect(loan.Id).toBe(sampleLoan.Id);
+    expect(loan.Principal).toBe(sampleLoan.Principal);
+    expect(loan.StartDate.getTime()).toBe(sampleLoan.StartDate.getTime());
+    expect(loan.EndDate.getTime()).toBe(sampleLoan.EndDate.getTime());
+
+    const inv = loaded!.investments[0];
+    expect(inv.Id).toBe(sampleInvestment.Id);
+    expect(inv.AverageReturnRate).toBe(sampleInvestment.AverageReturnRate);
+    expect(inv.StartDate.getTime()).toBe(sampleInvestment.StartDate.getTime());
+  });
+
+  it('writes inputs-only schema-v2 JSON (no derived data) under the data key', () => {
+    saveData([sampleLoan], []);
+    const raw = (globalThis.localStorage as Storage).getItem(STORAGE_DATA_KEY);
+    expect(raw).toBe(exportToJson([sampleLoan], []));
+    expect(JSON.parse(raw!).schemaVersion).toBe(2);
+  });
+});
+
+describe('saveData failure modes', () => {
+  it('reports quota-exceeded for a QuotaExceededError', () => {
+    vi.spyOn(MemoryStorage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('full', 'QuotaExceededError');
+    });
+    expect(saveData([sampleLoan], [])).toBe('quota-exceeded');
+  });
+
+  it("reports quota-exceeded for Firefox's NS_ERROR_DOM_QUOTA_REACHED", () => {
+    vi.spyOn(MemoryStorage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('full', 'NS_ERROR_DOM_QUOTA_REACHED');
+    });
+    expect(saveData([sampleLoan], [])).toBe('quota-exceeded');
+  });
+
+  it('reports unavailable for a non-quota DOMException', () => {
+    vi.spyOn(MemoryStorage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('nope', 'SecurityError');
+    });
+    expect(saveData([sampleLoan], [])).toBe('unavailable');
+  });
+
+  it('reports unavailable for a non-DOMException error (e.g. no storage)', () => {
+    setStorage(undefined);
+    expect(saveData([sampleLoan], [])).toBe('unavailable');
+  });
+});
+
+describe('loadData failure modes', () => {
+  it('returns null when nothing has been saved', () => {
+    expect(loadData()).toBeNull();
+  });
+
+  it('returns null when storage is unreadable', () => {
+    setStorage(undefined);
+    expect(loadData()).toBeNull();
+  });
+
+  it('discards malformed JSON instead of throwing', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (globalThis.localStorage as Storage).setItem(
+      STORAGE_DATA_KEY,
+      'not json {'
+    );
+    expect(loadData()).toBeNull();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('discards data with an unsupported schema version', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (globalThis.localStorage as Storage).setItem(
+      STORAGE_DATA_KEY,
+      JSON.stringify({ schemaVersion: 999, loans: [], investments: [] })
+    );
+    expect(loadData()).toBeNull();
+  });
+
+  it('discards structurally-valid data that fails import validation', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    (globalThis.localStorage as Storage).setItem(
+      STORAGE_DATA_KEY,
+      JSON.stringify({
+        schemaVersion: 2,
+        loans: [{ Id: 'x' }], // missing required fields
+        investments: [],
+      })
+    );
+    expect(loadData()).toBeNull();
+  });
+});
+
+describe('clearData', () => {
+  it('removes persisted data', () => {
+    saveData([sampleLoan], []);
+    clearData();
+    expect(loadData()).toBeNull();
+  });
+
+  it('is silent when storage is unavailable', () => {
+    setStorage(undefined);
+    expect(() => clearData()).not.toThrow();
+  });
+});
+
+describe('persistence preference', () => {
+  it('defaults to disabled', () => {
+    expect(isPersistenceEnabled()).toBe(false);
+  });
+
+  it('persists the enabled flag and reads it back', () => {
+    setPersistenceEnabled(true);
+    expect(
+      (globalThis.localStorage as Storage).getItem(STORAGE_ENABLED_KEY)
+    ).toBe('true');
+    expect(isPersistenceEnabled()).toBe(true);
+  });
+
+  it('clears the flag when disabled', () => {
+    setPersistenceEnabled(true);
+    setPersistenceEnabled(false);
+    expect(
+      (globalThis.localStorage as Storage).getItem(STORAGE_ENABLED_KEY)
+    ).toBeNull();
+    expect(isPersistenceEnabled()).toBe(false);
+  });
+
+  it('treats any non-"true" stored value as disabled', () => {
+    (globalThis.localStorage as Storage).setItem(STORAGE_ENABLED_KEY, 'yes');
+    expect(isPersistenceEnabled()).toBe(false);
+  });
+
+  it('treats unreadable storage as disabled', () => {
+    setStorage(undefined);
+    expect(isPersistenceEnabled()).toBe(false);
+  });
+
+  it('ignores storage failures when recording the preference', () => {
+    setStorage(undefined);
+    expect(() => setPersistenceEnabled(true)).not.toThrow();
+    expect(() => setPersistenceEnabled(false)).not.toThrow();
+  });
+});

--- a/src/helpers/storage-helpers.test.ts
+++ b/src/helpers/storage-helpers.test.ts
@@ -101,13 +101,26 @@ describe('saveData / loadData round-trip', () => {
     expect(inv.StartDate.getTime()).toBe(sampleInvestment.StartDate.getTime());
   });
 
-  it('writes inputs-only schema-v2 JSON under the data key', () => {
+  it('persists and hydrates scenarios alongside the inputs', () => {
+    const scenarios = [
+      {
+        Id: 's1',
+        Name: 'Pay it down',
+        ExtraLoanPayments: { 'loan-1': 250 },
+        ExtraContributions: {},
+      },
+    ];
+    expect(saveData([sampleLoan], [], scenarios)).toBe('saved');
+    expect(loadData()!.scenarios).toEqual(scenarios);
+  });
+
+  it('writes inputs-only current-schema JSON under the data key', () => {
     saveData([sampleLoan], []);
     const raw = (globalThis.localStorage as Storage).getItem(STORAGE_DATA_KEY);
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!);
-    // Same serializer the export path uses: schema v2, derived data stripped.
-    expect(parsed.schemaVersion).toBe(2);
+    // Same serializer the export path uses: current schema, derived data stripped.
+    expect(parsed.schemaVersion).toBe(3);
     expect(parsed.loans).toHaveLength(1);
     expect(parsed.loans[0].Id).toBe(sampleLoan.Id);
     // Inputs only — no computed amortization schedule rides along.

--- a/src/helpers/storage-helpers.ts
+++ b/src/helpers/storage-helpers.ts
@@ -23,6 +23,8 @@ import { migrate, VersionedData } from './migrate-helpers';
 export const STORAGE_DATA_KEY = 'pathwise:data';
 /** Where the "save on this device" preference lives (persisted per issue #20). */
 export const STORAGE_ENABLED_KEY = 'pathwise:persistence-enabled';
+/** Whether the first-visit on-device-data notice has been dismissed (1.3). */
+export const STORAGE_FIRST_VISIT_KEY = 'pathwise:first-visit-acknowledged';
 
 /** Outcome of a save attempt, so the UI can give honest feedback (1.2). */
 export type SaveStatus = 'saved' | 'quota-exceeded' | 'unavailable';
@@ -129,5 +131,27 @@ export const setPersistenceEnabled = (enabled: boolean): void => {
     }
   } catch {
     // Persisting the preference is best-effort; ignore storage failures.
+  }
+};
+
+/**
+ * Has the first-visit "your data stays on this device" notice been dismissed
+ * (1.3)? Unreadable storage is treated as "not yet seen" so the privacy story
+ * still surfaces; the trade-off is it may reappear when storage is unavailable.
+ */
+export const hasAcknowledgedFirstVisit = (): boolean => {
+  try {
+    return globalThis.localStorage.getItem(STORAGE_FIRST_VISIT_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+/** Record that the first-visit notice has been dismissed. Best-effort. */
+export const acknowledgeFirstVisit = (): void => {
+  try {
+    globalThis.localStorage.setItem(STORAGE_FIRST_VISIT_KEY, 'true');
+  } catch {
+    // Best-effort; if we can't record it the notice may reappear next visit.
   }
 };

--- a/src/helpers/storage-helpers.ts
+++ b/src/helpers/storage-helpers.ts
@@ -16,8 +16,8 @@
 
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
 import { exportToJson, importFromJson } from './data-helpers';
-import { migrate, VersionedData } from './migrate-helpers';
 
 /** Where the user's data lives in `localStorage`. */
 export const STORAGE_DATA_KEY = 'pathwise:data';
@@ -47,12 +47,13 @@ const isQuotaExceededError = (error: unknown): boolean =>
  */
 export const saveData = (
   loans: Loan[],
-  investments: Investment[]
+  investments: Investment[],
+  scenarios: Scenario[] = []
 ): SaveStatus => {
   try {
     globalThis.localStorage.setItem(
       STORAGE_DATA_KEY,
-      exportToJson(loans, investments)
+      exportToJson(loans, investments, scenarios)
     );
     return 'saved';
   } catch (error) {
@@ -69,6 +70,7 @@ export const saveData = (
 export const loadData = (): {
   loans: Loan[];
   investments: Investment[];
+  scenarios: Scenario[];
 } | null => {
   let raw: string | null;
   try {
@@ -83,9 +85,9 @@ export const loadData = (): {
   }
 
   try {
-    const parsed = JSON.parse(raw) as VersionedData;
-    const migrated = migrate(parsed);
-    return importFromJson(JSON.stringify(migrated));
+    // importFromJson runs the payload through the D8 migration ladder and the
+    // shared validator, so older stored schemas upgrade forward here too.
+    return importFromJson(raw);
   } catch (error) {
     // Corrupt, partial, or unmigratable data must never white-screen the app
     // (D4): drop it and start clean.

--- a/src/helpers/storage-helpers.ts
+++ b/src/helpers/storage-helpers.ts
@@ -1,0 +1,133 @@
+// On-device persistence (D4 / Phase 1, issue #20). Versioned save/load/clear of
+// the inputs-only schema, plus the persistence-enabled preference itself.
+//
+// D7 boundary: this stays framework-free — it touches only the Web Storage API
+// (a browser global, not an import) and reuses the existing export/import
+// serializers, so it remains unit-testable in Node with a stubbed
+// `localStorage`.
+//
+// Two design rules from issue #20 / the roadmap:
+//   - Inputs only. Serialization goes through `exportToJson`, which already
+//     emits the schema-v2, derived-data-free payload (G2 / D5).
+//   - Hydration must degrade gracefully. Loading runs through the D8 migration
+//     ladder and then the same validator as JSON import (D4); anything corrupt,
+//     partial, unmigratable, or unreadable is dropped (returns `null`) instead
+//     of throwing, so stale or tampered storage can never white-screen the app.
+
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { exportToJson, importFromJson } from './data-helpers';
+import { migrate, VersionedData } from './migrate-helpers';
+
+/** Where the user's data lives in `localStorage`. */
+export const STORAGE_DATA_KEY = 'pathwise:data';
+/** Where the "save on this device" preference lives (persisted per issue #20). */
+export const STORAGE_ENABLED_KEY = 'pathwise:persistence-enabled';
+
+/** Outcome of a save attempt, so the UI can give honest feedback (1.2). */
+export type SaveStatus = 'saved' | 'quota-exceeded' | 'unavailable';
+
+/**
+ * Was a write rejected because the storage quota is full? Browsers signal this
+ * with a `DOMException` named `QuotaExceededError` (Chromium/WebKit) or
+ * `NS_ERROR_DOM_QUOTA_REACHED` (Firefox). Anything else is an "unavailable"
+ * failure (storage disabled, private-mode restrictions, SSR, …).
+ */
+const isQuotaExceededError = (error: unknown): boolean =>
+  error instanceof DOMException &&
+  (error.name === 'QuotaExceededError' ||
+    error.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+
+/**
+ * Persist the current inputs (schema v2, derived data stripped). Returns a
+ * status rather than throwing so callers can surface quota/availability issues
+ * without a try/catch at every site.
+ */
+export const saveData = (
+  loans: Loan[],
+  investments: Investment[]
+): SaveStatus => {
+  try {
+    globalThis.localStorage.setItem(
+      STORAGE_DATA_KEY,
+      exportToJson(loans, investments)
+    );
+    return 'saved';
+  } catch (error) {
+    return isQuotaExceededError(error) ? 'quota-exceeded' : 'unavailable';
+  }
+};
+
+/**
+ * Hydrate previously-saved inputs, or `null` when there is nothing valid to
+ * load. Runs through the D8 migration ladder and the JSON-import validator, and
+ * treats every failure mode — unreadable storage, malformed JSON, an
+ * unmigratable version, or data that fails validation — as "no saved data".
+ */
+export const loadData = (): {
+  loans: Loan[];
+  investments: Investment[];
+} | null => {
+  let raw: string | null;
+  try {
+    raw = globalThis.localStorage.getItem(STORAGE_DATA_KEY);
+  } catch {
+    // Storage unreadable (disabled, private mode, SSR) — behave as if empty.
+    return null;
+  }
+
+  if (raw === null) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as VersionedData;
+    const migrated = migrate(parsed);
+    return importFromJson(JSON.stringify(migrated));
+  } catch (error) {
+    // Corrupt, partial, or unmigratable data must never white-screen the app
+    // (D4): drop it and start clean.
+    console.warn('PathWise: discarding unreadable saved data.', error);
+    return null;
+  }
+};
+
+/** Remove any persisted data. Best-effort; silent if storage is unavailable. */
+export const clearData = (): void => {
+  try {
+    globalThis.localStorage.removeItem(STORAGE_DATA_KEY);
+  } catch {
+    // Nothing to clear if storage is unavailable.
+  }
+};
+
+/**
+ * Is on-device persistence currently enabled? The preference itself is stored
+ * (issue #20), so it survives a reload. Defaults to `false` (opt-in) and treats
+ * unreadable storage as disabled.
+ */
+export const isPersistenceEnabled = (): boolean => {
+  try {
+    return globalThis.localStorage.getItem(STORAGE_ENABLED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Record the persistence preference. Best-effort: failing to store the flag
+ * shouldn't break the toggle interaction. Clearing the stored *data* on disable
+ * is the caller's responsibility (orchestrated in the UI, 1.2) so this stays a
+ * single-purpose setter.
+ */
+export const setPersistenceEnabled = (enabled: boolean): void => {
+  try {
+    if (enabled) {
+      globalThis.localStorage.setItem(STORAGE_ENABLED_KEY, 'true');
+    } else {
+      globalThis.localStorage.removeItem(STORAGE_ENABLED_KEY);
+    }
+  } catch {
+    // Persisting the preference is best-effort; ignore storage failures.
+  }
+};

--- a/src/helpers/summary-helpers.test.ts
+++ b/src/helpers/summary-helpers.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { summarizePositions } from './summary-helpers';
+import { forecastNetWorth } from './forecast-helpers';
+import { Loan } from '../models/loan-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+
+const TODAY = new Date(2025, 0, 1);
+
+const loan: Loan = {
+  Id: 'loan-1',
+  Provider: 'Bank',
+  Name: 'Car Loan',
+  InterestRate: 6,
+  Principal: 12000,
+  CurrentAmount: 6000,
+  MonthlyPayment: 500,
+  StartDate: new Date(2024, 0, 1),
+  EndDate: new Date(2026, 0, 1),
+};
+
+const investment: Investment = {
+  Id: 'inv-1',
+  Provider: 'Brokerage',
+  Name: 'Index Fund',
+  StartDate: new Date(2024, 0, 1),
+  StartingBalance: 10000,
+  AverageReturnRate: 6,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  CurrentValue: 10500,
+  RecurringContribution: 300,
+  ContributionFrequency: CompoundingFrequency.Monthly,
+};
+
+describe('summarizePositions', () => {
+  it('totals debt and assets from the engine today-anchor', () => {
+    const summary = summarizePositions([loan], [investment], TODAY);
+    expect(summary.totalDebt).toBe(6000);
+    // Honors CurrentValue as the asset anchor.
+    expect(summary.totalAssets).toBe(10500);
+    expect(summary.netWorth).toBe(4500);
+  });
+
+  it('net worth matches the chart start (forecastNetWorth index 0)', () => {
+    const summary = summarizePositions([loan], [investment], TODAY);
+    const chartStart = forecastNetWorth(
+      [loan],
+      [investment],
+      TODAY,
+      undefined,
+      TODAY
+    )[0].Value;
+    expect(summary.netWorth).toBe(chartStart);
+  });
+
+  it('sums monthly-equivalent commitments (loan payment + monthly contribution)', () => {
+    const summary = summarizePositions([loan], [investment], TODAY);
+    // 500 loan payment + 300 monthly contribution.
+    expect(summary.monthlyCommitments).toBe(800);
+  });
+
+  it('normalizes non-monthly contribution cadences to a monthly amount', () => {
+    const quarterly: Investment = {
+      ...investment,
+      Id: 'inv-q',
+      RecurringContribution: 300,
+      ContributionFrequency: CompoundingFrequency.Quarterly,
+    };
+    const annual: Investment = {
+      ...investment,
+      Id: 'inv-a',
+      RecurringContribution: 1200,
+      ContributionFrequency: CompoundingFrequency.Annually,
+    };
+    // Quarterly 300 → 100/mo; annual 1200 → 100/mo.
+    expect(summarizePositions([], [quarterly], TODAY).monthlyCommitments).toBe(
+      100
+    );
+    expect(summarizePositions([], [annual], TODAY).monthlyCommitments).toBe(
+      100
+    );
+  });
+
+  it('ignores contributions with no cadence and loans with no payment', () => {
+    const noCadence: Investment = {
+      ...investment,
+      Id: 'inv-n',
+      RecurringContribution: 500,
+      ContributionFrequency: undefined,
+    };
+    const noPayment: Loan = {
+      ...loan,
+      Id: 'loan-n',
+      MonthlyPayment: undefined,
+    };
+    // A cadence set but no amount also contributes nothing.
+    const cadenceNoAmount: Investment = {
+      ...investment,
+      Id: 'inv-na',
+      RecurringContribution: undefined,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+    };
+    const summary = summarizePositions(
+      [noPayment],
+      [noCadence, cadenceNoAmount],
+      TODAY
+    );
+    expect(summary.monthlyCommitments).toBe(0);
+  });
+
+  it('is all zeros with no positions', () => {
+    expect(summarizePositions([], [], TODAY)).toEqual({
+      totalDebt: 0,
+      totalAssets: 0,
+      netWorth: 0,
+      monthlyCommitments: 0,
+    });
+  });
+});

--- a/src/helpers/summary-helpers.ts
+++ b/src/helpers/summary-helpers.ts
@@ -1,0 +1,66 @@
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { forecastInvestment, forecastLoan } from './forecast-helpers';
+import { getPeriodsPerYear } from './investment-helpers';
+
+// "Today" net-worth summary metrics for the dashboard (Phase 3.1). Debt and
+// asset totals are read from the forecast engine's today-anchor (index 0), so
+// the cards show exactly the numbers the chart starts from — a single source of
+// truth. Pure and framework-free (D7).
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+export interface PositionSummary {
+  // Σ current loan balances (liabilities).
+  totalDebt: number;
+  // Σ current investment values (the engine's today anchor, honoring CurrentValue).
+  totalAssets: number;
+  // totalAssets − totalDebt.
+  netWorth: number;
+  // Σ monthly-equivalent outflow: loan payments + investment contributions,
+  // each contribution normalized to a monthly amount by its cadence.
+  monthlyCommitments: number;
+}
+
+export const summarizePositions = (
+  loans: Loan[],
+  investments: Investment[],
+  today: Date = new Date()
+): PositionSummary => {
+  // forecast*(…, today, 0, today) yields a single point at today's anchor.
+  const totalDebt = roundToCents(
+    loans.reduce(
+      (sum, loan) => sum + forecastLoan(loan, today, 0, today)[0].Value,
+      0
+    )
+  );
+  const totalAssets = roundToCents(
+    investments.reduce(
+      (sum, investment) =>
+        sum + forecastInvestment(investment, today, 0, today)[0].Value,
+      0
+    )
+  );
+
+  const loanCommitments = loans.reduce(
+    (sum, loan) => sum + Math.max(loan.MonthlyPayment ?? 0, 0),
+    0
+  );
+  const investmentCommitments = investments.reduce((sum, investment) => {
+    // Contributions only count when a cadence is set (mirrors the engine).
+    if (!investment.ContributionFrequency) {
+      return sum;
+    }
+    const perYear =
+      (investment.RecurringContribution ?? 0) *
+      getPeriodsPerYear(investment.ContributionFrequency);
+    return sum + perYear / 12;
+  }, 0);
+
+  return {
+    totalDebt,
+    totalAssets,
+    netWorth: roundToCents(totalAssets - totalDebt),
+    monthlyCommitments: roundToCents(loanCommitments + investmentCommitments),
+  };
+};

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -5,6 +5,8 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableFooter,
+  TableSortLabel,
   Paper,
   Box,
   Card,
@@ -21,8 +23,15 @@ import {
 } from '../models/investment-model';
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
-import { Calculate, Delete, Edit, TrendingUp } from '@mui/icons-material';
-import { useState } from 'react';
+import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
+import {
+  Calculate,
+  ContentCopy,
+  Delete,
+  Edit,
+  TrendingUp,
+} from '@mui/icons-material';
+import { useMemo, useState } from 'react';
 import { PitPopout } from './pit-popout';
 import { GrowthSchedulePopout } from './growth-schedule-popout';
 import { EntityRowActions, RowAction } from '../components/entity-row-actions';
@@ -33,8 +42,14 @@ interface InvestmentRowHandlers {
   onGrowth: (investment: Investment) => void;
   onPit: (investment: Investment) => void;
   onEdit: (investment: Investment) => void;
+  onClone: (investment: Investment) => void;
   onDelete: (investment: Investment) => void;
 }
+
+// Best-known current value: the explicit CurrentValue when set, else the
+// starting balance as a stand-in for the table/totals.
+const currentValue = (investment: Investment): number =>
+  investment.CurrentValue ?? investment.StartingBalance;
 
 const investmentActions = (
   investment: Investment,
@@ -54,6 +69,11 @@ const investmentActions = (
     icon: <Edit />,
     title: 'Edit Investment',
     onClick: () => handlers.onEdit(investment),
+  },
+  {
+    icon: <ContentCopy />,
+    title: 'Duplicate Investment',
+    onClick: () => handlers.onClone(investment),
   },
   {
     icon: <Delete />,
@@ -91,6 +111,62 @@ const getCompoundingText = (period: CompoundingFrequency) => {
   }
 };
 
+type InvestmentColumnId =
+  | 'Name'
+  | 'Provider'
+  | 'StartingBalance'
+  | 'CurrentValue'
+  | 'AverageReturnRate'
+  | 'CompoundingPeriod'
+  | 'RecurringContribution';
+
+interface InvestmentColumn {
+  id: InvestmentColumnId;
+  label: string;
+  numeric: boolean;
+  value: (investment: Investment) => SortValue;
+}
+
+const INVESTMENT_COLUMNS: InvestmentColumn[] = [
+  { id: 'Name', label: 'Name', numeric: false, value: (i) => i.Name },
+  {
+    id: 'Provider',
+    label: 'Provider',
+    numeric: false,
+    value: (i) => i.Provider,
+  },
+  {
+    id: 'StartingBalance',
+    label: 'Starting Balance',
+    numeric: true,
+    value: (i) => i.StartingBalance,
+  },
+  {
+    id: 'CurrentValue',
+    label: 'Current Value',
+    numeric: true,
+    value: (i) => currentValue(i),
+  },
+  {
+    id: 'AverageReturnRate',
+    label: 'Return Rate',
+    numeric: true,
+    value: (i) => i.AverageReturnRate,
+  },
+  {
+    id: 'CompoundingPeriod',
+    label: 'Compounding',
+    numeric: false,
+    value: (i) => getCompoundingText(i.CompoundingPeriod),
+  },
+  {
+    id: 'RecurringContribution',
+    label: 'Recurring Contribution',
+    numeric: true,
+    value: (i) => i.RecurringContribution ?? 0,
+  },
+];
+
 const InvestmentCard = ({
   investment,
   handlers,
@@ -105,22 +181,12 @@ const InvestmentCard = ({
       <Typography variant="h6" component="div">
         {investment.Name}
       </Typography>
-      <Typography
-        sx={{
-          color: 'text.secondary',
-          mb: 1.5,
-        }}
-      >
+      <Typography sx={{ color: 'text.secondary', mb: 1.5 }}>
         {investment.Provider}
       </Typography>
       <Box sx={{ marginBottom: 1 }}>
         <Grid container spacing={2}>
-          <Grid
-            size={{
-              xs: 12,
-              sm: 6,
-            }}
-          >
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Typography variant="body2">
               <strong>Starting Balance:</strong>
             </Typography>
@@ -128,12 +194,15 @@ const InvestmentCard = ({
               {formatCurrency(investment.StartingBalance)}
             </Typography>
           </Grid>
-          <Grid
-            size={{
-              xs: 12,
-              sm: 6,
-            }}
-          >
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <Typography variant="body2">
+              <strong>Current Value:</strong>
+            </Typography>
+            <Typography variant="body2">
+              {formatCurrency(currentValue(investment))}
+            </Typography>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Typography variant="body2">
               <strong>Return Rate:</strong>
             </Typography>
@@ -141,25 +210,7 @@ const InvestmentCard = ({
               {formatPercent(investment.AverageReturnRate, 3)}
             </Typography>
           </Grid>
-          <Grid
-            size={{
-              xs: 12,
-              sm: 6,
-            }}
-          >
-            <Typography variant="body2">
-              <strong>Compounding:</strong>
-            </Typography>
-            <Typography variant="body2">
-              {getCompoundingText(investment.CompoundingPeriod)}
-            </Typography>
-          </Grid>
-          <Grid
-            size={{
-              xs: 12,
-              sm: 6,
-            }}
-          >
+          <Grid size={{ xs: 12, sm: 6 }}>
             <Typography variant="body2">
               <strong>Recurring:</strong>
             </Typography>
@@ -198,12 +249,44 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
+  // Default ordering: highest expected return first.
+  const [sortColumn, setSortColumn] =
+    useState<InvestmentColumnId>('AverageReturnRate');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
   const handlers: InvestmentRowHandlers = {
     onGrowth: setSelectedGrowth,
     onPit: setSelectedPit,
     onEdit: props.onInvestmentEdit,
+    onClone: props.onInvestmentClone,
     onDelete: props.onInvestmentDelete,
   };
+
+  const column =
+    INVESTMENT_COLUMNS.find((c) => c.id === sortColumn) ??
+    INVESTMENT_COLUMNS[0];
+  const sortedInvestments = useMemo(
+    () => sortBy(props.investments, column.value, sortDirection),
+    [props.investments, column, sortDirection]
+  );
+
+  const handleSort = (id: InvestmentColumnId) => {
+    if (sortColumn === id) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortColumn(id);
+      setSortDirection('asc');
+    }
+  };
+
+  const totalStarting = props.investments.reduce(
+    (sum, i) => sum + i.StartingBalance,
+    0
+  );
+  const totalCurrent = props.investments.reduce(
+    (sum, i) => sum + currentValue(i),
+    0
+  );
 
   return (
     <>
@@ -222,7 +305,7 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
 
       {isMobile ? (
         <Box>
-          {props.investments.map((investment) => (
+          {sortedInvestments.map((investment) => (
             <InvestmentCard
               key={investment.Id}
               investment={investment}
@@ -236,28 +319,44 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Provider</TableCell>
-                <TableCell>Starting Balance</TableCell>
-                <TableCell>Return Rate</TableCell>
-                <TableCell>Compounding</TableCell>
-                <TableCell>Recurring Contribution</TableCell>
+                {INVESTMENT_COLUMNS.map((col) => (
+                  <TableCell
+                    key={col.id}
+                    align={col.numeric ? 'right' : 'left'}
+                    sortDirection={
+                      sortColumn === col.id ? sortDirection : false
+                    }
+                  >
+                    <TableSortLabel
+                      active={sortColumn === col.id}
+                      direction={sortColumn === col.id ? sortDirection : 'asc'}
+                      onClick={() => handleSort(col.id)}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  </TableCell>
+                ))}
                 <TableCell>Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {props.investments.map((row) => (
+              {sortedInvestments.map((row) => (
                 <TableRow key={row.Id}>
                   <TableCell>{row.Name}</TableCell>
                   <TableCell>{row.Provider}</TableCell>
-                  <TableCell>{formatCurrency(row.StartingBalance)}</TableCell>
-                  <TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(row.StartingBalance)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(currentValue(row))}
+                  </TableCell>
+                  <TableCell align="right">
                     {formatPercent(row.AverageReturnRate, 3)}
                   </TableCell>
                   <TableCell>
                     {getCompoundingText(row.CompoundingPeriod)}
                   </TableCell>
-                  <TableCell>{formatContribution(row)}</TableCell>
+                  <TableCell align="right">{formatContribution(row)}</TableCell>
                   <TableCell>
                     <EntityRowActions
                       actions={investmentActions(row, handlers)}
@@ -266,6 +365,24 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
                 </TableRow>
               ))}
             </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>
+                  <strong>Totals</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalStarting)}</strong>
+                </TableCell>
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalCurrent)}</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell />
+                <TableCell />
+              </TableRow>
+            </TableFooter>
           </Table>
         </TableContainer>
       )}
@@ -277,4 +394,5 @@ export type InvestmentTableProps = {
   investments: Investment[];
   onInvestmentEdit: (investment: Investment) => void;
   onInvestmentDelete: (investment: Investment) => void;
+  onInvestmentClone: (investment: Investment) => void;
 };

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -5,6 +5,9 @@ import {
   TableRow,
   TableCell,
   TableBody,
+  TableFooter,
+  TableSortLabel,
+  LinearProgress,
   Paper,
   Box,
   Card,
@@ -15,11 +18,20 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import { Loan } from '../models/loan-model';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 import { PitPopout } from './pit-popout';
 import { getTerms } from '../helpers/loan-helpers';
+import { forecastLoan, getPayoffDate } from '../helpers/forecast-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
-import { Calculate, CalendarMonth, Delete, Edit } from '@mui/icons-material';
+import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
+import {
+  Calculate,
+  CalendarMonth,
+  ContentCopy,
+  Delete,
+  Edit,
+} from '@mui/icons-material';
 import { AmortizationPopout } from './amortization-popout';
 import { EntityRowActions, RowAction } from '../components/entity-row-actions';
 
@@ -29,7 +41,16 @@ interface LoanRowHandlers {
   onAmortization: (loan: Loan) => void;
   onPit: (loan: Loan) => void;
   onEdit: (loan: Loan) => void;
+  onClone: (loan: Loan) => void;
   onDelete: (loan: Loan) => void;
+}
+
+// A loan plus its engine-derived display values (3.3): projected payoff date and
+// how much of the original principal has been paid down so far.
+interface LoanRow {
+  loan: Loan;
+  payoffDate?: Date;
+  principalPaidPct: number;
 }
 
 const loanActions = (loan: Loan, handlers: LoanRowHandlers): RowAction[] => [
@@ -49,6 +70,11 @@ const loanActions = (loan: Loan, handlers: LoanRowHandlers): RowAction[] => [
     onClick: () => handlers.onEdit(loan),
   },
   {
+    icon: <ContentCopy />,
+    title: 'Duplicate Loan',
+    onClick: () => handlers.onClone(loan),
+  },
+  {
     icon: <Delete />,
     title: 'Delete Loan',
     onClick: () => handlers.onDelete(loan),
@@ -56,65 +82,144 @@ const loanActions = (loan: Loan, handlers: LoanRowHandlers): RowAction[] => [
   },
 ];
 
+const principalPaidPct = (loan: Loan): number => {
+  if (!(loan.Principal > 0)) return 0;
+  const paid = ((loan.Principal - loan.CurrentAmount) / loan.Principal) * 100;
+  return Math.max(0, Math.min(100, paid));
+};
+
+const formatPayoff = (date?: Date): string =>
+  date ? dayjs(date).format('MMM YYYY') : 'beyond forecast';
+
+// Sortable column definitions. `value` maps a row to a comparable sort key.
+type LoanColumnId =
+  | 'Name'
+  | 'Provider'
+  | 'Principal'
+  | 'CurrentAmount'
+  | 'InterestRate'
+  | 'MonthlyPayment'
+  | 'Payoff';
+
+interface LoanColumn {
+  id: LoanColumnId;
+  label: string;
+  numeric: boolean;
+  value: (row: LoanRow) => SortValue;
+}
+
+const LOAN_COLUMNS: LoanColumn[] = [
+  { id: 'Name', label: 'Name', numeric: false, value: (r) => r.loan.Name },
+  {
+    id: 'Provider',
+    label: 'Provider',
+    numeric: false,
+    value: (r) => r.loan.Provider,
+  },
+  {
+    id: 'Principal',
+    label: 'Principal',
+    numeric: true,
+    value: (r) => r.loan.Principal,
+  },
+  {
+    id: 'CurrentAmount',
+    label: 'Current Balance',
+    numeric: true,
+    value: (r) => r.loan.CurrentAmount,
+  },
+  {
+    id: 'InterestRate',
+    label: 'Interest Rate',
+    numeric: true,
+    value: (r) => r.loan.InterestRate,
+  },
+  {
+    id: 'MonthlyPayment',
+    label: 'Monthly Payment',
+    numeric: true,
+    value: (r) => r.loan.MonthlyPayment ?? 0,
+  },
+  {
+    id: 'Payoff',
+    label: 'Payoff',
+    numeric: true,
+    // Loans that never pay off sort last in ascending order.
+    value: (r) => r.payoffDate?.getTime() ?? Infinity,
+  },
+];
+
 const LoanCard = ({
-  loan,
+  row,
   handlers,
 }: {
-  loan: Loan;
+  row: LoanRow;
   handlers: LoanRowHandlers;
-}) => (
-  <Card sx={{ marginBottom: 2 }}>
-    <CardContent>
-      <Typography variant="h6" component="div" gutterBottom>
-        {loan.Name}
-      </Typography>
-      <Typography
-        variant="body2"
-        gutterBottom
-        sx={{
-          color: 'text.secondary',
-        }}
-      >
-        {loan.Provider}
-      </Typography>
-      <Grid container spacing={2}>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>Principal:</strong> {formatCurrency(loan.Principal)}
-          </Typography>
+}) => {
+  const { loan } = row;
+  return (
+    <Card sx={{ marginBottom: 2 }}>
+      <CardContent>
+        <Typography variant="h6" component="div" gutterBottom>
+          {loan.Name}
+        </Typography>
+        <Typography
+          variant="body2"
+          gutterBottom
+          sx={{ color: 'text.secondary' }}
+        >
+          {loan.Provider}
+        </Typography>
+        <Grid container spacing={2}>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Principal:</strong> {formatCurrency(loan.Principal)}
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Current:</strong> {formatCurrency(loan.CurrentAmount)}
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Interest:</strong> {formatPercent(loan.InterestRate)}
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Payment:</strong>{' '}
+              {formatCurrency(loan.MonthlyPayment || 0)}
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Terms:</strong> {getTerms(loan)} months
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Payoff:</strong> {formatPayoff(row.payoffDate)}
+            </Typography>
+          </Grid>
         </Grid>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>Current:</strong> {formatCurrency(loan.CurrentAmount)}
+        <Box sx={{ marginTop: 1.5 }}>
+          <Typography variant="caption" color="text.secondary">
+            Principal paid: {Math.round(row.principalPaidPct)}%
           </Typography>
-        </Grid>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>Interest:</strong> {formatPercent(loan.InterestRate)}
-          </Typography>
-        </Grid>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>Payment:</strong> {formatCurrency(loan.MonthlyPayment || 0)}
-          </Typography>
-        </Grid>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>Terms:</strong> {getTerms(loan)} months
-          </Typography>
-        </Grid>
-        <Grid size={6}>
-          <Typography variant="body2">
-            <strong>End Date:</strong> {loan.EndDate.toLocaleDateString()}
-          </Typography>
-        </Grid>
-      </Grid>
-      <Box sx={{ marginTop: 2 }}>
-        <EntityRowActions actions={loanActions(loan, handlers)} isMobile />
-      </Box>
-    </CardContent>
-  </Card>
-);
+          <LinearProgress
+            variant="determinate"
+            value={row.principalPaidPct}
+            sx={{ marginTop: 0.5 }}
+          />
+        </Box>
+        <Box sx={{ marginTop: 2 }}>
+          <EntityRowActions actions={loanActions(loan, handlers)} isMobile />
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
 
 export const LoanTable = (props: LoanTableProps) => {
   const [selectedPit, setSelectedPit] = useState<Loan | undefined>();
@@ -124,12 +229,52 @@ export const LoanTable = (props: LoanTableProps) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
+  // Default ordering mirrors how the optimizer reasons: highest rate first.
+  const [sortColumn, setSortColumn] = useState<LoanColumnId>('InterestRate');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
   const handlers: LoanRowHandlers = {
     onAmortization: setSelectedAmortization,
     onPit: setSelectedPit,
     onEdit: props.onLoanEdit,
+    onClone: props.onLoanClone,
     onDelete: props.onLoanDelete,
   };
+
+  // Engine-derived rows (payoff date + principal-paid %), memoized so they
+  // recompute only when the loans change.
+  const today = useMemo(() => new Date(), []);
+  const rows = useMemo<LoanRow[]>(() => {
+    const horizon = dayjs(today).add(50, 'year').toDate();
+    return props.loans.map((loan) => ({
+      loan,
+      payoffDate: getPayoffDate(forecastLoan(loan, horizon, 0, today)),
+      principalPaidPct: principalPaidPct(loan),
+    }));
+  }, [props.loans, today]);
+
+  const column =
+    LOAN_COLUMNS.find((c) => c.id === sortColumn) ?? LOAN_COLUMNS[0];
+  const sortedRows = useMemo(
+    () => sortBy(rows, column.value, sortDirection),
+    [rows, column, sortDirection]
+  );
+
+  const handleSort = (id: LoanColumnId) => {
+    if (sortColumn === id) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortColumn(id);
+      setSortDirection('asc');
+    }
+  };
+
+  const totalPrincipal = props.loans.reduce((sum, l) => sum + l.Principal, 0);
+  const totalCurrent = props.loans.reduce((sum, l) => sum + l.CurrentAmount, 0);
+  const totalPayment = props.loans.reduce(
+    (sum, l) => sum + (l.MonthlyPayment ?? 0),
+    0
+  );
 
   return (
     <>
@@ -148,8 +293,8 @@ export const LoanTable = (props: LoanTableProps) => {
 
       {isMobile ? (
         <Box>
-          {props.loans.map((loan) => (
-            <LoanCard key={loan.Id} loan={loan} handlers={handlers} />
+          {sortedRows.map((row) => (
+            <LoanCard key={row.loan.Id} row={row} handlers={handlers} />
           ))}
         </Box>
       ) : (
@@ -157,32 +302,95 @@ export const LoanTable = (props: LoanTableProps) => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Provider</TableCell>
-                <TableCell>Principal</TableCell>
-                <TableCell>Interest Rate</TableCell>
-                <TableCell>Monthly Payment</TableCell>
-                <TableCell>Terms</TableCell>
+                {LOAN_COLUMNS.map((col) => (
+                  <TableCell
+                    key={col.id}
+                    align={col.numeric ? 'right' : 'left'}
+                    sortDirection={
+                      sortColumn === col.id ? sortDirection : false
+                    }
+                  >
+                    <TableSortLabel
+                      active={sortColumn === col.id}
+                      direction={sortColumn === col.id ? sortDirection : 'asc'}
+                      onClick={() => handleSort(col.id)}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  </TableCell>
+                ))}
+                <TableCell>Principal Paid</TableCell>
                 <TableCell>Actions</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
-              {props.loans.map((row) => (
-                <TableRow key={row.Id}>
-                  <TableCell>{row.Name}</TableCell>
-                  <TableCell>{row.Provider}</TableCell>
-                  <TableCell>{formatCurrency(row.Principal)}</TableCell>
-                  <TableCell>{formatPercent(row.InterestRate)}</TableCell>
-                  <TableCell>
-                    {formatCurrency(row.MonthlyPayment || 0)}
+              {sortedRows.map((row) => (
+                <TableRow key={row.loan.Id}>
+                  <TableCell>{row.loan.Name}</TableCell>
+                  <TableCell>{row.loan.Provider}</TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(row.loan.Principal)}
                   </TableCell>
-                  <TableCell>{getTerms(row)} months</TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(row.loan.CurrentAmount)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatPercent(row.loan.InterestRate)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatCurrency(row.loan.MonthlyPayment || 0)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {formatPayoff(row.payoffDate)}
+                  </TableCell>
                   <TableCell>
-                    <EntityRowActions actions={loanActions(row, handlers)} />
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 1,
+                        minWidth: 120,
+                      }}
+                    >
+                      <LinearProgress
+                        variant="determinate"
+                        value={row.principalPaidPct}
+                        sx={{ flexGrow: 1 }}
+                      />
+                      <Typography variant="caption" sx={{ minWidth: 32 }}>
+                        {Math.round(row.principalPaidPct)}%
+                      </Typography>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <EntityRowActions
+                      actions={loanActions(row.loan, handlers)}
+                    />
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>
+                  <strong>Totals</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalPrincipal)}</strong>
+                </TableCell>
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalCurrent)}</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalPayment)}</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell />
+              </TableRow>
+            </TableFooter>
           </Table>
         </TableContainer>
       )}
@@ -194,4 +402,5 @@ export type LoanTableProps = {
   loans: Loan[];
   onLoanEdit: (l: Loan) => void;
   onLoanDelete: (l: Loan) => void;
+  onLoanClone: (l: Loan) => void;
 };

--- a/src/models/scenario-model.ts
+++ b/src/models/scenario-model.ts
@@ -1,0 +1,20 @@
+// A named what-if scenario (Phase 4): extra monthly amounts applied on top of
+// existing payments/contributions, keyed by entity Id. The shape is a superset
+// of ScenarioInput (forecast-model) with required maps + identity fields, so a
+// Scenario can be passed straight to the forecast engine as a ScenarioInput.
+//
+// Input-only, like the other models: derived overlays are computed on demand by
+// the engine, never stored.
+export interface Scenario {
+  Id: string;
+  Name: string;
+  ExtraLoanPayments: Record<string, number>;
+  ExtraContributions: Record<string, number>;
+}
+
+export const emptyScenario: Scenario = {
+  Id: '',
+  Name: '',
+  ExtraLoanPayments: {},
+  ExtraContributions: {},
+};

--- a/src/persistence/first-visit-notice.tsx
+++ b/src/persistence/first-visit-notice.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { Alert, AlertTitle, Collapse } from '@mui/material';
+import {
+  acknowledgeFirstVisit,
+  hasAcknowledgedFirstVisit,
+} from '../helpers/storage-helpers';
+import { SECTION_GAP } from '../theme';
+
+// First-visit privacy notice (Phase 1.3, issue #20). Explains that PathWise is
+// backend-free and that data stays on-device, and points to the "Save on this
+// device" toggle. Shown once, then dismissed permanently via a stored flag.
+// Doubles as the app's privacy story: no backend, no account, no tracking.
+export const FirstVisitNotice = () => {
+  const [open, setOpen] = useState(() => !hasAcknowledgedFirstVisit());
+
+  const dismiss = () => {
+    acknowledgeFirstVisit();
+    setOpen(false);
+  };
+
+  return (
+    <Collapse in={open} unmountOnExit>
+      <Alert
+        severity="info"
+        onClose={dismiss}
+        sx={{ marginBottom: SECTION_GAP }}
+      >
+        <AlertTitle>Your data stays on this device</AlertTitle>
+        PathWise has no backend, no account, and no tracking — nothing you enter
+        ever leaves your browser. Turn on <strong>
+          Save on this device
+        </strong>{' '}
+        in the toolbar to keep your data across refreshes.
+      </Alert>
+    </Collapse>
+  );
+};

--- a/src/persistence/persistence-toggle.tsx
+++ b/src/persistence/persistence-toggle.tsx
@@ -1,0 +1,60 @@
+import {
+  Alert,
+  FormControlLabel,
+  Snackbar,
+  Switch,
+  Tooltip,
+} from '@mui/material';
+import { usePersistence } from './use-persistence';
+
+// Command-bar "Save on this device" toggle (Phase 1.2, issue #20). The switch
+// reflects the persisted preference; flipping it hydrates/clears storage and
+// starts/stops debounced auto-save via `usePersistence`. Snackbar feedback
+// mirrors DataManager's conventions (bottom-center, auto-hide).
+export const PersistenceToggle = () => {
+  const { enabled, toggle, feedback, clearFeedback } = usePersistence();
+
+  return (
+    <>
+      <Tooltip
+        title={
+          enabled
+            ? 'Your data is saved on this device. Turn this off to clear it.'
+            : 'Save your data on this device so it survives a refresh. Nothing ever leaves your browser.'
+        }
+      >
+        <FormControlLabel
+          sx={{ color: 'inherit', mr: 0 }}
+          control={
+            <Switch
+              checked={enabled}
+              onChange={toggle}
+              color="default"
+              slotProps={{
+                input: { 'aria-label': 'Save data on this device' },
+              }}
+            />
+          }
+          label="Save on this device"
+        />
+      </Tooltip>
+
+      <Snackbar
+        open={!!feedback}
+        autoHideDuration={4000}
+        onClose={clearFeedback}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        {feedback ? (
+          <Alert
+            onClose={clearFeedback}
+            severity={feedback.severity}
+            sx={{ width: '100%' }}
+          >
+            {feedback.message}
+          </Alert>
+        ) : undefined}
+      </Snackbar>
+    </>
+  );
+};

--- a/src/persistence/use-persistence.ts
+++ b/src/persistence/use-persistence.ts
@@ -35,6 +35,7 @@ export const usePersistence = (): PersistenceController => {
   const {
     loans,
     investments,
+    scenarios,
     sampleDataLoaded,
     stashedLoans,
     stashedInvestments,
@@ -68,7 +69,7 @@ export const usePersistence = (): PersistenceController => {
     if (isPersistenceEnabled()) {
       const loaded = loadData();
       if (loaded) {
-        importMerge(loaded.loans, loaded.investments);
+        importMerge(loaded.loans, loaded.investments, loaded.scenarios);
       }
     }
   }, [importMerge]);
@@ -98,10 +99,10 @@ export const usePersistence = (): PersistenceController => {
       return;
     }
     const handle = setTimeout(() => {
-      reportSaveProblem(saveData(realLoans, realInvestments));
+      reportSaveProblem(saveData(realLoans, realInvestments, scenarios));
     }, AUTO_SAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [enabled, realLoans, realInvestments, reportSaveProblem]);
+  }, [enabled, realLoans, realInvestments, scenarios, reportSaveProblem]);
 
   const toggle = useCallback(() => {
     const next = !enabled;
@@ -109,7 +110,7 @@ export const usePersistence = (): PersistenceController => {
     setPersistenceEnabled(next);
     if (next) {
       // Save immediately on enable so a reload right away still restores data.
-      const status = saveData(realLoans, realInvestments);
+      const status = saveData(realLoans, realInvestments, scenarios);
       if (status === 'saved') {
         setFeedback({
           severity: 'success',
@@ -126,7 +127,7 @@ export const usePersistence = (): PersistenceController => {
         message: 'Saved data cleared from this device.',
       });
     }
-  }, [enabled, realLoans, realInvestments, reportSaveProblem]);
+  }, [enabled, realLoans, realInvestments, scenarios, reportSaveProblem]);
 
   const clearFeedback = useCallback(() => setFeedback(null), []);
 

--- a/src/persistence/use-persistence.ts
+++ b/src/persistence/use-persistence.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useFinanceData } from '../state/use-finance-data';
+import {
+  SaveStatus,
+  clearData,
+  isPersistenceEnabled,
+  loadData,
+  saveData,
+  setPersistenceEnabled,
+} from '../helpers/storage-helpers';
+
+// Wait for typing to settle before writing, so a burst of edits is one save.
+const AUTO_SAVE_DEBOUNCE_MS = 800;
+
+export type PersistenceFeedback = {
+  severity: 'success' | 'error';
+  message: string;
+};
+
+export interface PersistenceController {
+  enabled: boolean;
+  toggle: () => void;
+  feedback: PersistenceFeedback | null;
+  clearFeedback: () => void;
+}
+
+// Owns the "save on this device" behavior (Phase 1.2, issue #20): the persisted
+// on/off preference, one-time hydration on load, debounced auto-save while on,
+// and clearing storage when turned off. The pure storage I/O lives in
+// `storage-helpers` (D7); this hook is the thin React layer that wires it to the
+// finance-data context and surfaces snackbar feedback. Render it from exactly
+// one place so hydration and auto-save run once.
+export const usePersistence = (): PersistenceController => {
+  const { state, importMerge } = useFinanceData();
+  const {
+    loans,
+    investments,
+    sampleDataLoaded,
+    stashedLoans,
+    stashedInvestments,
+  } = state;
+
+  const [enabled, setEnabled] = useState<boolean>(() => isPersistenceEnabled());
+  const [feedback, setFeedback] = useState<PersistenceFeedback | null>(null);
+
+  // Persist the user's *real* data only — never the sample data shown while the
+  // onboarding banner is up (the reducer parks real data in the stash then).
+  // Memoized so the auto-save effect/toggle depend on stable references and
+  // re-run only when the real data actually changes.
+  const realLoans = useMemo(
+    () => (sampleDataLoaded ? (stashedLoans ?? []) : loans),
+    [sampleDataLoaded, stashedLoans, loans]
+  );
+  const realInvestments = useMemo(
+    () => (sampleDataLoaded ? (stashedInvestments ?? []) : investments),
+    [sampleDataLoaded, stashedInvestments, investments]
+  );
+
+  // Hydrate once on mount when persistence is on. Initial context state is
+  // empty, so a merge is effectively a load; the ref makes it run a single time
+  // (StrictMode double-invokes effects, and the merge is idempotent regardless).
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (hydratedRef.current) {
+      return;
+    }
+    hydratedRef.current = true;
+    if (isPersistenceEnabled()) {
+      const loaded = loadData();
+      if (loaded) {
+        importMerge(loaded.loans, loaded.investments);
+      }
+    }
+  }, [importMerge]);
+
+  // Translate a non-success save outcome into user-facing feedback. A 'saved'
+  // status is silent during auto-save (no snackbar on every keystroke).
+  const reportSaveProblem = useCallback((status: SaveStatus) => {
+    if (status === 'quota-exceeded') {
+      setFeedback({
+        severity: 'error',
+        message:
+          'This device is out of storage space — your latest changes could not be saved.',
+      });
+    } else if (status === 'unavailable') {
+      setFeedback({
+        severity: 'error',
+        message: 'Saving on this device isn’t available in this browser.',
+      });
+    }
+  }, []);
+
+  // Debounced auto-save while enabled. Re-runs only when the real data changes
+  // (stable references otherwise), so a fresh edit cancels the pending save and
+  // reschedules — coalescing a burst of edits into a single write.
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const handle = setTimeout(() => {
+      reportSaveProblem(saveData(realLoans, realInvestments));
+    }, AUTO_SAVE_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [enabled, realLoans, realInvestments, reportSaveProblem]);
+
+  const toggle = useCallback(() => {
+    const next = !enabled;
+    setEnabled(next);
+    setPersistenceEnabled(next);
+    if (next) {
+      // Save immediately on enable so a reload right away still restores data.
+      const status = saveData(realLoans, realInvestments);
+      if (status === 'saved') {
+        setFeedback({
+          severity: 'success',
+          message: 'Your data will be saved on this device.',
+        });
+      } else {
+        reportSaveProblem(status);
+      }
+    } else {
+      // Disabling clears the stored copy (issue #20).
+      clearData();
+      setFeedback({
+        severity: 'success',
+        message: 'Saved data cleared from this device.',
+      });
+    }
+  }, [enabled, realLoans, realInvestments, reportSaveProblem]);
+
+  const clearFeedback = useCallback(() => setFeedback(null), []);
+
+  return { enabled, toggle, feedback, clearFeedback };
+};

--- a/src/scenario/scenario-bar.tsx
+++ b/src/scenario/scenario-bar.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import { Scenario } from '../models/scenario-model';
+import { useFinanceData } from '../state/use-finance-data';
+import { ScenarioBuilderDialog } from './scenario-builder-dialog';
+
+// Scenario controls in the forecast section (Phase 4.2). Create a scenario,
+// switch the active overlay between "Baseline" and any saved scenario, and
+// delete scenarios. The active selection drives the chart overlay (4.3).
+export const ScenarioBar = () => {
+  const {
+    state: { loans, investments, scenarios, activeScenarioId },
+    addScenario,
+    setActiveScenario,
+    deleteScenario,
+  } = useFinanceData();
+
+  const [builderOpen, setBuilderOpen] = useState(false);
+
+  const handleSave = (scenario: Scenario) => {
+    const id = addScenario(scenario);
+    setActiveScenario(id);
+  };
+
+  return (
+    <Box sx={{ marginBottom: 2 }}>
+      <Stack
+        direction="row"
+        spacing={1}
+        useFlexGap
+        sx={{ flexWrap: 'wrap', alignItems: 'center' }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          Scenarios:
+        </Typography>
+
+        <Chip
+          label="Baseline"
+          color={activeScenarioId === null ? 'primary' : 'default'}
+          variant={activeScenarioId === null ? 'filled' : 'outlined'}
+          onClick={() => setActiveScenario(null)}
+        />
+
+        {scenarios.map((scenario) => {
+          const active = scenario.Id === activeScenarioId;
+          return (
+            <Chip
+              key={scenario.Id}
+              label={scenario.Name}
+              color={active ? 'primary' : 'default'}
+              variant={active ? 'filled' : 'outlined'}
+              onClick={() => setActiveScenario(active ? null : scenario.Id)}
+              onDelete={() => deleteScenario(scenario.Id)}
+            />
+          );
+        })}
+
+        <Button
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={() => setBuilderOpen(true)}
+        >
+          New scenario
+        </Button>
+      </Stack>
+
+      <ScenarioBuilderDialog
+        open={builderOpen}
+        loans={loans}
+        investments={investments}
+        onSave={handleSave}
+        onClose={() => setBuilderOpen(false)}
+      />
+    </Box>
+  );
+};

--- a/src/scenario/scenario-builder-dialog.tsx
+++ b/src/scenario/scenario-builder-dialog.tsx
@@ -1,0 +1,171 @@
+import {
+  Alert,
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { NumericFormat } from 'react-number-format';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { Scenario, emptyScenario } from '../models/scenario-model';
+import { ResponsiveDialog } from '../components/responsive-dialog';
+
+interface ScenarioBuilderDialogProps {
+  open: boolean;
+  loans: Loan[];
+  investments: Investment[];
+  scenario?: Scenario;
+  onSave: (scenario: Scenario) => void;
+  onClose: () => void;
+}
+
+// Drop zero/blank entries so a scenario only carries the extras the user
+// actually set.
+const positiveEntries = (
+  amounts: Record<string, number>
+): Record<string, number> =>
+  Object.fromEntries(Object.entries(amounts).filter(([, value]) => value > 0));
+
+// Scenario builder dialog (Phase 4.2): name the scenario and enter extra $/month
+// toward any loans (principal) and investments (contributions). Saving with at
+// least one positive extra produces a Scenario the chart can overlay.
+export const ScenarioBuilderDialog = ({
+  open,
+  loans,
+  investments,
+  scenario,
+  onSave,
+  onClose,
+}: ScenarioBuilderDialogProps) => {
+  const [name, setName] = useState('');
+  const [extraLoanPayments, setExtraLoanPayments] = useState<
+    Record<string, number>
+  >({});
+  const [extraContributions, setExtraContributions] = useState<
+    Record<string, number>
+  >({});
+
+  // Reset the form to the edited scenario (or blank) each time it opens.
+  useEffect(() => {
+    setName(scenario?.Name ?? '');
+    setExtraLoanPayments(scenario?.ExtraLoanPayments ?? {});
+    setExtraContributions(scenario?.ExtraContributions ?? {});
+  }, [scenario, open]);
+
+  const cleanedLoans = positiveEntries(extraLoanPayments);
+  const cleanedContributions = positiveEntries(extraContributions);
+  const hasAnyExtra =
+    Object.keys(cleanedLoans).length > 0 ||
+    Object.keys(cleanedContributions).length > 0;
+  const isValid = name.trim() !== '' && hasAnyExtra;
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      ...emptyScenario,
+      Id: scenario?.Id ?? '',
+      Name: name.trim(),
+      ExtraLoanPayments: cleanedLoans,
+      ExtraContributions: cleanedContributions,
+    });
+    onClose();
+  };
+
+  const extraInput = (
+    label: string,
+    value: number | undefined,
+    onChange: (value: number) => void
+  ) => (
+    <NumericFormat
+      key={label}
+      label={label}
+      value={value ?? 0}
+      thousandSeparator
+      decimalScale={2}
+      prefix="$"
+      customInput={TextField}
+      size="small"
+      fullWidth
+      onValueChange={(vs) => onChange(Number(vs.value))}
+    />
+  );
+
+  return (
+    <ResponsiveDialog open={open} onClose={onClose}>
+      <DialogTitle sx={{ textAlign: 'center' }}>
+        {scenario ? 'Edit scenario' : 'New scenario'}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            label="Scenario name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <Typography variant="body2" color="text.secondary">
+            Enter extra $/month to put toward any positions. Leave the rest at
+            $0.
+          </Typography>
+
+          {loans.length > 0 && (
+            <>
+              <Divider>Extra loan payments</Divider>
+              {loans.map((loan) =>
+                extraInput(loan.Name, extraLoanPayments[loan.Id], (value) =>
+                  setExtraLoanPayments((prev) => ({
+                    ...prev,
+                    [loan.Id]: value,
+                  }))
+                )
+              )}
+            </>
+          )}
+
+          {investments.length > 0 && (
+            <>
+              <Divider>Extra contributions</Divider>
+              {investments.map((investment) =>
+                extraInput(
+                  investment.Name,
+                  extraContributions[investment.Id],
+                  (value) =>
+                    setExtraContributions((prev) => ({
+                      ...prev,
+                      [investment.Id]: value,
+                    }))
+                )
+              )}
+            </>
+          )}
+        </Box>
+      </DialogContent>
+      <Box sx={{ px: 3 }}>
+        {!isValid && (
+          <Alert severity="info" sx={{ mb: 1 }}>
+            Name the scenario and add at least one extra $/month.
+          </Alert>
+        )}
+      </Box>
+      <DialogActions>
+        <Button color="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={handleSave}
+          disabled={!isValid}
+        >
+          {scenario ? 'Save scenario' : 'Add scenario'}
+        </Button>
+      </DialogActions>
+    </ResponsiveDialog>
+  );
+};

--- a/src/scenario/scenario-impact-summary.tsx
+++ b/src/scenario/scenario-impact-summary.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from 'react';
+import { Box, Paper, Stack, Typography } from '@mui/material';
+import { Loan } from '../models/loan-model';
+import { Investment } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
+import { computeScenarioImpact } from '../helpers/scenario-impact-helpers';
+import { formatCurrency } from '../helpers/format-helpers';
+
+interface ScenarioImpactSummaryProps {
+  loans: Loan[];
+  investments: Investment[];
+  scenario: Scenario;
+}
+
+const formatMonths = (months: number): string => {
+  if (months <= 0) return 'No change';
+  const years = Math.floor(months / 12);
+  const rem = months % 12;
+  const parts = [];
+  if (years > 0) parts.push(`${years}y`);
+  if (rem > 0) parts.push(`${rem}mo`);
+  return `${parts.join(' ')} sooner`;
+};
+
+// Scenario impact summary (Phase 4.4): what the active scenario buys vs.
+// baseline — net worth at the horizon, lifetime interest saved, and how much
+// sooner the debt-free date arrives. Turns the overlay chart into a decision.
+export const ScenarioImpactSummary = ({
+  loans,
+  investments,
+  scenario,
+}: ScenarioImpactSummaryProps) => {
+  const impact = useMemo(
+    () => computeScenarioImpact(loans, investments, scenario, new Date()),
+    [loans, investments, scenario]
+  );
+
+  const metrics: { label: string; value: string }[] = [
+    {
+      label: 'Net worth at horizon',
+      value: `${impact.netWorthDelta >= 0 ? '+' : ''}${formatCurrency(impact.netWorthDelta)}`,
+    },
+    {
+      label: 'Lifetime interest saved',
+      value: formatCurrency(impact.interestSaved),
+    },
+    {
+      label: 'Debt-free',
+      value: formatMonths(impact.payoffMonthsEarlier),
+    },
+  ];
+
+  return (
+    <Paper variant="outlined" sx={{ padding: 2, marginTop: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        “{scenario.Name}” vs. baseline
+      </Typography>
+      <Stack direction="row" spacing={4} useFlexGap sx={{ flexWrap: 'wrap' }}>
+        {metrics.map((metric) => (
+          <Box key={metric.label}>
+            <Typography variant="caption" color="text.secondary">
+              {metric.label}
+            </Typography>
+            <Typography variant="h6">{metric.value}</Typography>
+          </Box>
+        ))}
+      </Stack>
+    </Paper>
+  );
+};

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -25,7 +25,11 @@ export interface FinanceDataContextValue {
   deleteInvestment: (id: string) => void;
   // Undo an investment delete by restoring it at its original index.
   insertInvestmentAt: (investment: Investment, index: number) => void;
-  importMerge: (loans: Loan[], investments: Investment[]) => void;
+  importMerge: (
+    loans: Loan[],
+    investments: Investment[],
+    scenarios?: Scenario[]
+  ) => void;
   loadSampleData: (loans: Loan[], investments: Investment[]) => void;
   clearSampleData: () => void;
   // Scenario actions (Phase 4). addScenario assigns an Id and returns it so the
@@ -69,8 +73,11 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'DeleteInvestment', id }),
       insertInvestmentAt: (investment: Investment, index: number) =>
         dispatch({ type: 'InsertInvestmentAt', investment, index }),
-      importMerge: (loans: Loan[], investments: Investment[]) =>
-        dispatch({ type: 'ImportMerge', loans, investments }),
+      importMerge: (
+        loans: Loan[],
+        investments: Investment[],
+        scenarios?: Scenario[]
+      ) => dispatch({ type: 'ImportMerge', loans, investments, scenarios }),
       loadSampleData: (loans: Loan[], investments: Investment[]) =>
         dispatch({ type: 'LoadSampleData', loans, investments }),
       clearSampleData: () => dispatch({ type: 'ClearSampleData' }),

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, Dispatch, ReactNode, useMemo, useReducer } from 'react';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
 import { generateId } from '../helpers/id-helpers';
 import {
   FinanceAction,
@@ -27,6 +28,12 @@ export interface FinanceDataContextValue {
   importMerge: (loans: Loan[], investments: Investment[]) => void;
   loadSampleData: (loans: Loan[], investments: Investment[]) => void;
   clearSampleData: () => void;
+  // Scenario actions (Phase 4). addScenario assigns an Id and returns it so the
+  // caller can immediately make the new scenario active.
+  addScenario: (scenario: Scenario) => string;
+  updateScenario: (scenario: Scenario) => void;
+  deleteScenario: (id: string) => void;
+  setActiveScenario: (id: string | null) => void;
 }
 
 export const FinanceDataContext = createContext<
@@ -67,6 +74,16 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
       loadSampleData: (loans: Loan[], investments: Investment[]) =>
         dispatch({ type: 'LoadSampleData', loans, investments }),
       clearSampleData: () => dispatch({ type: 'ClearSampleData' }),
+      addScenario: (scenario: Scenario) => {
+        const id = scenario.Id || generateId();
+        dispatch({ type: 'AddScenario', scenario: { ...scenario, Id: id } });
+        return id;
+      },
+      updateScenario: (scenario: Scenario) =>
+        dispatch({ type: 'UpdateScenario', scenario }),
+      deleteScenario: (id: string) => dispatch({ type: 'DeleteScenario', id }),
+      setActiveScenario: (id: string | null) =>
+        dispatch({ type: 'SetActiveScenario', id }),
     }),
     []
   );

--- a/src/state/finance-reducer.test.ts
+++ b/src/state/finance-reducer.test.ts
@@ -6,6 +6,7 @@ import {
 } from './finance-reducer';
 import { Loan } from '../models/loan-model';
 import { Investment, CompoundingFrequency } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
 
 const makeLoan = (id: string, overrides: Partial<Loan> = {}): Loan => ({
   Id: id,
@@ -463,6 +464,70 @@ describe('financeReducer', () => {
       const start = stateWith({ loans: [makeLoan('a')] });
       const next = financeReducer(start, { type: 'ClearSampleData' });
       expect(next).toBe(start);
+    });
+  });
+
+  describe('scenarios', () => {
+    const makeScenario = (id: string, name = `Scenario ${id}`): Scenario => ({
+      Id: id,
+      Name: name,
+      ExtraLoanPayments: {},
+      ExtraContributions: {},
+    });
+
+    it('AddScenario appends a scenario', () => {
+      const next = financeReducer(initialFinanceState, {
+        type: 'AddScenario',
+        scenario: makeScenario('s1'),
+      });
+      expect(next.scenarios.map((s) => s.Id)).toEqual(['s1']);
+    });
+
+    it('UpdateScenario replaces in place by Id', () => {
+      const start = stateWith({
+        scenarios: [makeScenario('s1'), makeScenario('s2')],
+      });
+      const next = financeReducer(start, {
+        type: 'UpdateScenario',
+        scenario: makeScenario('s1', 'Renamed'),
+      });
+      expect(next.scenarios.map((s) => s.Name)).toEqual([
+        'Renamed',
+        'Scenario s2',
+      ]);
+    });
+
+    it('DeleteScenario removes by Id and clears it if it was active', () => {
+      const start = stateWith({
+        scenarios: [makeScenario('s1'), makeScenario('s2')],
+        activeScenarioId: 's1',
+      });
+      const next = financeReducer(start, { type: 'DeleteScenario', id: 's1' });
+      expect(next.scenarios.map((s) => s.Id)).toEqual(['s2']);
+      expect(next.activeScenarioId).toBeNull();
+    });
+
+    it('DeleteScenario keeps the active selection when a different scenario is removed', () => {
+      const start = stateWith({
+        scenarios: [makeScenario('s1'), makeScenario('s2')],
+        activeScenarioId: 's2',
+      });
+      const next = financeReducer(start, { type: 'DeleteScenario', id: 's1' });
+      expect(next.activeScenarioId).toBe('s2');
+    });
+
+    it('SetActiveScenario sets and clears the active id', () => {
+      const start = stateWith({ scenarios: [makeScenario('s1')] });
+      expect(
+        financeReducer(start, { type: 'SetActiveScenario', id: 's1' })
+          .activeScenarioId
+      ).toBe('s1');
+      expect(
+        financeReducer(stateWith({ activeScenarioId: 's1' }), {
+          type: 'SetActiveScenario',
+          id: null,
+        }).activeScenarioId
+      ).toBeNull();
     });
   });
 

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -49,7 +49,12 @@ export type FinanceAction =
   | { type: 'UpdateInvestment'; investment: Investment }
   | { type: 'DeleteInvestment'; id: string }
   | { type: 'InsertInvestmentAt'; investment: Investment; index: number }
-  | { type: 'ImportMerge'; loans: Loan[]; investments: Investment[] }
+  | {
+      type: 'ImportMerge';
+      loans: Loan[];
+      investments: Investment[];
+      scenarios?: Scenario[];
+    }
   | { type: 'LoadSampleData'; loans: Loan[]; investments: Investment[] }
   | { type: 'ClearSampleData' }
   // Scenario actions (Phase 4). Like entities, Id generation happens at the
@@ -148,10 +153,15 @@ export const financeReducer = (
         state.investments,
         action.investments
       );
+      // Scenarios merge by Id too (Phase 4.5); omitted means "leave unchanged".
+      const mergedScenarios = action.scenarios
+        ? mergeData(state.scenarios, action.scenarios).items
+        : state.scenarios;
       return {
         ...state,
         loans: mergedLoans,
         investments: mergedInvestments,
+        scenarios: mergedScenarios,
       };
     }
 

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -1,5 +1,6 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Scenario } from '../models/scenario-model';
 import { mergeData } from '../helpers/data-helpers';
 
 // State shape for the finance data context (D2).
@@ -15,6 +16,10 @@ export interface FinanceState {
   // User data stashed while sample data is loaded; null otherwise.
   stashedLoans: Loan[] | null;
   stashedInvestments: Investment[] | null;
+  // Named what-if scenarios (Phase 4). Session-scoped until 4.5 persists them.
+  scenarios: Scenario[];
+  // Which scenario is currently overlaid on the chart, or null for none.
+  activeScenarioId: string | null;
 }
 
 export const initialFinanceState: FinanceState = {
@@ -23,6 +28,8 @@ export const initialFinanceState: FinanceState = {
   sampleDataLoaded: false,
   stashedLoans: null,
   stashedInvestments: null,
+  scenarios: [],
+  activeScenarioId: null,
 };
 
 // Reducer actions (D2). ID generation happens OUTSIDE the reducer (in the
@@ -44,7 +51,13 @@ export type FinanceAction =
   | { type: 'InsertInvestmentAt'; investment: Investment; index: number }
   | { type: 'ImportMerge'; loans: Loan[]; investments: Investment[] }
   | { type: 'LoadSampleData'; loans: Loan[]; investments: Investment[] }
-  | { type: 'ClearSampleData' };
+  | { type: 'ClearSampleData' }
+  // Scenario actions (Phase 4). Like entities, Id generation happens at the
+  // dispatch call site so the reducer stays pure.
+  | { type: 'AddScenario'; scenario: Scenario }
+  | { type: 'UpdateScenario'; scenario: Scenario }
+  | { type: 'DeleteScenario'; id: string }
+  | { type: 'SetActiveScenario'; id: string | null };
 
 // Insert `item` into `list` at `index`, clamping the index into [0, length].
 // Pure helper: returns a new array and never mutates the input.
@@ -174,6 +187,31 @@ export const financeReducer = (
         stashedInvestments: null,
       };
     }
+
+    case 'AddScenario':
+      return { ...state, scenarios: [...state.scenarios, action.scenario] };
+
+    case 'UpdateScenario':
+      return {
+        ...state,
+        scenarios: state.scenarios.map((scenario) =>
+          scenario.Id === action.scenario.Id ? action.scenario : scenario
+        ),
+      };
+
+    case 'DeleteScenario':
+      return {
+        ...state,
+        scenarios: state.scenarios.filter(
+          (scenario) => scenario.Id !== action.id
+        ),
+        // Drop the active selection if the deleted scenario was active.
+        activeScenarioId:
+          state.activeScenarioId === action.id ? null : state.activeScenarioId,
+      };
+
+    case 'SetActiveScenario':
+      return { ...state, activeScenarioId: action.id };
 
     default:
       return state;


### PR DESCRIPTION
Rolling roadmap-implementation PR on the working branch. Each substep is a self-contained commit; every commit keeps `npm test`, `test:coverage` (100% on `src/helpers/**`), `check:lint`, `check:format`, and `build` green.

## Complete: Phases 1–4 (v0.8.0 → v0.11.0) ✅

**Phase 1 — Local Persistence (issue #20, v0.8.0)**
1.1 storage-helpers + D8 migration ladder · 1.2 "Save on this device" toggle (hydrate, debounced auto-save, clear-on-disable) · 1.3 first-visit privacy notice · 1.4 global error boundary with export + reload recovery

**Phase 2 — Visualizations (issue #18, v0.9.0)**
2.1 charting spike (D1: @mui/x-charts v9) · 2.2 forecast chart + stable colors · 2.3 show/hide legend · 2.4 time-range + tooltip · 2.5 responsive · 2.6 accessible "view as table"

**Phase 3 — Net Worth Dashboard (v0.10.0)**
3.1 summary cards · 3.2 milestone callouts · 3.3 table upgrades (sorting, totals, payoff/current columns, progress, clone) · 3.4 stated-assumptions panel

**Phase 4 — Scenario Forecasting (issue #24, v0.11.0)**
4.1 scenario model + reducer · 4.2 builder dialog + bar · 4.3 dotted color-matched overlays · 4.4 impact summary · 4.5 persist scenarios + **export schema v3** (first real D8 migration; import now routes through the ladder)

Docs (README, `copilot-instructions.md`, ROADMAP) updated each phase; version at **0.11.0**.

## Started: Phase 5 — "Next Dollar" Optimizer (→ v1.0.0)
- [x] 5.1 optimizer engine (`evaluatePlan` over allocation plans) — pure, coverage-gated
- [ ] 5.2 suggested-split search (Web Worker) · 5.3 optimizer UI · 5.4 custom split builder · 5.5 release polish

https://claude.ai/code/session_01TvbUVCzpcgm976uN8z6fsq