### PR TITLE
docs(roadmap): propose additions — backlog reconciliation, schedule perf, UX safety, totals

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -415,3 +415,32 @@ waived with a comment," which a non-blocking weekly run won't drive on its own.
 - **Baseline (first full run, 2026-06-13)**: overall **85.33%** (844 killed / 147 survived / 11 timeout). Lowest files: `format-helpers.ts` 73.3%, `validation-helpers.ts` 82.7%, `forecast-helpers.ts` 85.1%, `investment-helpers.ts` 85.2%.
 - **Progress (2026-06-14)**: after strengthening the validation warning tests to assert message **content** (not just presence), `validation-helpers.ts` rose 82.7 → **83.7%** and overall held at **85.04%** despite the new #70/#72 warning + guard code adding mutants. `thresholds.break` ratcheted **80 → 83** (just below baseline, with headroom for run-to-run timeout variance). `format-helpers.ts` (73.3%) remains the lowest; its 4 survivors are the `Intl.NumberFormat` caching layer — equivalent mutants that change performance, not output, so they are a documented waiver rather than a test gap.
 - **Done when**: surviving mutants are triaged (each killed by a strengthened test or explicitly waived as equivalent), and `break` is ratcheted up toward zero survivors as the score improves. Next targets: `investment-helpers.ts` (83.9%) and `forecast-helpers.ts` (84.9%).
+
+---
+
+## 9. Proposed Additions (2026-06-15 review)
+
+A triage list, in the same spirit as the cross-cutting proposals that became §6/§8
+(PRs #60, #67): small, concrete additions surfaced by reading the current code and
+the open issue tracker against the roadmap. Each is filed under a category with a
+one-line rationale; none is a commitment until folded into a phase. Where an item
+belongs to an existing phase, the target phase is noted so it can be merged in
+rather than living here long-term.
+
+### 9.1 — Roadmap hygiene / tracking
+
+- **Reconcile §8 with the live issue tracker.** Nine bug issues are currently open (#68–#83), but §8 (which exists precisely for cross-cutting correctness items) reflects none of them. Several are even cited in the Phase 0.12 row as already handled — #70/#72/#73 as "follow-ups" and #68 as the sample-data date fix "shipped in #66, #74, #76" — yet all four remain **open**; #69 (dependency audit), #71 (PIT label), #75 (quarterly period count), #79 (0% loan auto-payment), and #83 (import/export on sample data) are untracked entirely. _Rationale: the roadmap currently overstates correctness status; a backlog pass that either closes the cited issues or moves the open ones into §8 keeps "what's done" trustworthy, which is the same standard §4 holds the math to._
+
+### 9.2 — Performance
+
+- **Virtualize the long schedule tables** (Phase 6, alongside the existing code-split/bundle items). `amortization-popout.tsx` and `growth-schedule-popout.tsx` both `.map()` every row straight into the DOM — a 50-year monthly loan is 600+ `TableRow`s, and the growth schedule projects 30 years (up to ~360 rows) eagerly. _Rationale: the existing perf items target bundle size and first paint, not list render volume; windowing these popouts (e.g. `@mui/x-data-grid` virtualization or a lightweight virtualizer) keeps opening/scrolling smooth on mobile without touching the verified math._
+
+### 9.3 — UX
+
+- **Unsaved-data guard until Phase 1 lands** (bridge to Phase 1, issue #20). A refresh currently wipes everything (gap G6), and there is no warning. A `beforeunload` prompt shown only while there is unpersisted user data — removed once the persistence toggle ships — is a cheap safety net for the window before Phase 1. _Rationale: silent, irreversible data loss on an accidental refresh is the same footgun class as #47/#83; a guard costs little and disappears once real persistence exists._
+- **Surface entity-level sanity warnings on the tables/cards, not only in the edit form.** `validateLoan`/`validateInvestment` already produce "wrong premise" warnings (rate > 30%, `CurrentAmount > Principal`, the proposed under-amortizing-payment warning in #70), but they appear only while a dialog is open — an imported or returning-user entity never shows them. A small warning badge + tooltip on the row would flag questionable inputs at a glance. _Rationale: extends the Charter's "a plausible-looking number on a wrong premise is worse than none" philosophy from the form into the always-visible tables, and gives imported #72-class entities a visible cue._
+
+### 9.4 — New features (small)
+
+- **Lifetime-totals footer in the schedule popouts.** The amortization popout shows per-row figures but no **total interest paid over the life of the loan**; the growth popout shows no **total contributed / total interest earned**. A single summary row is a cheap, high-value derivation from series the popout already computes. _Rationale: "what does this loan actually cost me?" is a headline question users open the schedule to answer, and the totals feed naturally into the Phase 3 dashboard and Phase 5 optimizer framing._
+- **Copy/download a single schedule as CSV** from the amortization/growth popouts. Distinct from the JSON backup (whole-dataset, inputs-only) and the H5 CSV _import_: this is exporting one computed schedule for a spreadsheet or a financial conversation. _Rationale: small UI affordance over data already on screen; pairs with the H5 "printable report" artifact without needing the full report._


### PR DESCRIPTION
## Summary

Adds a new **§9 — Proposed Additions** section to `ROADMAP.md` with categorized, rationale-backed suggestions, following the established convention of the cross-cutting proposal PRs (#60, #67) that became §6/§8. Each item carries a 1–2 sentence rationale and, where applicable, a target phase so it can be folded in rather than living in §9 long-term.

The roadmap is already unusually complete (Phases 0–7 plus the H1–H5 horizon catalog and the §8 correctness backlog), so this PR deliberately avoids padding with speculative features that overlap the existing catalog or its declared non-goals. The suggestions are limited to genuine gaps found by reading the current code and the open issue tracker against the roadmap.

## Proposed additions

**9.1 — Roadmap hygiene / tracking**
- Reconcile §8 with the live tracker: 9 bug issues are open (#68–#83), but §8 reflects none of them. The Phase 0.12 row cites #70/#72/#73 as "follow-ups" and #68 as a fix "shipped in #66, #74, #76" — yet **all four remain open** — and #69/#71/#75/#79/#83 are untracked entirely. The roadmap currently overstates correctness status.

**9.2 — Performance**
- Virtualize the amortization and growth-schedule popouts: both `.map()` every row into the DOM (600+ rows for a 50-year monthly loan; ~360 for a 30-year monthly projection). Existing perf items target bundle size/first paint, not list render volume.

**9.3 — UX**
- A `beforeunload` unsaved-data guard for the window before Phase 1 persistence (#20) ships — a refresh currently wipes everything (gap G6) with no warning.
- Surface entity-level sanity warnings on the tables/cards, not only in the edit dialog, so imported/returning-user entities with questionable inputs (rate > 30%, `CurrentAmount > Principal`, under-amortizing payment) flag at a glance.

**9.4 — New features (small)**
- Lifetime-totals footer in the schedule popouts (total interest paid / total contributed / total interest earned) — a cheap derivation from series already computed.
- Copy/download a single schedule as CSV — distinct from the inputs-only JSON backup and the H5 CSV *import*.

## Notes

- Documentation-only change; no code, tests, or behavior touched (CI's lint/format/build/test gates are unaffected).
- These are proposals for triage, not commitments. The highest-confidence item is 9.1 — it's a verifiable tracking drift between the roadmap's stated status and the open issues. The maintainer can accept, reschedule, or drop any item.

https://claude.ai/code/session_01M3towEaG97VhifNj9m2WKC

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3towEaG97VhifNj9m2WKC)_