### PR TITLE
Fix open bugs: forecast horizon, import validation, sample-data import/export, 0% loan payment, quarterly periods, PIT label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-calculator",
-  "version": "0.8.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "0.8.0",
+      "version": "0.11.0",
       "dependencies": {
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.13.5",

--- a/src/data-manager/data-manager.tsx
+++ b/src/data-manager/data-manager.tsx
@@ -8,18 +8,34 @@ import { useFinanceData } from '../state/use-finance-data';
 
 export const DataManager = () => {
   const {
-    state: { loans, investments, scenarios },
+    state: {
+      loans,
+      investments,
+      scenarios,
+      sampleDataLoaded,
+      stashedLoans,
+      stashedInvestments,
+    },
     importMerge,
   } = useFinanceData();
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [successMessage, setSuccessMessage] = useState<string>('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const hasData = loans.length > 0 || investments.length > 0;
+  // While sample data is displayed, the user's real data is parked in the
+  // stash. Import/Export must act on that real data, not the visible samples —
+  // otherwise an export dumps sample data and an import (which the reducer
+  // routes into the stash) would report stats against the wrong collection. (#83)
+  const realLoans = sampleDataLoaded ? (stashedLoans ?? []) : loans;
+  const realInvestments = sampleDataLoaded
+    ? (stashedInvestments ?? [])
+    : investments;
+
+  const hasData = realLoans.length > 0 || realInvestments.length > 0;
 
   const handleExport = () => {
     try {
-      downloadJsonExport(loans, investments, scenarios);
+      downloadJsonExport(realLoans, realInvestments, scenarios);
       setSuccessMessage('Data exported successfully!');
     } catch (error) {
       // Log full error details for debugging
@@ -64,9 +80,9 @@ export const DataManager = () => {
         // Compute merge statistics for the success message. The actual state
         // update is performed by the reducer's ImportMerge action (which runs
         // the same mergeData merge), keeping merge semantics in one place.
-        const { result: loansResult } = mergeData(loans, importedLoans);
+        const { result: loansResult } = mergeData(realLoans, importedLoans);
         const { result: investmentsResult } = mergeData(
-          investments,
+          realInvestments,
           importedInvestments
         );
 

--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -328,6 +328,33 @@ describe('exportToJson and importFromJson', () => {
     expect(() => importFromJson(invalidJson)).toThrow('Invalid date');
   });
 
+  it('should reject a loan whose EndDate is before its StartDate (#85)', () => {
+    // The add/edit form blocks EndDate <= StartDate; import must agree so it
+    // can't accept a loan that yields a degenerate 1-term schedule and traps the
+    // entity as uneditable.
+    const reversedDates = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [{ ...testLoan, StartDate: '2050-01-01', EndDate: '2020-01-01' }],
+      investments: [],
+    });
+
+    expect(() => importFromJson(reversedDates)).toThrow(
+      'end date must be after the start date'
+    );
+  });
+
+  it('should reject a loan whose EndDate equals its StartDate (#85)', () => {
+    const equalDates = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [{ ...testLoan, StartDate: '2030-01-01', EndDate: '2030-01-01' }],
+      investments: [],
+    });
+
+    expect(() => importFromJson(equalDates)).toThrow(
+      'end date must be after the start date'
+    );
+  });
+
   it('should preserve all loan fields', () => {
     const json = exportToJson([testLoan], []);
     const { loans } = importFromJson(json);

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -469,6 +469,15 @@ export const importFromJson = (
       if (isNaN(loan.StartDate.getTime()) || isNaN(loan.EndDate.getTime())) {
         throw new Error(`Invalid date in loan at index ${index}`);
       }
+      // Mirror the form's validateLoan rule at the import boundary: a loan whose
+      // EndDate is on or before its StartDate is rejected by the UI, so accepting
+      // it on import produces a degenerate 1-term schedule and an entity the Edit
+      // dialog can't save. Keep import and validateLoan in agreement. (#85)
+      if (!(loan.StartDate < loan.EndDate)) {
+        throw new Error(
+          `Invalid dates in loan at index ${index}: end date must be after the start date.`
+        );
+      }
     });
 
     investments.forEach((investment, index) => {

--- a/src/helpers/forecast-helpers.test.ts
+++ b/src/helpers/forecast-helpers.test.ts
@@ -72,6 +72,29 @@ describe('Forecast Helpers', () => {
       const horizon = getDefaultHorizon(loans, [makeInvestment()], today);
       expect(horizon.getTime()).toBe(new Date(2070, 0, 1).getTime());
     });
+
+    it('should extend to 30 years when a loans-only portfolio has all EndDates in the past but still owes a balance (#86)', () => {
+      const pastDueLoan = makeLoan({
+        StartDate: new Date(2018, 0, 1),
+        EndDate: new Date(2024, 0, 1), // already in the past relative to `today`
+        Principal: 30000,
+        CurrentAmount: 8000, // still owes money
+        MonthlyPayment: 500,
+        InterestRate: 6,
+      });
+
+      const horizon = getDefaultHorizon([pastDueLoan], [], today);
+
+      // Must not be earlier than today (which would collapse the chart); falls
+      // back to the 30-year default so the payoff can still be projected.
+      expect(horizon.getTime()).toBe(dayjs(today).add(30, 'year').valueOf());
+
+      // And the forecast actually projects the remaining payoff rather than
+      // degenerating to a single point at today.
+      const series = forecastLoan(pastDueLoan, horizon, 0, today);
+      expect(series.length).toBeGreaterThan(1);
+      expect(getPayoffDate(series)).toBeDefined();
+    });
   });
 
   describe('forecastLoan', () => {

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -39,7 +39,13 @@ export const getDefaultHorizon = (
     undefined
   );
 
-  if (!latestLoanEnd) {
+  // No loans to anchor to, or every loan's scheduled EndDate is already in the
+  // past (a loans-only portfolio that is behind on / past the nominal term of
+  // its loans but still owes a balance): there is nothing further out to anchor
+  // the horizon to, so fall back to the default 30-year horizon. Returning the
+  // latest (past) EndDate here would make the horizon earlier than today and
+  // collapse the forecast chart to a single point. (#86)
+  if (!latestLoanEnd || !latestLoanEnd.isAfter(dayjs(today))) {
     return thirtyYearsOut.toDate();
   }
 

--- a/src/helpers/investment-helpers.test.ts
+++ b/src/helpers/investment-helpers.test.ts
@@ -159,6 +159,49 @@ describe('Investment Helpers', () => {
       // After 4 quarters (1 year)
       expect(getInvestmentPeriods(investment, new Date(2026, 0, 1))).toBe(5);
     });
+
+    it('should anchor quarterly periods to StartDate, not calendar quarters (#75)', () => {
+      // StartDate is Feb 15 — NOT on a calendar-quarter boundary. Real
+      // compounding boundaries are Feb 15 -> May 15 -> Aug 15..., so the period
+      // count must follow those, not the calendar Q1/Q2 line at Apr 1. The count
+      // must match the periods generateInvestmentGrowth actually emits.
+      const investment: Investment = {
+        Id: 'test-id-q-offset',
+        Provider: 'Test',
+        Name: 'Test',
+        StartDate: new Date(2020, 1, 15), // Feb 15
+        StartingBalance: 10000,
+        AverageReturnRate: 5,
+        CompoundingPeriod: CompoundingFrequency.Quarterly,
+      };
+
+      const actualPeriods = (projectTo: Date): number =>
+        generateInvestmentGrowth(investment, projectTo).filter(
+          (entry) => entry.Period > 0
+        ).length;
+
+      // Crossed the calendar-quarter line (Apr 1) but still inside the first
+      // real period (next boundary is May 15): exactly 1 period, not 2.
+      const aprDate = new Date(2020, 3, 20);
+      expect(getInvestmentPeriods(investment, aprDate)).toBe(1);
+      expect(getInvestmentPeriods(investment, aprDate)).toBe(
+        actualPeriods(aprDate)
+      );
+
+      // Before the May 15 boundary: still 1.
+      const earlyMayDate = new Date(2020, 4, 10);
+      expect(getInvestmentPeriods(investment, earlyMayDate)).toBe(1);
+      expect(getInvestmentPeriods(investment, earlyMayDate)).toBe(
+        actualPeriods(earlyMayDate)
+      );
+
+      // Past the May 15 boundary: now 2.
+      const lateMayDate = new Date(2020, 4, 20);
+      expect(getInvestmentPeriods(investment, lateMayDate)).toBe(2);
+      expect(getInvestmentPeriods(investment, lateMayDate)).toBe(
+        actualPeriods(lateMayDate)
+      );
+    });
   });
 
   describe('getNextCompoundingDate', () => {

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -91,22 +91,19 @@ export const getInvestmentPeriods = (
       periods += 1;
     }
   } else if (periodsPerYear === 4) {
-    // Quarterly
-    const startQuarter = Math.floor(start.getMonth() / 3);
-    const endQuarter = Math.floor(end.getMonth() / 3);
-    periods =
-      (end.getFullYear() - start.getFullYear()) * 4 +
-      (endQuarter - startQuarter);
-    // Add partial quarter if we've passed the quarter start
-    const quarterStartMonth = endQuarter * 3;
-    const quarterStartDate = new Date(
-      end.getFullYear(),
-      quarterStartMonth,
-      start.getDate()
-    );
-    if (end >= quarterStartDate) {
-      periods += 1;
+    // Quarterly — anchored to StartDate, not the calendar (Jan/Apr/Jul/Oct)
+    // quarters. Bucketing into calendar quarters added a phantom period for any
+    // investment that didn't start on a quarter boundary, disagreeing with
+    // generateInvestmentGrowth (which steps 3 months at a time from StartDate).
+    // Count whole months elapsed since StartDate (same start-day comparison as
+    // the monthly branch) and divide into 3-month quarters. (#75)
+    let monthsElapsed =
+      (end.getFullYear() - start.getFullYear()) * 12 +
+      (end.getMonth() - start.getMonth());
+    if (end.getDate() < start.getDate()) {
+      monthsElapsed -= 1;
     }
+    periods = Math.floor(monthsElapsed / 3) + 1;
   } else {
     // Annually
     periods = end.getFullYear() - start.getFullYear();

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -77,9 +77,15 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
       skipNextPaymentRecompute.current = false;
       return;
     }
+    // Guard on "rate is a valid non-negative number" rather than truthiness:
+    // a 0% (interest-free) loan is a first-class, supported input, but `0` is
+    // falsy, so a truthiness check skipped the recompute entirely — leaving the
+    // payment at $0 (blocking Save) for a new 0% loan, and keeping a stale
+    // payment when an existing loan's rate was changed to 0%. getMonthlyPayment
+    // already returns principal / terms for a 0% rate. (#79)
     if (
-      newLoan.Principal &&
-      newLoan.InterestRate &&
+      newLoan.Principal > 0 &&
+      newLoan.InterestRate >= 0 &&
       newLoan.StartDate &&
       newLoan.EndDate
     ) {

--- a/src/loan/pit-popout.tsx
+++ b/src/loan/pit-popout.tsx
@@ -53,7 +53,7 @@ export const PitPopout = (props: PitPopoutProps) => {
         >
           <Stack direction="row">
             <DatePicker
-              label="Start Date"
+              label="Projection Date"
               value={dayjs(selectedDate)}
               onChange={(date) => setSelectedDate(date?.toDate() ?? new Date())}
               minDate={dayjs(props.loan.StartDate)}

--- a/src/state/finance-reducer.test.ts
+++ b/src/state/finance-reducer.test.ts
@@ -340,6 +340,38 @@ describe('financeReducer', () => {
       expect(next.loans.map((l) => l.Id)).toEqual(['a']);
       expect(next.investments.map((i) => i.Id)).toEqual(['x']);
     });
+
+    it('merges into stashed real data while sample data is loaded, surviving a later clear (#83)', () => {
+      // Start with the user's real data, load samples (real data is stashed),
+      // then import. The import must land in the stash, not the visible samples,
+      // so it survives ClearSampleData rather than being silently dropped.
+      const withUserData = stateWith({ loans: [makeLoan('real')] });
+      const loaded = financeReducer(withUserData, {
+        type: 'LoadSampleData',
+        loans: [makeLoan('sample')],
+        investments: [],
+      });
+
+      const afterImport = financeReducer(loaded, {
+        type: 'ImportMerge',
+        loans: [makeLoan('imported')],
+        investments: [],
+      });
+
+      // Samples stay visible and untouched; the import goes to the stash.
+      expect(afterImport.loans.map((l) => l.Id)).toEqual(['sample']);
+      expect(afterImport.stashedLoans?.map((l) => l.Id).sort()).toEqual([
+        'imported',
+        'real',
+      ]);
+
+      // Clearing samples restores the real data WITH the import included.
+      const cleared = financeReducer(afterImport, { type: 'ClearSampleData' });
+      expect(cleared.loans.map((l) => l.Id).sort()).toEqual([
+        'imported',
+        'real',
+      ]);
+    });
   });
 
   describe('Sample data load/clear (roadmap 0.9)', () => {

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -147,16 +147,40 @@ export const financeReducer = (
       };
 
     case 'ImportMerge': {
+      // Scenarios merge by Id too (Phase 4.5); omitted means "leave unchanged".
+      const mergedScenarios = action.scenarios
+        ? mergeData(state.scenarios, action.scenarios).items
+        : state.scenarios;
+
+      // While sample data is loaded, the visible loans/investments are the
+      // samples and the user's real data is parked in the stash. Merge imports
+      // into the *stashed real data* (not the samples), so an import isn't
+      // silently discarded when ClearSampleData restores the stash. Samples stay
+      // visible and untouched until cleared, at which point the merged real data
+      // (including the import) is restored. (#83)
+      if (state.sampleDataLoaded) {
+        const { items: mergedLoans } = mergeData(
+          state.stashedLoans ?? [],
+          action.loans
+        );
+        const { items: mergedInvestments } = mergeData(
+          state.stashedInvestments ?? [],
+          action.investments
+        );
+        return {
+          ...state,
+          stashedLoans: mergedLoans,
+          stashedInvestments: mergedInvestments,
+          scenarios: mergedScenarios,
+        };
+      }
+
       // Preserve DataManager's merge-by-Id semantics exactly.
       const { items: mergedLoans } = mergeData(state.loans, action.loans);
       const { items: mergedInvestments } = mergeData(
         state.investments,
         action.investments
       );
-      // Scenarios merge by Id too (Phase 4.5); omitted means "leave unchanged".
-      const mergedScenarios = action.scenarios
-        ? mergeData(state.scenarios, action.scenarios).items
-        : state.scenarios;
       return {
         ...state,
         loans: mergedLoans,


### PR DESCRIPTION
## Summary

Resolves the open bug issues. Each fix keeps the engine/validation as the single source of truth and adds a regression test where the layer is testable.

| Issue | Fix |
|------|------|
| #86 | `getDefaultHorizon` no longer returns a **past** date for a loans-only portfolio whose loans are past their `EndDate` but still owe a balance. When there's nothing future to anchor to, it falls back to the 30-year default, so the forecast chart projects payoff instead of collapsing to a single point at today. |
| #85 | `importFromJson` now rejects loans whose `EndDate` is on/before `StartDate`, matching the form's `validateLoan` rule — no more degenerate 1-term schedule or uneditable imported entity. |
| #83 | While sample data is loaded, **Import** merges into the user's *stashed real data* and **Export** serializes that real data. Imported entities are no longer silently dropped on "Clear sample data", and exports no longer capture sample data. |
| #79 | The Monthly Payment auto-recompute effect guards on a valid **non-negative** rate instead of truthiness, so 0% loans auto-fill their payment (Save no longer blocked) and a rate changed to 0% recomputes instead of keeping a stale payment. |
| #75 | `getInvestmentPeriods` anchors quarterly periods to `StartDate` rather than calendar quarters, agreeing with `generateInvestmentGrowth` for investments that don't start on a quarter boundary. |
| #71 | The loan Point-in-Time popout date picker is relabeled **"Projection Date"** to match the investment popout and describe the control accurately. |
| #73 | Already resolved on this branch — `RemainingTerms` is derived from payoff state (verified, code + regression test present). |
| #69 | Already resolved on this branch — `npm audit` reports **0 vulnerabilities**. |

## Tests
- New regression tests for #86, #85, #83, and #75.
- Full suite green: **391 tests passing**, lint clean, build + prettier pass.

Fixes #86
Fixes #85
Fixes #83
Fixes #79
Fixes #75
Fixes #73
Fixes #71
Fixes #69

https://claude.ai/code/session_01QdZi4MND9BqjjWi47vajmU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdZi4MND9BqjjWi47vajmU)_