### PR TITLE
Split scenario impact computation for baseline reuse

### DIFF
--- a/src/helpers/optimizer-helpers.ts
+++ b/src/helpers/optimizer-helpers.ts
@@ -1,7 +1,13 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
 import { ScenarioInput } from '../models/forecast-model';
-import { computeScenarioImpact } from './scenario-impact-helpers';
+import {
+  ScenarioBaseline,
+  ScenarioImpact,
+  computeScenarioBaseline,
+  computeScenarioImpact,
+  computeScenarioImpactWithBaseline,
+} from './scenario-impact-helpers';
 
 // The "Next Dollar" optimizer engine (Phase 5). An allocation plan splits $X/mo
 // across any number of loans/investments; evaluatePlan scores it against the
@@ -68,6 +74,20 @@ export const splitAllocations = (
   return { ExtraLoanPayments, ExtraContributions };
 };
 
+// Assemble a PlanEvaluation from a plan and its computed impact, applying the
+// ranking objective (see PlanEvaluation.score). Shared by the single-plan
+// evaluatePlan and the many-plan suggestPlans search.
+const toEvaluation = (
+  plan: AllocationPlan,
+  impact: ScenarioImpact
+): PlanEvaluation => ({
+  plan,
+  netWorthDelta: impact.netWorthDelta,
+  interestSaved: impact.interestSaved,
+  payoffMonthsEarlier: impact.payoffMonthsEarlier,
+  score: roundToCents(impact.netWorthDelta + impact.interestSaved),
+});
+
 export const evaluatePlan = (
   loans: Loan[],
   investments: Investment[],
@@ -83,13 +103,7 @@ export const evaluatePlan = (
     today,
     horizon
   );
-  return {
-    plan,
-    netWorthDelta: impact.netWorthDelta,
-    interestSaved: impact.interestSaved,
-    payoffMonthsEarlier: impact.payoffMonthsEarlier,
-    score: roundToCents(impact.netWorthDelta + impact.interestSaved),
-  };
+  return toEvaluation(plan, impact);
 };
 
 // Knobs for the suggested-split search (engine parameters, per roadmap 5.2).
@@ -181,8 +195,27 @@ export const suggestPlans = (
   ];
   if (targets.length === 0) return [];
 
-  const evaluate = (plan: AllocationPlan): PlanEvaluation =>
-    evaluatePlan(loans, investments, plan, today, horizon);
+  // The baseline is identical for every candidate (it has no extra payments),
+  // so compute it once and score each plan against it instead of re-forecasting
+  // the baseline ~70 times across the split grid.
+  const baseline: ScenarioBaseline = computeScenarioBaseline(
+    loans,
+    investments,
+    today,
+    horizon
+  );
+
+  const evaluate = (plan: AllocationPlan): PlanEvaluation => {
+    const scenario = splitAllocations(loans, plan.allocations);
+    const impact = computeScenarioImpactWithBaseline(
+      loans,
+      investments,
+      scenario,
+      baseline,
+      today
+    );
+    return toEvaluation(plan, impact);
+  };
 
   // 1. Single-target plans: all $X to one position.
   const singles = targets.map((target) =>

--- a/src/helpers/scenario-impact-helpers.test.ts
+++ b/src/helpers/scenario-impact-helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import dayjs from 'dayjs';
-import { computeScenarioImpact } from './scenario-impact-helpers';
+import {
+  computeScenarioBaseline,
+  computeScenarioImpact,
+  computeScenarioImpactWithBaseline,
+} from './scenario-impact-helpers';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
 
@@ -91,5 +95,103 @@ describe('computeScenarioImpact', () => {
     );
     expect(impact.payoffMonthsEarlier).toBe(0);
     expect(impact.interestSaved).toBe(0);
+  });
+});
+
+describe('computeScenarioImpactWithBaseline', () => {
+  // The split baseline/scenario API must be a faithful decomposition of
+  // computeScenarioImpact: a baseline computed once and reused per scenario has
+  // to reproduce the all-in-one result exactly.
+  const cases: {
+    name: string;
+    scenario: Parameters<typeof computeScenarioImpact>[2];
+  }[] = [
+    {
+      name: 'an extra loan payment',
+      scenario: { ExtraLoanPayments: { 'loan-1': 300 } },
+    },
+    {
+      name: 'an extra contribution',
+      scenario: { ExtraContributions: { 'inv-1': 200 } },
+    },
+    { name: 'an empty scenario', scenario: {} },
+  ];
+
+  for (const { name, scenario } of cases) {
+    it(`reproduces computeScenarioImpact for ${name}`, () => {
+      const baseline = computeScenarioBaseline([loan], [investment], TODAY);
+      const viaBaseline = computeScenarioImpactWithBaseline(
+        [loan],
+        [investment],
+        scenario,
+        baseline,
+        TODAY
+      );
+      const direct = computeScenarioImpact(
+        [loan],
+        [investment],
+        scenario,
+        TODAY
+      );
+      expect(viaBaseline).toEqual(direct);
+    });
+  }
+
+  it('honours a horizon override carried on the baseline', () => {
+    const horizon = dayjs(TODAY).add(2, 'year').toDate();
+    const baseline = computeScenarioBaseline(
+      [loan],
+      [investment],
+      TODAY,
+      horizon
+    );
+    const viaBaseline = computeScenarioImpactWithBaseline(
+      [loan],
+      [investment],
+      { ExtraContributions: { 'inv-1': 200 } },
+      baseline,
+      TODAY
+    );
+    const direct = computeScenarioImpact(
+      [loan],
+      [investment],
+      { ExtraContributions: { 'inv-1': 200 } },
+      TODAY,
+      horizon
+    );
+    expect(viaBaseline).toEqual(direct);
+  });
+
+  it('reuses one baseline across multiple scenarios', () => {
+    const baseline = computeScenarioBaseline([loan], [], TODAY);
+    const small = computeScenarioImpactWithBaseline(
+      [loan],
+      [],
+      { ExtraLoanPayments: { 'loan-1': 100 } },
+      baseline,
+      TODAY
+    );
+    const big = computeScenarioImpactWithBaseline(
+      [loan],
+      [],
+      { ExtraLoanPayments: { 'loan-1': 400 } },
+      baseline,
+      TODAY
+    );
+    // A bigger extra payment saves strictly more interest off the same baseline.
+    expect(big.interestSaved).toBeGreaterThan(small.interestSaved);
+  });
+
+  it('reports no payoff change when the baseline has no loans', () => {
+    const baseline = computeScenarioBaseline([], [investment], TODAY);
+    expect(baseline.payoffMonth).toBeUndefined();
+    const impact = computeScenarioImpactWithBaseline(
+      [],
+      [investment],
+      { ExtraContributions: { 'inv-1': 100 } },
+      baseline,
+      TODAY
+    );
+    expect(impact.payoffMonthsEarlier).toBe(0);
   });
 });

--- a/src/helpers/scenario-impact-helpers.ts
+++ b/src/helpers/scenario-impact-helpers.ts
@@ -69,6 +69,120 @@ const debtFreeMonth = (
   return undefined;
 };
 
+// The plan-independent half of a scenario impact: everything derived from the
+// baseline (no extra payments/contributions). Computing this once lets a search
+// that scores many scenarios against the same starting point — the Phase 5
+// optimizer — reuse it instead of re-forecasting the baseline per candidate.
+export interface ScenarioBaseline {
+  // Resolved net-worth comparison horizon (honours the optional override).
+  nwHorizon: Date;
+  // Long horizon over which interest and payoff are measured (full lifetimes).
+  longHorizon: Date;
+  // Shared month-count of any series over `longHorizon`.
+  length: number;
+  // Baseline net worth at `nwHorizon`.
+  netWorthAtHorizon: number;
+  // Baseline lifetime loan interest.
+  interest: number;
+  // Baseline debt-free month, or undefined if debt isn't cleared in the horizon.
+  payoffMonth: number | undefined;
+}
+
+// Compute the baseline (no-scenario) figures a scenario is measured against.
+// Pure (D7); the horizon override matches computeScenarioImpact's semantics.
+export const computeScenarioBaseline = (
+  loans: Loan[],
+  investments: Investment[],
+  today: Date = new Date(),
+  horizon?: Date
+): ScenarioBaseline => {
+  // Net worth compared at the requested (or chart default) horizon.
+  const nwHorizon = horizon ?? getDefaultHorizon(loans, investments, today);
+  const baselineNet = forecastNetWorth(
+    loans,
+    investments,
+    nwHorizon,
+    undefined,
+    today
+  );
+
+  // Interest and payoff over a long horizon so full loan lifetimes are captured.
+  const longHorizon = dayjs(today).add(50, 'year').toDate();
+  // The shared month-count of any series over this horizon (an empty net-worth
+  // series is still a date-stamped axis).
+  const length = forecastNetWorth([], [], longHorizon, undefined, today).length;
+
+  const interest = loans.reduce(
+    (sum, loan) => sum + totalLoanInterest(loan, longHorizon, 0, today),
+    0
+  );
+  const payoffMonth = debtFreeMonth(
+    loans,
+    longHorizon,
+    undefined,
+    today,
+    length
+  );
+
+  return {
+    nwHorizon,
+    longHorizon,
+    length,
+    netWorthAtHorizon: baselineNet[baselineNet.length - 1].Value,
+    interest,
+    payoffMonth,
+  };
+};
+
+// Score a single scenario against a precomputed baseline — the
+// scenario-dependent half of computeScenarioImpact, split out so a many-scenario
+// search can amortise the baseline across candidates (roadmap 5.2).
+export const computeScenarioImpactWithBaseline = (
+  loans: Loan[],
+  investments: Investment[],
+  scenario: ScenarioInput,
+  baseline: ScenarioBaseline,
+  today: Date = new Date()
+): ScenarioImpact => {
+  const scenarioNet = forecastNetWorth(
+    loans,
+    investments,
+    baseline.nwHorizon,
+    scenario,
+    today
+  );
+  const netWorthDelta = roundToCents(
+    scenarioNet[scenarioNet.length - 1].Value - baseline.netWorthAtHorizon
+  );
+
+  const scenarioInterest = loans.reduce(
+    (sum, loan) =>
+      sum +
+      totalLoanInterest(
+        loan,
+        baseline.longHorizon,
+        scenario.ExtraLoanPayments?.[loan.Id] ?? 0,
+        today
+      ),
+    0
+  );
+  const interestSaved = roundToCents(baseline.interest - scenarioInterest);
+
+  const scenarioPayoff = debtFreeMonth(
+    loans,
+    baseline.longHorizon,
+    scenario,
+    today,
+    baseline.length
+  );
+  const payoffMonthsEarlier =
+    baseline.payoffMonth !== undefined && scenarioPayoff !== undefined
+      ? Math.max(0, baseline.payoffMonth - scenarioPayoff)
+      : 0;
+
+  return { netWorthDelta, interestSaved, payoffMonthsEarlier };
+};
+
 export const computeScenarioImpact = (
   loans: Loan[],
   investments: Investment[],
@@ -80,68 +194,12 @@ export const computeScenarioImpact = (
   // payoff are always measured over a full 50-year lifetime regardless.
   horizon?: Date
 ): ScenarioImpact => {
-  // Net worth compared at the requested (or chart default) horizon.
-  const nwHorizon = horizon ?? getDefaultHorizon(loans, investments, today);
-  const baselineNet = forecastNetWorth(
+  const baseline = computeScenarioBaseline(loans, investments, today, horizon);
+  return computeScenarioImpactWithBaseline(
     loans,
     investments,
-    nwHorizon,
-    undefined,
+    scenario,
+    baseline,
     today
   );
-  const scenarioNet = forecastNetWorth(
-    loans,
-    investments,
-    nwHorizon,
-    scenario,
-    today
-  );
-  const netWorthDelta = roundToCents(
-    scenarioNet[scenarioNet.length - 1].Value -
-      baselineNet[baselineNet.length - 1].Value
-  );
-
-  // Interest and payoff over a long horizon so full loan lifetimes are captured.
-  const longHorizon = dayjs(today).add(50, 'year').toDate();
-  // The shared month-count of any series over this horizon (an empty net-worth
-  // series is still a date-stamped axis).
-  const length = forecastNetWorth([], [], longHorizon, undefined, today).length;
-
-  const baselineInterest = loans.reduce(
-    (sum, loan) => sum + totalLoanInterest(loan, longHorizon, 0, today),
-    0
-  );
-  const scenarioInterest = loans.reduce(
-    (sum, loan) =>
-      sum +
-      totalLoanInterest(
-        loan,
-        longHorizon,
-        scenario.ExtraLoanPayments?.[loan.Id] ?? 0,
-        today
-      ),
-    0
-  );
-  const interestSaved = roundToCents(baselineInterest - scenarioInterest);
-
-  const baselinePayoff = debtFreeMonth(
-    loans,
-    longHorizon,
-    undefined,
-    today,
-    length
-  );
-  const scenarioPayoff = debtFreeMonth(
-    loans,
-    longHorizon,
-    scenario,
-    today,
-    length
-  );
-  const payoffMonthsEarlier =
-    baselinePayoff !== undefined && scenarioPayoff !== undefined
-      ? Math.max(0, baselinePayoff - scenarioPayoff)
-      : 0;
-
-  return { netWorthDelta, interestSaved, payoffMonthsEarlier };
 };


### PR DESCRIPTION
## Summary
Refactor scenario impact computation to separate baseline (plan-independent) calculations from scenario-dependent scoring. This enables the Phase 5 optimizer to compute the baseline once and reuse it across multiple candidate plans, avoiding redundant forecasting.

## Key Changes
- **New `ScenarioBaseline` interface**: Captures plan-independent figures (net worth horizon, interest, payoff month) computed once from loans/investments without any scenario
- **New `computeScenarioBaseline()` function**: Pure function that computes baseline metrics; replaces the baseline calculation logic previously embedded in `computeScenarioImpact()`
- **New `computeScenarioImpactWithBaseline()` function**: Scores a single scenario against a precomputed baseline; contains the scenario-dependent half of the original logic
- **Refactored `computeScenarioImpact()`**: Now delegates to the two new functions, maintaining backward compatibility
- **New `toEvaluation()` helper**: Extracted common plan-to-evaluation conversion logic shared by `evaluatePlan()` and `suggestPlans()`
- **Optimized `suggestPlans()`**: Computes baseline once before the search loop and uses `computeScenarioImpactWithBaseline()` for each candidate plan, eliminating ~70 redundant baseline forecasts

## Implementation Details
- The baseline computation honors the optional horizon override parameter, matching `computeScenarioImpact()` semantics
- Interest and payoff metrics are always measured over a full 50-year lifetime regardless of the net-worth comparison horizon
- Comprehensive test coverage validates that the split API faithfully decomposes the original function across various scenarios and horizon overrides
- Tests confirm baseline reuse works correctly and produces identical results to the monolithic approach

https://claude.ai/code/session_01Xrk8umH4mFH4LmgiXzHP4s