### PR TITLE
Fix forecast/summary inconsistencies (#88, #91)

### DIFF
--- a/src/helpers/PRECISION.md
+++ b/src/helpers/PRECISION.md
@@ -63,6 +63,25 @@ and **must not drift**. The enforced, tested guarantees:
   cent** at every compounding boundary (month `period × 12 / periodsPerYear`),
   for monthly/quarterly/annual compounding with monthly/quarterly contributions,
   **including with yearly step-ups** (see below).
+- **Investments — off-boundary anchor.** When `today` falls _inside_ a
+  compounding period (the live app always calls the forecast with
+  `today = new Date()`), the canonical engine pro-rates that period's interest
+  into the value it reports for `today`. `forecastInvestment` anchors on exactly
+  that value, so applying a _full_ `periodRate` at the next boundary would count
+  the elapsed slice twice — the #88 double-count (up to ~7% / thousands of
+  dollars for annual compounding). The fix grows the carried anchor by the
+  **complementary** factor `(1+r)/(1+r·f)` at the first boundary (where `f` is
+  the fraction of the period already elapsed at `today`, measured exactly as the
+  canonical engine measures it), which lifts the pro-rated slice to one full
+  period; contributions made during the remainder of the period still earn the
+  full period rate. With `f = 0` (a boundary anchor) the factor is `(1+r)` and
+  this reduces to the boundary-anchored behavior above, so those exact
+  guarantees are unchanged. Off a boundary the two engines then agree to **within
+  intra-step rounding** (a few cents over multi-decade horizons): the forecast
+  can only anchor on the canonical engine's _already-rounded_ today-value, and
+  that ≤½-cent rounding amplifies under compounding. `forecast-consistency.test.ts`
+  asserts this with an off-boundary `today` and a 5-cent band, plus an explicit
+  regression on the #88 numbers.
 
 ### Step-up anniversary attribution (reconciled, ROADMAP §8.1)
 

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -173,6 +173,121 @@ describe('Consistency: forecastInvestment matches growth at compounding boundari
   });
 });
 
+describe('Consistency: forecastInvestment matches growth at an OFF-boundary today (#88)', () => {
+  // The previous tests all anchor at StartDate (an exact compounding boundary,
+  // f = 0), which masked a partial-period double-count: when `today` falls
+  // inside a period, generateInvestmentGrowth pro-rates that slice into the
+  // anchor, and forecastInvestment then applied a *full* periodRate at the next
+  // boundary — counting the elapsed slice twice. With the fix, the forecast
+  // anchored at an off-boundary `today` must still agree with the canonical
+  // engine to the cent at every future compounding boundary.
+  const start = new Date(2020, 0, 1);
+  // 2026-09-16 is off a boundary for monthly/quarterly/annual cadences anchored
+  // to a Jan-1 start (the regression date from issue #88).
+  const today = new Date(2026, 8, 16);
+  const end = new Date(2050, 0, 1);
+
+  const cases: Array<{ name: string; inv: Investment }> = [
+    {
+      name: 'annual compounding, no contributions',
+      inv: makeInvestment({
+        StartDate: start,
+        StartingBalance: 10000,
+        AverageReturnRate: 10,
+        CompoundingPeriod: CompoundingFrequency.Annually,
+      }),
+    },
+    {
+      name: 'quarterly compounding, no contributions',
+      inv: makeInvestment({
+        StartDate: start,
+        StartingBalance: 10000,
+        AverageReturnRate: 10,
+        CompoundingPeriod: CompoundingFrequency.Quarterly,
+      }),
+    },
+    {
+      name: 'monthly compounding, no contributions',
+      inv: makeInvestment({
+        StartDate: start,
+        StartingBalance: 10000,
+        AverageReturnRate: 10,
+        CompoundingPeriod: CompoundingFrequency.Monthly,
+      }),
+    },
+  ];
+
+  cases.forEach(({ name, inv }) => {
+    it(`agrees at every future boundary: ${name}`, () => {
+      const growth = generateInvestmentGrowth(inv, end);
+      const forecast = forecastInvestment(inv, end, 0, today);
+      const interval = 12 / getPeriodsPerYear(inv.CompoundingPeriod);
+
+      // Anchor (today's value) must match the canonical pro-rated value exactly:
+      // both read the same rounded generateInvestmentGrowth output.
+      expect(cents(forecast[0].Value)).toBe(
+        cents(generateInvestmentGrowth(inv, today).at(-1)!.TotalValue)
+      );
+
+      // generateInvestmentGrowth is indexed by period from StartDate; map each
+      // canonical boundary to the forecast's today-anchored month grid and
+      // compare only boundaries that fall on or after today.
+      //
+      // Tolerance: a few cents ("± intra-step rounding order", PRECISION.md
+      // §2/§4). The forecast can only anchor on the canonical engine's
+      // *reported* today-value, which is already rounded to cents; off a
+      // compounding boundary that ≤½-cent rounding amplifies under up to 24
+      // years of compounding and can shift the last few cents at the far
+      // boundaries (measured ≤3¢ here). The pre-fix double-count was orders of
+      // magnitude larger (up to ~7% / thousands of dollars — see the explicit
+      // regression check below), so a 5-cent band still pins the fix tightly.
+      for (let period = 1; period < growth.length; period++) {
+        const monthsFromStart = period * interval;
+        const monthsFromToday =
+          monthsFromStart -
+          (today.getFullYear() - start.getFullYear()) * 12 -
+          (today.getMonth() - start.getMonth());
+        if (monthsFromToday <= 0 || monthsFromToday >= forecast.length)
+          continue;
+        expect(
+          Math.abs(
+            cents(forecast[monthsFromToday].Value) -
+              cents(growth[period].TotalValue)
+          )
+        ).toBeLessThanOrEqual(5);
+      }
+    });
+  });
+
+  it('eliminates the partial-period double-count from the issue report (#88)', () => {
+    // The exact scenario and numbers from issue #88: $10k @ 10%/yr, annual
+    // compounding, no contributions, today off a boundary, projected to 2050.
+    // Canonical value: 174494.02. The pre-fix forecast overstated this as
+    // 186828.15 (+$12,334.13 / +7.07%). After the fix the forecast tracks the
+    // canonical engine to within intra-step rounding (a few cents).
+    const inv = makeInvestment({
+      StartDate: new Date(2020, 0, 1),
+      StartingBalance: 10000,
+      AverageReturnRate: 10,
+      CompoundingPeriod: CompoundingFrequency.Annually,
+    });
+    const offBoundaryToday = new Date(2026, 8, 16);
+    const future = new Date(2050, 0, 1);
+
+    const canonical = generateInvestmentGrowth(inv, future).at(-1)!.TotalValue;
+    const forecast = forecastInvestment(inv, future, 0, offBoundaryToday).at(
+      -1
+    )!.Value;
+
+    expect(canonical).toBeCloseTo(174494.02, 2);
+    // Agreement within a few cents — and nowhere near the old 186828.15
+    // overstatement (~$12k). The pre-fix code would fail this assertion by
+    // four orders of magnitude.
+    expect(Math.abs(forecast - canonical)).toBeLessThanOrEqual(0.05);
+    expect(forecast).toBeLessThan(180000);
+  });
+});
+
 describe('Consistency: step-up anniversary attribution (reconciled, ROADMAP §8.1)', () => {
   // The two investment engines agree to the cent WITHOUT step-ups (asserted
   // above) and now ALSO agree WITH a yearly step-up. They previously diverged:

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -7,6 +7,7 @@ import {
   generateInvestmentGrowth,
   getContributionForYear,
   getInvestmentYear,
+  getNextCompoundingDate,
   getPeriodsPerYear,
 } from './investment-helpers';
 
@@ -20,6 +21,34 @@ const getMonthsBetween = (start: Date, end: Date): number =>
 // Months between occurrences for a frequency (monthly=1, quarterly=3, annually=12).
 const getIntervalMonths = (frequency: CompoundingFrequency): number =>
   12 / getPeriodsPerYear(frequency);
+
+// Fraction (0 ≤ f < 1) of the current compounding period already elapsed at
+// `today`, measured exactly as generateInvestmentGrowth does: step from the
+// StartDate cadence to the last boundary on or before `today` and pro-rate by
+// elapsed/total days of that period. Returns 0 when `today` lands on a
+// boundary (or before StartDate) — no partial period is in flight. (#88)
+const getPartialPeriodFraction = (
+  startDate: Date,
+  today: Date,
+  frequency: CompoundingFrequency
+): number => {
+  if (today <= startDate) {
+    return 0;
+  }
+  let boundary = new Date(startDate.getTime());
+  let next = getNextCompoundingDate(boundary, frequency);
+  while (next <= today) {
+    boundary = next;
+    next = getNextCompoundingDate(boundary, frequency);
+  }
+  // boundary ≤ today < next.
+  if (boundary.getTime() === today.getTime()) {
+    return 0;
+  }
+  const totalMs = next.getTime() - boundary.getTime();
+  const elapsedMs = today.getTime() - boundary.getTime();
+  return elapsedMs / totalMs;
+};
 
 // Default chart horizon: the longest loan schedule, extended to at least
 // 30 years from today when any investments exist (or when there is nothing
@@ -56,6 +85,32 @@ export const getDefaultHorizon = (
   return latestLoanEnd.toDate();
 };
 
+// The monthly payment the forecast actually applies to a loan. When a usable
+// positive MonthlyPayment is stored it is used as-is; otherwise a payment is
+// derived that amortizes today's actual balance over the remaining term — not
+// the original principal over the full term, which would mis-estimate an
+// anchored forecast. A stored 0 (or any non-positive value) is treated as
+// "unset" rather than a real $0/month payment, which would otherwise grow the
+// balance forever. (#51)
+//
+// Shared by forecastLoan and the dashboard summary so the "Monthly commitments"
+// card and the chart never disagree on a loan's outflow: a loan imported with
+// MonthlyPayment: 0 (or no MonthlyPayment key) amortizes in the forecast, so it
+// must contribute that same derived payment to the commitment total. (#91)
+export const getEffectiveMonthlyPayment = (
+  loan: Loan,
+  today: Date = new Date()
+): number => {
+  const balance = roundToCents(Math.max(loan.CurrentAmount, 0));
+  const remainingTerms = Math.max(1, getMonthsBetween(today, loan.EndDate));
+  const storedPayment = loan.MonthlyPayment ?? 0;
+  return storedPayment > 0
+    ? storedPayment
+    : loan.InterestRate > 0
+      ? getMonthlyPayment(balance, loan.InterestRate, remainingTerms)
+      : roundToCents(balance / remainingTerms);
+};
+
 // Forecast a loan's remaining balance month by month from today to the
 // horizon. The series is anchored to CurrentAmount (today's actual balance)
 // rather than replaying the theoretical schedule from StartDate, so the
@@ -74,20 +129,7 @@ export const forecastLoan = (
 
   let balance = roundToCents(Math.max(loan.CurrentAmount, 0));
 
-  // When no usable payment is stored, derive one that amortizes today's actual
-  // balance over the remaining term — not the original principal over the full
-  // term, which would mis-estimate an anchored forecast. A stored 0 (or any
-  // non-positive value) is treated as "unset" rather than a real $0/month
-  // payment, which would otherwise grow the balance forever. (#51)
-  const remainingTerms = Math.max(1, getMonthsBetween(today, loan.EndDate));
-  const storedPayment = loan.MonthlyPayment ?? 0;
-  const basePayment =
-    storedPayment > 0
-      ? storedPayment
-      : loan.InterestRate > 0
-        ? getMonthlyPayment(balance, loan.InterestRate, remainingTerms)
-        : roundToCents(balance / remainingTerms);
-  const payment = basePayment + extraMonthlyPayment;
+  const payment = getEffectiveMonthlyPayment(loan, today) + extraMonthlyPayment;
 
   const points: ForecastPoint[] = [{ Date: start.toDate(), Value: balance }];
 
@@ -146,6 +188,29 @@ export const forecastInvestment = (
 
   const investmentStartMonth = dayjs(investment.StartDate).startOf('month');
 
+  // Off-boundary anchor reconciliation (#88). When `today` falls inside a
+  // compounding period, the anchor (generateInvestmentGrowth up to today, or
+  // CurrentValue) already carries that period's *partial* interest (pro-rated
+  // r·f). Applying a full `periodRate` at the next boundary would count the
+  // elapsed slice twice. At that first boundary we instead grow the carried
+  // anchor by the complementary factor (1+r)/(1+r·f) — which upgrades the
+  // pro-rated slice to exactly one full period — while contributions made
+  // during the remainder of the period still earn the full period rate (they
+  // open the period in the canonical engine). When `today` is on a boundary
+  // f = 0, the factor is (1+r), and this reduces to the previous behavior, so
+  // boundary-anchored consistency is unchanged.
+  const partialFraction = getPartialPeriodFraction(
+    investment.StartDate,
+    today,
+    investment.CompoundingPeriod
+  );
+  const firstBoundaryFactor =
+    (1 + periodRate) / (1 + periodRate * partialFraction);
+  let firstBoundaryApplied = false;
+  // Contributions added since today within the still-open first period; these
+  // earn the full period rate, separate from the carried anchor's correction.
+  let partialPeriodContributions = 0;
+
   let value = anchorValue;
   const points: ForecastPoint[] = [
     { Date: start.toDate(), Value: roundToCents(value) },
@@ -158,6 +223,10 @@ export const forecastInvestment = (
     const elapsedMonths = monthDate
       .startOf('month')
       .diff(investmentStartMonth, 'month');
+
+    // Contributions added before the first compounding boundary belong to the
+    // open period and earn the full period rate there.
+    let contributionThisMonth = 0;
 
     if (
       baseContribution > 0 &&
@@ -178,7 +247,7 @@ export const forecastInvestment = (
         monthDate.subtract(contributionInterval, 'month').toDate(),
         investment.StartDate
       );
-      value += getContributionForYear(
+      contributionThisMonth += getContributionForYear(
         baseContribution,
         yearNumber,
         investment.ContributionStepUpAmount,
@@ -187,11 +256,27 @@ export const forecastInvestment = (
     }
 
     if (extraMonthlyContribution > 0) {
-      value += extraMonthlyContribution;
+      contributionThisMonth += extraMonthlyContribution;
+    }
+
+    value += contributionThisMonth;
+    if (!firstBoundaryApplied) {
+      partialPeriodContributions += contributionThisMonth;
     }
 
     if (elapsedMonths > 0 && elapsedMonths % compoundingInterval === 0) {
-      value *= 1 + periodRate;
+      if (!firstBoundaryApplied) {
+        // First boundary after an off-boundary `today`: grow the carried anchor
+        // by the complementary factor, and credit this period's contributions
+        // the full period rate. With f = 0 (boundary anchor) this collapses to
+        // value *= (1 + periodRate).
+        value =
+          (value - partialPeriodContributions) * firstBoundaryFactor +
+          partialPeriodContributions * (1 + periodRate);
+        firstBoundaryApplied = true;
+      } else {
+        value *= 1 + periodRate;
+      }
     }
 
     points.push({

--- a/src/helpers/summary-helpers.test.ts
+++ b/src/helpers/summary-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { summarizePositions } from './summary-helpers';
 import { forecastNetWorth } from './forecast-helpers';
+import { getMonthlyPayment } from './loan-helpers';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
 
@@ -80,17 +81,12 @@ describe('summarizePositions', () => {
     );
   });
 
-  it('ignores contributions with no cadence and loans with no payment', () => {
+  it('ignores contributions with no cadence or no amount', () => {
     const noCadence: Investment = {
       ...investment,
       Id: 'inv-n',
       RecurringContribution: 500,
       ContributionFrequency: undefined,
-    };
-    const noPayment: Loan = {
-      ...loan,
-      Id: 'loan-n',
-      MonthlyPayment: undefined,
     };
     // A cadence set but no amount also contributes nothing.
     const cadenceNoAmount: Investment = {
@@ -99,12 +95,32 @@ describe('summarizePositions', () => {
       RecurringContribution: undefined,
       ContributionFrequency: CompoundingFrequency.Monthly,
     };
-    const summary = summarizePositions(
-      [noPayment],
-      [noCadence, cadenceNoAmount],
-      TODAY
-    );
+    const summary = summarizePositions([], [noCadence, cadenceNoAmount], TODAY);
     expect(summary.monthlyCommitments).toBe(0);
+  });
+
+  it('counts the forecast-derived payment for a loan with no stored payment (#91)', () => {
+    // A loan imported with MonthlyPayment unset (or 0) is amortized by the
+    // forecast over its remaining term, so it must contribute that same derived
+    // payment to "Monthly commitments" — the card and the chart use a single
+    // source of truth (getEffectiveMonthlyPayment).
+    const remainingTerms = 12; // 2025-01-01 → 2026-01-01
+    const derived = getMonthlyPayment(6000, 6, remainingTerms); // ≈ 516.40
+
+    const noPayment: Loan = {
+      ...loan,
+      Id: 'loan-n',
+      MonthlyPayment: undefined,
+    };
+    const zeroPayment: Loan = { ...loan, Id: 'loan-z', MonthlyPayment: 0 };
+
+    expect(
+      summarizePositions([noPayment], [], TODAY).monthlyCommitments
+    ).toBeCloseTo(derived, 2);
+    // A stored 0 is treated identically to "unset" (not a real $0/mo payment).
+    expect(
+      summarizePositions([zeroPayment], [], TODAY).monthlyCommitments
+    ).toBeCloseTo(derived, 2);
   });
 
   it('is all zeros with no positions', () => {

--- a/src/helpers/summary-helpers.ts
+++ b/src/helpers/summary-helpers.ts
@@ -1,6 +1,10 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
-import { forecastInvestment, forecastLoan } from './forecast-helpers';
+import {
+  forecastInvestment,
+  forecastLoan,
+  getEffectiveMonthlyPayment,
+} from './forecast-helpers';
 import { getPeriodsPerYear } from './investment-helpers';
 
 // "Today" net-worth summary metrics for the dashboard (Phase 3.1). Debt and
@@ -42,8 +46,11 @@ export const summarizePositions = (
     )
   );
 
+  // Use the engine's effective payment (the same value forecastLoan applies),
+  // so a loan with an unset/0 MonthlyPayment that the forecast amortizes still
+  // contributes its derived payment to the commitment total. (#91)
   const loanCommitments = loans.reduce(
-    (sum, loan) => sum + Math.max(loan.MonthlyPayment ?? 0, 0),
+    (sum, loan) => sum + getEffectiveMonthlyPayment(loan, today),
     0
   );
   const investmentCommitments = investments.reduce((sum, investment) => {


### PR DESCRIPTION
Resolves the two open bugs (#88, #91). Both are cross-implementation consistency violations where the forecast engine and a second surface disagreed; each is fixed by routing both surfaces through a single source of truth.

## #91 — "Monthly commitments" understated outflow for loans with no stored payment

`forecastLoan` treats a non-positive/undefined `MonthlyPayment` as "unset" and **derives** an amortizing payment (the #51 behavior), while `summarizePositions` counted only the literal `loan.MonthlyPayment ?? 0` — contributing **$0** for the very same loan the chart shows being paid down. Such loans are valid data (the JSON import boundary allows `MonthlyPayment: 0` or omitted).

**Fix:** factored the engine's payment derivation into a shared `getEffectiveMonthlyPayment(loan, today)` and call it from both `forecastLoan` and `summarizePositions`, so the dashboard card and the chart never disagree.

## #88 — `forecastInvestment` double-counted partial-period interest

The canonical `generateInvestmentGrowth` pro-rates the partial compounding period up to `today` into the anchor; `forecastInvestment` then applied a **full** `periodRate` at the next boundary, counting the elapsed slice twice. Because the live app always calls the forecast with `today = new Date()` (off a boundary), this silently overstated investment growth and net worth — **up to ~7% (+$12,334 on the issue's $10k → 2050 annual-compounding example)** — and contradicted the Growth Schedule / PIT views.

**Fix:** at the first boundary after an off-boundary `today`, grow the carried anchor by the complementary factor `(1 + r) / (1 + r·f)` (where `f` is the fraction of the period already elapsed, measured exactly as the canonical engine measures it), which lifts the pro-rated slice to one full period; contributions made during the remainder of the period still earn the full period rate. When `f = 0` (a boundary anchor) the factor is `(1 + r)` and the change collapses to the previous behavior, so **all existing exact boundary guarantees are unchanged**.

Off a boundary the engines now agree to **within intra-step rounding** (≤3¢ measured over a 24-year horizon) — the forecast can only anchor on the canonical engine's already-rounded today-value, and that ≤½-cent rounding amplifies under compounding (PRECISION.md §2/§4). This is four orders of magnitude tighter than the bug it replaces.

## Tests & docs
- New off-boundary `forecast-consistency.test.ts` cases (monthly/quarterly/annual) anchored at an off-boundary `today`, plus an explicit regression pinning the #88 numbers.
- New `#91` regression asserting a loan with unset/`0` payment contributes its derived amortizing payment to commitments.
- Documented both reconciliations in `PRECISION.md` §4.
- Full suite green (**415 tests**); `tsc -b`, ESLint, and Prettier all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQoE2HpWEH7qVeyWJ29vE7)_