### PR TITLE
Resolve open bugs: month-end compounding, uneditable imported loans, defensive hardening

### DIFF
--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -11,6 +11,8 @@ import {
   CompoundingFrequency,
   StepUpType,
 } from '../models/investment-model';
+import { validateLoan } from './validation-helpers';
+import { getEffectiveMonthlyPayment } from './forecast-helpers';
 
 describe('exportToJson and importFromJson', () => {
   const testLoan: Loan = {
@@ -645,6 +647,32 @@ describe('exportToJson and importFromJson', () => {
       });
       const { loans } = importFromJson(json);
       expect(loans[0].MonthlyPayment).toBeUndefined();
+    });
+
+    it('an imported loan with absent MonthlyPayment is repairable to a valid, editable loan (#94)', () => {
+      // The import boundary admits a loan with no MonthlyPayment, but validateLoan
+      // (the Edit form's Save gate) requires MonthlyPayment > 0. The form must be
+      // able to fill in a derivable payment so the import → edit → save round-trip
+      // is not trapped — a payment derived from the loan's own fields is positive
+      // and makes the loan pass the form gate.
+      const json = JSON.stringify({
+        schemaVersion: EXPORT_SCHEMA_VERSION,
+        loans: [{ ...baseLoan }],
+        investments: [],
+      });
+      const imported = importFromJson(json).loans[0];
+      const today = new Date('2024-06-01');
+
+      // As imported, the form gate blocks it (no positive payment).
+      expect(validateLoan(imported).errors.MonthlyPayment).toBeDefined();
+
+      // A payment derived from its own fields is positive and clears the gate.
+      const derived = getEffectiveMonthlyPayment(imported, today);
+      expect(derived).toBeGreaterThan(0);
+      expect(
+        validateLoan({ ...imported, MonthlyPayment: derived }).errors
+          .MonthlyPayment
+      ).toBeUndefined();
     });
   });
 

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -6,6 +6,7 @@ import {
 } from './loan-helpers';
 import {
   generateInvestmentGrowth,
+  getInvestmentPeriods,
   getPeriodsPerYear,
 } from './investment-helpers';
 import { forecastLoan, forecastInvestment } from './forecast-helpers';
@@ -170,6 +171,67 @@ describe('Consistency: forecastInvestment matches growth at compounding boundari
         );
       }
     });
+  });
+});
+
+describe('Consistency: month-end start dates do not skip a period (#93)', () => {
+  // For a day-29..31 start, Date.setMonth used to overflow February ("Feb 31" →
+  // Mar 3), so generateInvestmentGrowth ran a calendar month behind: it produced
+  // one fewer compounding period than the calendar counters (getInvestmentPeriods)
+  // and forecastInvestment, for the life of the investment. Clamped stepping
+  // (Jan 31 → Feb 28) removes the skip so all three agree again.
+
+  it('getInvestmentPeriods equals the period count generateInvestmentGrowth produces (symptom A)', () => {
+    const inv = makeInvestment({
+      StartDate: new Date(2025, 0, 31),
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    });
+    const end = new Date(2025, 4, 31); // 2025-05-31
+    // growth includes a period-0 anchor entry, so its period count is length − 1.
+    const growthPeriods = generateInvestmentGrowth(inv, end).length - 1;
+    expect(getInvestmentPeriods(inv, end)).toBe(growthPeriods);
+    expect(getInvestmentPeriods(inv, end)).toBe(5); // was 5 vs 4 before the fix
+  });
+
+  it('a month-end start loses no period versus a mid-month start (no skipped February)', () => {
+    const end = new Date(2025, 4, 31);
+    const monthEnd = makeInvestment({
+      StartDate: new Date(2025, 0, 31),
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    });
+    const midMonth = makeInvestment({
+      StartDate: new Date(2025, 0, 15),
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    });
+    // Before the fix the month-end start produced one fewer period (February was
+    // skipped); now both span the same number of compounding events.
+    expect(generateInvestmentGrowth(monthEnd, end).length).toBe(
+      generateInvestmentGrowth(midMonth, end).length
+    );
+  });
+
+  it('forecastInvestment matches generateInvestmentGrowth at the first (aligned) boundary for a month-end start (symptom B)', () => {
+    // Anchored at StartDate, the first compounding boundary (Feb 28) is the one
+    // date where the clamped growth schedule and the forecast's month grid still
+    // coincide. Before the fix, generateInvestmentGrowth treated Jan 31 → Feb 28
+    // as a *partial* slice of a Jan 31 → Mar 3 period, so its value at Feb 28
+    // diverged from the forecast's full-period month-1 value. With clamping,
+    // Feb 28 is a full period in both and they agree to the cent.
+    const start = new Date(2025, 0, 31);
+    const firstBoundary = new Date(2025, 1, 28); // 2025-02-28
+    const inv = makeInvestment({
+      StartDate: start,
+      StartingBalance: 1000,
+      AverageReturnRate: 12,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+    });
+    const growth = generateInvestmentGrowth(inv, firstBoundary);
+    const forecast = forecastInvestment(inv, firstBoundary, 0, start);
+    expect(cents(forecast.at(-1)!.Value)).toBe(
+      cents(growth.at(-1)!.TotalValue)
+    );
+    // One full 1%/month period applied, not a partial slice.
+    expect(cents(growth.at(-1)!.TotalValue)).toBe(cents(1010));
   });
 });
 

--- a/src/helpers/forecast-series.test.ts
+++ b/src/helpers/forecast-series.test.ts
@@ -165,4 +165,12 @@ describe('sliceForecastChartData', () => {
     sliceForecastChartData(full, 1);
     expect(full.dates).toHaveLength(beforeLength);
   });
+
+  it('returns an empty window for a negative month count (#95)', () => {
+    // A negative window is clamped to empty rather than letting
+    // Array.slice(0, negative) back-trim the series from the end.
+    const sliced = sliceForecastChartData(full, -3);
+    expect(sliced.dates).toHaveLength(0);
+    sliced.series.forEach((s) => expect(s.values).toHaveLength(0));
+  });
 });

--- a/src/helpers/forecast-series.ts
+++ b/src/helpers/forecast-series.ts
@@ -118,7 +118,11 @@ export const sliceForecastChartData = (
   data: ForecastChartData,
   months: number
 ): ForecastChartData => {
-  const count = Math.min(months + 1, data.dates.length);
+  // Clamp `months` at the low end before adding the index-0 point: a negative
+  // window is meaningless, and `Array.slice(0, negative)` would trim from the
+  // end rather than return an empty window, silently yielding a back-trimmed
+  // series instead of nothing. (#95)
+  const count = Math.min(Math.max(0, months + 1), data.dates.length);
   return {
     dates: data.dates.slice(0, count),
     series: data.series.map((s) => ({

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -119,26 +119,49 @@ export const getInvestmentPeriods = (
   return Math.max(periods, 1);
 };
 
-// Get the next compounding date based on frequency
+// Add `months` calendar months to a date, CLAMPING to the last valid day of the
+// target month (Jan 31 + 1mo → Feb 28) instead of OVERFLOWING the way bare
+// Date.setMonth does ("Feb 31" → Mar 3). Native Date math (no dayjs) keeps this
+// cheap on the hot forecast/growth loops. Time-of-day is preserved.
+const addMonthsClamped = (date: Date, months: number): Date => {
+  const day = date.getDate();
+  const result = new Date(date.getTime());
+  // Move to the 1st first so the pending large day can't itself overflow the
+  // month while we shift months.
+  result.setDate(1);
+  result.setMonth(result.getMonth() + months);
+  // Day 0 of the following month is the last day of the target month.
+  const lastDayOfMonth = new Date(
+    result.getFullYear(),
+    result.getMonth() + 1,
+    0
+  ).getDate();
+  result.setDate(Math.min(day, lastDayOfMonth));
+  return result;
+};
+
+// Get the next compounding date based on frequency.
+//
+// Clamps month/year steps to the last valid day of the target month rather than
+// overflowing. For a day-29..31 start, Date.setMonth's overflow ("Feb 31" →
+// Mar 3) silently skipped a whole month (February), so generateInvestmentGrowth
+// ran one calendar month behind for the life of the investment and disagreed
+// with the calendar period counters (getInvestmentPeriods) and forecastInvestment
+// — both of which step months with dayjs, which clamps. Clamping here makes all
+// three agree for month-end starts. (#93) For day-1..28 starts clamping is a
+// no-op, so non-month-end behavior is unchanged. (Feb 29 annual clamps to Feb 28,
+// consistent with getAnniversaryDate.)
 export const getNextCompoundingDate = (
   currentDate: Date,
   frequency: CompoundingFrequency
 ): Date => {
-  const nextDate = new Date(currentDate.getTime());
-
-  switch (frequency) {
-    case CompoundingFrequency.Monthly:
-      nextDate.setMonth(nextDate.getMonth() + 1);
-      break;
-    case CompoundingFrequency.Quarterly:
-      nextDate.setMonth(nextDate.getMonth() + 3);
-      break;
-    case CompoundingFrequency.Annually:
-      nextDate.setFullYear(nextDate.getFullYear() + 1);
-      break;
-  }
-
-  return nextDate;
+  const monthsToAdd =
+    frequency === CompoundingFrequency.Monthly
+      ? 1
+      : frequency === CompoundingFrequency.Quarterly
+        ? 3
+        : 12; // Annually
+  return addMonthsClamped(currentDate, monthsToAdd);
 };
 
 // Count how many contributions occur between two dates (exclusive of end date)

--- a/src/helpers/math-edge-cases.test.ts
+++ b/src/helpers/math-edge-cases.test.ts
@@ -59,17 +59,37 @@ describe('Edge: leap-day anniversaries', () => {
   });
 });
 
-describe('Edge: month-end date rollover', () => {
-  it('documents the JS Date rollover for Jan 31 + 1 month (lands in March)', () => {
-    // Jan 31 + 1 month overflows February and normalizes into March — a known
-    // Date quirk. Pinned so a future dayjs migration (Phase 6) is a deliberate
-    // behavior change, not a silent one.
+describe('Edge: month-end date clamping', () => {
+  it('clamps Jan 31 + 1 month to the last day of February (no rollover) (#93)', () => {
+    // Jan 31 + 1 month clamps to Feb 28 rather than overflowing into March. This
+    // stops generateInvestmentGrowth from skipping February for a month-end start
+    // and keeps it aligned with the calendar period counters. (Previously this
+    // overflowed to Mar 3 — pinned as a known quirk; #93 makes it deliberate.)
     const next = getNextCompoundingDate(
       new Date(2021, 0, 31),
       CompoundingFrequency.Monthly
     );
-    expect(next.getMonth()).toBe(2); // March
-    expect(next).toEqual(new Date(2021, 2, 3));
+    expect(next.getMonth()).toBe(1); // February
+    expect(next).toEqual(new Date(2021, 1, 28));
+  });
+
+  it('keeps stepping one month at a time after a month-end clamp', () => {
+    // Once clamped to Feb 28, subsequent steps follow day 28 — Mar 28, Apr 28 —
+    // one calendar month per step, so no month is ever skipped.
+    const feb = getNextCompoundingDate(
+      new Date(2021, 0, 31),
+      CompoundingFrequency.Monthly
+    );
+    const mar = getNextCompoundingDate(feb, CompoundingFrequency.Monthly);
+    expect(mar).toEqual(new Date(2021, 2, 28));
+  });
+
+  it('clamps a Feb-29 start to Feb 28 on an annual step into a non-leap year (#93)', () => {
+    const next = getNextCompoundingDate(
+      new Date(2020, 1, 29),
+      CompoundingFrequency.Annually
+    );
+    expect(next).toEqual(new Date(2021, 1, 28));
   });
 });
 

--- a/src/helpers/optimizer-helpers.test.ts
+++ b/src/helpers/optimizer-helpers.test.ts
@@ -194,7 +194,13 @@ describe('suggestPlans', () => {
   it('normalizes a step that does not divide 100 so split ratios still total 100% (#95)', () => {
     // stepPercent 7 does not divide 100 (a raw grid would top out at 98%); it is
     // snapped to the nearest exact divisor (5) so labels/ratios sum to 100.
-    const plans = suggestPlans([loan, loan2], [], 300, { stepPercent: 7 }, TODAY);
+    const plans = suggestPlans(
+      [loan, loan2],
+      [],
+      300,
+      { stepPercent: 7 },
+      TODAY
+    );
     for (const plan of plans) {
       expect(sumAllocations(plan.plan.allocations)).toBeCloseTo(300, 2);
     }
@@ -205,6 +211,22 @@ describe('suggestPlans', () => {
         Number(m[1])
       );
       expect(pcts.reduce((sum, n) => sum + n, 0)).toBe(100);
+    }
+  });
+
+  it('falls back to the default step for a non-positive stepPercent (#95)', () => {
+    // A zero/negative step is meaningless; it falls back to the default grid
+    // rather than dividing by zero, and still produces budget-preserving splits.
+    const plans = suggestPlans(
+      [loan, loan2],
+      [],
+      300,
+      { stepPercent: 0 },
+      TODAY
+    );
+    expect(plans.length).toBeGreaterThan(2);
+    for (const plan of plans) {
+      expect(sumAllocations(plan.plan.allocations)).toBeCloseTo(300, 2);
     }
   });
 });
@@ -253,7 +275,24 @@ describe('rebalanceAllocation', () => {
     // Old behavior parked the negative drift cent on the last other target;
     // here that target's share rounds to 0, so it would have become -0.01.
     // The drift now lands on the largest other target and is clamped at 0.
-    const result = rebalanceAllocation({ a: 0, b: 1, c: 1, d: 0 }, 'a', 99.99, 100);
+    const result = rebalanceAllocation(
+      { a: 0, b: 1, c: 1, d: 0 },
+      'a',
+      99.99,
+      100
+    );
+    Object.values(result).forEach((v) => expect(v).toBeGreaterThanOrEqual(0));
+    expect(Object.values(result).reduce((sum, v) => sum + v, 0)).toBeCloseTo(
+      100,
+      2
+    );
+  });
+
+  it('parks rounding drift on the largest other target even when it is not first (#95)', () => {
+    // others b:1, c:1, d:5 → shares 14.29 / 14.29 / 71.43 overshoot by a cent;
+    // the drift lands on d (the largest, last in order), keeping Σ == total.
+    const result = rebalanceAllocation({ a: 0, b: 1, c: 1, d: 5 }, 'a', 0, 100);
+    expect(result.d).toBeCloseTo(71.42, 2);
     Object.values(result).forEach((v) => expect(v).toBeGreaterThanOrEqual(0));
     expect(Object.values(result).reduce((sum, v) => sum + v, 0)).toBeCloseTo(
       100,

--- a/src/helpers/optimizer-helpers.test.ts
+++ b/src/helpers/optimizer-helpers.test.ts
@@ -190,6 +190,23 @@ describe('suggestPlans', () => {
     );
     expect(threeWay).toBe(true);
   });
+
+  it('normalizes a step that does not divide 100 so split ratios still total 100% (#95)', () => {
+    // stepPercent 7 does not divide 100 (a raw grid would top out at 98%); it is
+    // snapped to the nearest exact divisor (5) so labels/ratios sum to 100.
+    const plans = suggestPlans([loan, loan2], [], 300, { stepPercent: 7 }, TODAY);
+    for (const plan of plans) {
+      expect(sumAllocations(plan.plan.allocations)).toBeCloseTo(300, 2);
+    }
+    const splits = plans.filter((p) => p.plan.label.includes('%'));
+    expect(splits.length).toBeGreaterThan(0);
+    for (const p of splits) {
+      const pcts = [...p.plan.label.matchAll(/(\d+)%/g)].map((m) =>
+        Number(m[1])
+      );
+      expect(pcts.reduce((sum, n) => sum + n, 0)).toBe(100);
+    }
+  });
 });
 
 describe('rebalanceAllocation', () => {
@@ -224,10 +241,23 @@ describe('rebalanceAllocation', () => {
   });
 
   it('absorbs rounding drift so the split still sums to the total', () => {
-    // 99.99 split evenly across two zero-weighted others rounds to 50.00 each,
-    // overshooting by a cent; the drift is pulled back off the last target.
+    // 99.99 split evenly across two equal others rounds to 50.00 each,
+    // overshooting by a cent; the drift is pulled back off the largest target.
     const result = rebalanceAllocation({ a: 0, b: 1, c: 1 }, 'a', 0.01, 100);
     expect(result.a + result.b + result.c).toBeCloseTo(100, 2);
-    expect(result.c).toBeCloseTo(49.99, 2);
+    expect(result.b).toBeCloseTo(49.99, 2);
+    expect(result.c).toBeCloseTo(50, 2);
+  });
+
+  it('never produces a negative target when drift lands on a near-zero share (#95)', () => {
+    // Old behavior parked the negative drift cent on the last other target;
+    // here that target's share rounds to 0, so it would have become -0.01.
+    // The drift now lands on the largest other target and is clamped at 0.
+    const result = rebalanceAllocation({ a: 0, b: 1, c: 1, d: 0 }, 'a', 99.99, 100);
+    Object.values(result).forEach((v) => expect(v).toBeGreaterThanOrEqual(0));
+    expect(Object.values(result).reduce((sum, v) => sum + v, 0)).toBeCloseTo(
+      100,
+      2
+    );
   });
 });

--- a/src/helpers/optimizer-helpers.ts
+++ b/src/helpers/optimizer-helpers.ts
@@ -117,6 +117,19 @@ export interface SuggestOptions {
 const DEFAULT_STEP_PERCENT = 10;
 const DEFAULT_MAX_CANDIDATES = 3;
 
+// The split grid only sums to a true 100% when the step evenly divides 100;
+// otherwise `Math.round(100 / step) * step` lands short (e.g. step=7 → 98%),
+// drifting the displayed splitLabel percentages and share ratios away from a
+// real 100% split. Snap any requested step to the nearest exact divisor of 100
+// so the grid, the labels, and the ratios always represent a clean 100%. (#95)
+const STEP_DIVISORS = [1, 2, 4, 5, 10, 20, 25, 50, 100];
+const normalizeStepPercent = (requested: number): number => {
+  if (!(requested > 0)) return DEFAULT_STEP_PERCENT;
+  return STEP_DIVISORS.reduce((best, divisor) =>
+    Math.abs(divisor - requested) < Math.abs(best - requested) ? divisor : best
+  );
+};
+
 // Every ordered list of `parts` non-negative integers that sum to `total`
 // (integer compositions including zeros), e.g. total=10, parts=2 →
 // [10,0],[9,1],…,[0,10]. Used to enumerate the percentage grid over candidates.
@@ -186,7 +199,9 @@ export const suggestPlans = (
 ): PlanEvaluation[] => {
   if (!(monthlyExtra > 0)) return [];
 
-  const stepPercent = options.stepPercent ?? DEFAULT_STEP_PERCENT;
+  const stepPercent = normalizeStepPercent(
+    options.stepPercent ?? DEFAULT_STEP_PERCENT
+  );
   const maxCandidates = options.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
 
   const targets: Target[] = [
@@ -286,13 +301,20 @@ export const rebalanceAllocation = (
     result[id] = roundToCents(share);
   });
 
-  // Absorb rounding drift on the last other target so Σ == total exactly.
+  // Absorb rounding drift so Σ == total exactly. Park it on the LARGEST other
+  // target (mirroring sharesToAllocations) and clamp at 0: dumping a negative
+  // cent on the last target unconditionally could push a target whose share
+  // rounded to ~0 down to a transient -0.01. The largest non-zero target can
+  // always absorb a sub-cent drift without going negative. (#95)
   const drift = roundToCents(
     total - Object.values(result).reduce((sum, amount) => sum + amount, 0)
   );
   if (drift !== 0) {
-    const last = otherIds[otherIds.length - 1];
-    result[last] = roundToCents(result[last] + drift);
+    const largest = otherIds.reduce(
+      (maxId, id) => (result[id] > result[maxId] ? id : maxId),
+      otherIds[0]
+    );
+    result[largest] = Math.max(0, roundToCents(result[largest] + drift));
   }
 
   return result;

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -64,12 +64,23 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
   // otherwise trigger the auto-recompute effect and clobber the loan's stored
   // MonthlyPayment. Suppress that one recompute so a saved/custom payment
   // survives opening the editor. (#56)
+  //
+  // Only suppress when the loaded loan actually carries a usable (positive)
+  // payment. An imported loan can arrive with MonthlyPayment absent or 0 — the
+  // JSON import boundary allows it and the forecast derives an effective payment
+  // — but validateLoan requires MonthlyPayment > 0, so suppressing the recompute
+  // there would leave Save permanently disabled and trap the loan as uneditable.
+  // Letting the recompute run fills in the derived payment so the round-trip
+  // (import → edit → save) works, matching the engine's "derive when unset"
+  // behavior. (#94)
   const skipNextPaymentRecompute = useRef(false);
 
   useEffect(() => {
     setNewLoan(props.loan ?? emptyLoan);
     resetTracking();
-    skipNextPaymentRecompute.current = Boolean(props.loan);
+    skipNextPaymentRecompute.current =
+      typeof props.loan?.MonthlyPayment === 'number' &&
+      props.loan.MonthlyPayment > 0;
   }, [props.loan, props.open, resetTracking]);
 
   useEffect(() => {


### PR DESCRIPTION
Resolves the open bug backlog, one focused commit per issue. `tsc -b` clean, ESLint clean, Prettier clean, 426/426 tests pass, and the helpers' 100% line+branch coverage gate holds.

## Closes #93 — Month-end (day 29–31) compounding skipped February
`getNextCompoundingDate` stepped months with `Date.setMonth`, which *overflows* a day-29..31 start past the short month (`"Feb 31"` → `Mar 3`), silently skipping February. `generateInvestmentGrowth` therefore ran one calendar month behind the calendar period counters (`getInvestmentPeriods`) and `forecastInvestment` for the life of any month-end-dated investment — so the PIT view's period count contradicted its own value, and the forecast chart diverged from the Growth Schedule view.

**Fix:** step with day-*clamped* native `Date` arithmetic (`Jan 31` → `Feb 28`), matching the dayjs cadence the forecast already uses, so all three agree. Day-1..28 starts are unchanged. Native `Date` (not dayjs) keeps the hot growth/forecast loops fast. Adds month-end consistency tests and updates the edge-case test that had explicitly pinned the old overflow as "a deliberate change when migrated".

## Closes #94 — Imported loan with missing/0 MonthlyPayment was uneditable
`importFromJson` admits a loan with `MonthlyPayment` absent or `0`, but `validateLoan` (the Edit form's Save gate) requires `> 0`, so such a loan rendered yet could never be saved — a broken import↔form round-trip.

**Fix:** only suppress the form's payment-recompute when the loaded loan carries a *usable* (positive) payment. When the stored payment is missing/non-positive, the recompute derives one so Save is enabled — consistent with the engine's "derive when unset" behavior (#51/#91) and the "loosen the form to match import" precedent (#72). A real stored custom payment is still preserved on open (#56). Adds a logic-layer round-trip test.

## Closes #95 — Defensive hardening (3 dormant robustness gaps)
- **`sliceForecastChartData`**: clamp a negative `months` to an empty window instead of letting `Array.slice(0, negative)` back-trim the series from the end.
- **`suggestPlans`**: snap a `stepPercent` that doesn't divide 100 to the nearest exact divisor, so the split grid, labels, and ratios always total a real 100%.
- **`rebalanceAllocation`**: absorb rounding drift on the *largest* other target and clamp at `0`, so a negative cent can never produce a transient `-0.01`.

---

### Note on #88 and #91
These were already resolved on `main` (commit 37aa4c4 added `getPartialPeriodFraction` for the off-boundary forecast reconciliation and `getEffectiveMonthlyPayment`, which the dashboard summary now uses). They are not changed here; they just need closing. Verified against the current code and existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QanTZB4dLmokuYxGTbM8r6)_