### PR TITLE
Resolve triaged bugs: import/form validation, scenario keys, PIT date, CurrentValue projection

### DIFF
--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -328,6 +328,36 @@ describe('exportToJson and importFromJson', () => {
     expect(() => importFromJson(invalidJson)).toThrow('Invalid date');
   });
 
+  it('should reject a loan with a boolean StartDate (non-string date type) (#100)', () => {
+    // new Date(true) is a *valid* Date (1970-01-01T00:00:00.001Z), so the NaN
+    // check never fires — the type must be rejected up front.
+    const json = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [{ ...testLoan, StartDate: true }],
+      investments: [],
+    });
+    expect(() => importFromJson(json)).toThrow("Invalid value for 'StartDate'");
+  });
+
+  it('should reject a loan with a numeric (epoch) EndDate (#100)', () => {
+    // new Date(1700000000000) coerces a raw epoch to an arbitrary valid date.
+    const json = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [{ ...testLoan, EndDate: 1700000000000 }],
+      investments: [],
+    });
+    expect(() => importFromJson(json)).toThrow("Invalid value for 'EndDate'");
+  });
+
+  it('should reject an investment with a non-string StartDate (#100)', () => {
+    const json = JSON.stringify({
+      schemaVersion: EXPORT_SCHEMA_VERSION,
+      loans: [],
+      investments: [{ ...testInvestment, StartDate: true }],
+    });
+    expect(() => importFromJson(json)).toThrow("Invalid value for 'StartDate'");
+  });
+
   it('should reject a loan whose EndDate is before its StartDate (#85)', () => {
     // The add/edit form blocks EndDate <= StartDate; import must agree so it
     // can't accept a loan that yields a degenerate 1-term schedule and traps the

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -97,6 +97,25 @@ const validateOptionalNumericField = (
   );
 };
 
+// Date fields must be ISO date *strings*. `new Date(value)` coerces a raw epoch
+// number or a boolean into a valid Date (e.g. `new Date(true)` →
+// 1970-01-01T00:00:00.001Z), so a downstream `isNaN(getTime())` check never
+// fires and a tampered/hand-edited file silently materializes a wrong date.
+// Reject any non-string up front, consistent with the numeric type validation
+// (the NaN check still catches malformed strings afterward). (#100)
+const validateDateField = (
+  value: unknown,
+  field: string,
+  entityType: string,
+  index: number
+): void => {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Invalid value for '${field}' in ${entityType} at index ${index}: expected an ISO date string.`
+    );
+  }
+};
+
 /** Valid CompoundingFrequency values derived from the enum */
 const VALID_COMPOUNDING_FREQUENCIES: string[] =
   Object.values(CompoundingFrequency);
@@ -311,6 +330,12 @@ export const importFromJson = (
         'a non-negative finite number'
       );
 
+      // Date fields must be ISO strings (the NaN check below catches malformed
+      // strings; this rejects non-string types that would coerce to a wrong
+      // date). (#100)
+      validateDateField(serializedLoan.StartDate, 'StartDate', 'loan', index);
+      validateDateField(serializedLoan.EndDate, 'EndDate', 'loan', index);
+
       // Pick fields explicitly so unknown properties are dropped at the import boundary
       return {
         Id: serializedLoan.Id,
@@ -407,6 +432,16 @@ export const importFromJson = (
           index,
           (n) => n >= 0,
           'a non-negative finite number'
+        );
+
+        // Date field must be an ISO string (the NaN check below catches malformed
+        // strings; this rejects non-string types that would coerce to a wrong
+        // date). (#100)
+        validateDateField(
+          serializedInvestment.StartDate,
+          'StartDate',
+          'investment',
+          index
         );
 
         // Validate enum fields: CompoundingPeriod must be a valid CompoundingFrequency value

--- a/src/helpers/forecast-helpers.test.ts
+++ b/src/helpers/forecast-helpers.test.ts
@@ -406,6 +406,49 @@ describe('Forecast Helpers', () => {
       expect(series[12].Value).toBe(1000 + 12 * 100);
       expect(series[13].Value).toBe(1000 + 12 * 100 + 150);
     });
+
+    it('grows a user-supplied CurrentValue by only the remaining partial period at the first boundary (#103)', () => {
+      // CurrentValue is today's actual value with NO pro-rated slice baked in
+      // (unlike the generateInvestmentGrowth anchor), so at the first boundary it
+      // must earn only the remaining (1 − f) of the period — not the
+      // (1+r)/(1+r·f) factor, which would divide out a slice that was never added
+      // and systematically under-credit it.
+      const investment = makeInvestment({
+        StartDate: new Date(2020, 0, 1),
+        CompoundingPeriod: CompoundingFrequency.Annually,
+        AverageReturnRate: 10,
+        StartingBalance: 100000,
+        CurrentValue: 100000,
+      });
+      const series = forecastInvestment(
+        investment,
+        new Date(2030, 0, 1),
+        0,
+        today
+      );
+
+      // today (Jun 1 2026) is f of the way through the 2026 annual period; the
+      // first compounding boundary is the grid month that reaches Jan 2027.
+      const boundary = new Date(2026, 0, 1);
+      const next = new Date(2027, 0, 1);
+      const f =
+        (today.getTime() - boundary.getTime()) /
+        (next.getTime() - boundary.getTime());
+      const firstBoundaryMonth = 7; // Jun 2026 + 7 months = Jan 2027
+      expect(dayjs(today).add(firstBoundaryMonth, 'month').month()).toBe(0);
+
+      // Linear remaining-fraction growth, matching the engine's partial-period
+      // pro-rating.
+      const expected =
+        Math.round(100000 * (1 + (10 / 100) * (1 - f)) * 100) / 100;
+      expect(Math.round(series[firstBoundaryMonth].Value * 100)).toBe(
+        Math.round(expected * 100)
+      );
+
+      // Strictly exceeds the old (buggy) (1+r)/(1+r·f) value it used to produce.
+      const buggy = 100000 * (1.1 / (1 + 0.1 * f));
+      expect(series[firstBoundaryMonth].Value).toBeGreaterThan(buggy);
+    });
   });
 
   describe('forecastNetWorth', () => {

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -188,24 +188,37 @@ export const forecastInvestment = (
 
   const investmentStartMonth = dayjs(investment.StartDate).startOf('month');
 
-  // Off-boundary anchor reconciliation (#88). When `today` falls inside a
-  // compounding period, the anchor (generateInvestmentGrowth up to today, or
-  // CurrentValue) already carries that period's *partial* interest (pro-rated
-  // r·f). Applying a full `periodRate` at the next boundary would count the
-  // elapsed slice twice. At that first boundary we instead grow the carried
-  // anchor by the complementary factor (1+r)/(1+r·f) — which upgrades the
-  // pro-rated slice to exactly one full period — while contributions made
-  // during the remainder of the period still earn the full period rate (they
-  // open the period in the canonical engine). When `today` is on a boundary
-  // f = 0, the factor is (1+r), and this reduces to the previous behavior, so
-  // boundary-anchored consistency is unchanged.
+  // Off-boundary anchor reconciliation (#88, #103). When `today` falls inside a
+  // compounding period (fraction f elapsed), contributions made during the
+  // remainder of the period still earn the full period rate (they open the
+  // period in the canonical engine), but the carried anchor grows by a
+  // first-boundary factor that depends on WHICH anchor we carried:
+  //
+  //  - generateInvestmentGrowth / StartingBalance anchor: it already bakes in
+  //    this period's pro-rated slice (base·(1 + r·f)), so applying a full
+  //    `periodRate` at the next boundary would count that slice twice. Complete
+  //    the period instead with (1 + r)/(1 + r·f), which divides the baked-in
+  //    slice back out and upgrades it to exactly one full period → base·(1 + r).
+  //
+  //  - user-supplied CurrentValue anchor: it is just today's actual value, with
+  //    NO pro-rated slice baked in. Applying (1 + r)/(1 + r·f) would divide out a
+  //    slice that was never added, systematically under-crediting the first
+  //    partial period and every value after it (#103). It must instead earn only
+  //    the *remaining* fraction of the period to the next boundary. Use the same
+  //    LINEAR day-fraction pro-rating generateInvestmentGrowth uses for a partial
+  //    period (PRECISION.md): 1 + r·(1 − f).
+  //
+  // Both reduce to (1 + r) when `today` is on a boundary (f = 0), so boundary-
+  // anchored consistency — and the #88 off-boundary tests — are unchanged.
   const partialFraction = getPartialPeriodFraction(
     investment.StartDate,
     today,
     investment.CompoundingPeriod
   );
-  const firstBoundaryFactor =
-    (1 + periodRate) / (1 + periodRate * partialFraction);
+  const usesCurrentValueAnchor = investment.CurrentValue != null;
+  const firstBoundaryFactor = usesCurrentValueAnchor
+    ? 1 + periodRate * (1 - partialFraction)
+    : (1 + periodRate) / (1 + periodRate * partialFraction);
   let firstBoundaryApplied = false;
   // Contributions added since today within the still-open first period; these
   // earn the full period rate, separate from the carried anchor's correction.

--- a/src/helpers/validation-helpers.test.ts
+++ b/src/helpers/validation-helpers.test.ts
@@ -259,10 +259,48 @@ describe('validateInvestment — errors', () => {
     ).toBeDefined();
   });
 
+  it('rejects a negative RecurringContribution (matches import) (#99)', () => {
+    expect(
+      validateInvestment({ ...validInvestment(), RecurringContribution: -500 })
+        .errors.RecurringContribution
+    ).toBeDefined();
+    // Absent and 0 stay valid.
+    expect(
+      validateInvestment({ ...validInvestment(), RecurringContribution: 0 })
+        .errors.RecurringContribution
+    ).toBeUndefined();
+    expect(
+      validateInvestment(validInvestment()).errors.RecurringContribution
+    ).toBeUndefined();
+  });
+
+  it('rejects a negative ContributionStepUpAmount (matches import) (#99)', () => {
+    expect(
+      validateInvestment({
+        ...validInvestment(),
+        ContributionStepUpAmount: -10,
+      }).errors.ContributionStepUpAmount
+    ).toBeDefined();
+  });
+
+  it('rejects a negative CurrentValue (matches import) (#99)', () => {
+    expect(
+      validateInvestment({ ...validInvestment(), CurrentValue: -1 }).errors
+        .CurrentValue
+    ).toBeDefined();
+    expect(
+      validateInvestment({ ...validInvestment(), CurrentValue: 0 }).errors
+        .CurrentValue
+    ).toBeUndefined();
+  });
+
   it('isInvestmentValid is false whenever any error is present', () => {
     expect(isInvestmentValid({ ...validInvestment(), Name: '' })).toBe(false);
     expect(
       isInvestmentValid({ ...validInvestment(), StartingBalance: -1 })
+    ).toBe(false);
+    expect(
+      isInvestmentValid({ ...validInvestment(), RecurringContribution: -1 })
     ).toBe(false);
   });
 });

--- a/src/helpers/validation-helpers.ts
+++ b/src/helpers/validation-helpers.ts
@@ -151,7 +151,8 @@ export type InvestmentField =
   | 'CompoundingPeriod'
   | 'RecurringContribution'
   | 'ContributionFrequency'
-  | 'ContributionStepUpAmount';
+  | 'ContributionStepUpAmount'
+  | 'CurrentValue';
 
 export const validateInvestment = (
   investment: Investment
@@ -180,6 +181,30 @@ export const validateInvestment = (
   }
   if (!investment.StartDate) {
     errors.StartDate = 'Start date is required.';
+  }
+  // These optional numeric fields are rejected when negative by the JSON import
+  // boundary (data-helpers, >= 0), so the form must reject them too — otherwise a
+  // value the form happily saves (a negative RecurringContribution drains the
+  // investment in the forecast) cannot round-trip through export/import, and the
+  // form and import boundary disagree. Only block when present and negative;
+  // absent/0 stays valid. (#99, mirrors the #72 invariant)
+  if (
+    typeof investment.RecurringContribution === 'number' &&
+    investment.RecurringContribution < 0
+  ) {
+    errors.RecurringContribution = 'Recurring contribution cannot be negative.';
+  }
+  if (
+    typeof investment.ContributionStepUpAmount === 'number' &&
+    investment.ContributionStepUpAmount < 0
+  ) {
+    errors.ContributionStepUpAmount = 'Step-up amount cannot be negative.';
+  }
+  if (
+    typeof investment.CurrentValue === 'number' &&
+    investment.CurrentValue < 0
+  ) {
+    errors.CurrentValue = 'Current value cannot be negative.';
   }
 
   // --- Non-blocking sanity warnings ---

--- a/src/investment/pit-popout.tsx
+++ b/src/investment/pit-popout.tsx
@@ -21,7 +21,14 @@ import { NumericFormat, NumberFormatValues } from 'react-number-format';
 import { ResponsiveDialog } from '../components/responsive-dialog';
 
 export const PitPopout = (props: PitPopoutProps) => {
-  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  // Seed in range of the date picker's minDate (StartDate). For a future-dated
+  // investment, today is before StartDate, so defaulting to today would open the
+  // popout in an invalid state (min-date error, 0 periods). Use the later of the
+  // two so the initial date is always >= StartDate. (#102)
+  const [selectedDate, setSelectedDate] = useState<Date>(() => {
+    const now = new Date();
+    return props.investment.StartDate > now ? props.investment.StartDate : now;
+  });
   const [pitInvestment, setPitInvestment] =
     useState<PitInvestment>(defaultPitInvestment);
 

--- a/src/scenario/scenario-builder-dialog.tsx
+++ b/src/scenario/scenario-builder-dialog.tsx
@@ -78,12 +78,16 @@ export const ScenarioBuilderDialog = ({
   };
 
   const extraInput = (
+    id: string,
     label: string,
     value: number | undefined,
     onChange: (value: number) => void
   ) => (
+    // Key by the stable entity Id, not the display Name: names are not unique, so
+    // two same-named positions keyed by Name produce duplicate React keys and the
+    // two fields bleed focus/caret/formatting into each other. (#101)
     <NumericFormat
-      key={label}
+      key={id}
       label={label}
       value={value ?? 0}
       thousandSeparator
@@ -118,11 +122,15 @@ export const ScenarioBuilderDialog = ({
             <>
               <Divider>Extra loan payments</Divider>
               {loans.map((loan) =>
-                extraInput(loan.Name, extraLoanPayments[loan.Id], (value) =>
-                  setExtraLoanPayments((prev) => ({
-                    ...prev,
-                    [loan.Id]: value,
-                  }))
+                extraInput(
+                  loan.Id,
+                  loan.Name,
+                  extraLoanPayments[loan.Id],
+                  (value) =>
+                    setExtraLoanPayments((prev) => ({
+                      ...prev,
+                      [loan.Id]: value,
+                    }))
                 )
               )}
             </>
@@ -133,6 +141,7 @@ export const ScenarioBuilderDialog = ({
               <Divider>Extra contributions</Divider>
               {investments.map((investment) =>
                 extraInput(
+                  investment.Id,
                   investment.Name,
                   extraContributions[investment.Id],
                   (value) =>


### PR DESCRIPTION
Resolves the five bugs opened today (#99–#103), one focused commit each. Independent of PR #104 (no overlapping files). `tsc -b` clean, ESLint clean, Prettier clean, production build succeeds, 422/422 tests pass, and the helpers' 100% line+branch coverage gate holds.

## Closes #99 — Form accepted negative contribution/value fields that import rejects
`validateInvestment` had no blocking error for a negative `RecurringContribution`, `ContributionStepUpAmount`, or `CurrentValue`, but the JSON import boundary rejects all three (`>= 0`). A value the form happily saved (a negative `RecurringContribution` *drains* the investment in the forecast) couldn't round-trip through export/import. **Fix:** added the three blocking errors mirroring the import rule (absent/0 stays valid), plus tests.

## Closes #100 — Import accepted non-string date types
Dates were validated only with `isNaN(date.getTime())`, but `new Date(value)` coerces a raw epoch **number** or a **boolean** into a valid `Date` (`new Date(true)` → `1970-01-01T00:00:00.001Z`), so the guard never fired and a tampered/hand-edited file silently materialized a wrong date. **Fix:** added a `validateDateField` type guard requiring `StartDate`/`EndDate` to be strings (the NaN check still catches malformed strings), plus tests for boolean/numeric date values.

## Closes #103 — #88 reconciliation factor mis-applied to a user-supplied CurrentValue
The `(1+r)/(1+r·f)` off-boundary factor is derived assuming the anchor already carries this period's pro-rated slice (`base·(1+r·f)`) — true for the `generateInvestmentGrowth` anchor, but **not** for a user-supplied `CurrentValue` (just today's value, no slice baked in). Applying it there divided out a slice that was never added, systematically under-crediting the first partial period (~0.1%) and everything after. **Fix:** grow a `CurrentValue` anchor by the remaining fraction only, `1 + r·(1−f)`, using the same linear day-fraction pro-rating `generateInvestmentGrowth` uses; both forms reduce to `(1+r)` on a boundary so the canonical-anchor / #88 behavior is unchanged. Adds a test for the previously-untested intersection (CurrentValue + off-boundary `today` + non-zero rate).

## Closes #101 — Scenario builder used entity Name as React key
Same-named positions produced duplicate React keys → duplicate-key warning and focus/caret/format bleed between the two fields. **Fix:** key the inputs by the stable entity `Id`, keep `Name` as the visible label.

## Closes #102 — Investment PIT popout opened in an invalid date state for future-dated investments
The popout seeded its projection date to today but constrained the picker with `minDate=StartDate`; for a future-dated investment today is before `StartDate`, so it opened with a min-date error and 0 periods. **Fix:** seed `selectedDate` to the later of today and `StartDate` (mirroring the loan PIT popout).

---

#101 and #102 are UI-only; the project's test environment is `node` (no jsdom/RTL) and these surfaces have no component tests, so they're covered by `tsc`, ESLint, and a successful production build rather than unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QanTZB4dLmokuYxGTbM8r6)_