### PR TITLE
Phase 6: table search/filter + bulk multi-select (6.4)

### DIFF
--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -25,6 +25,7 @@ import { ScenarioBar } from './scenario/scenario-bar';
 import { ScenarioImpactSummary } from './scenario/scenario-impact-summary';
 import { OptimizerPanel } from './optimizer/optimizer-panel';
 import { useFinanceData } from './state/use-finance-data';
+import { DataSnapshot } from './state/finance-reducer';
 import { ColorModeToggle, SECTION_GAP, PAPER_PADDING } from './theme';
 import { ConfirmDeleteDialog } from './components/confirm-delete-dialog';
 import {
@@ -62,7 +63,21 @@ type UndoableDelete =
   | { kind: 'loan'; entity: Loan; index: number }
   | { kind: 'investment'; entity: Investment; index: number };
 
+// A bulk delete pending confirmation: which kind, and the selected entities.
+type PendingBulkDelete =
+  | { kind: 'loan'; entities: Loan[] }
+  | { kind: 'investment'; entities: Investment[] };
+
+// A committed bulk delete that can still be undone: the pre-delete data
+// snapshot (restored wholesale) plus the snackbar message.
+interface BulkUndo {
+  snapshot: DataSnapshot;
+  message: string;
+}
+
 const DELETE_UNDO_DURATION_MS = 6000;
+// A bulk delete removes many rows at once, so give the undo a little longer.
+const BULK_DELETE_UNDO_DURATION_MS = 8000;
 
 // Command-bar primary actions ("Add Loan" / "Add Investment"): solid white
 // buttons with deep brand-green text. Styled explicitly rather than via
@@ -82,6 +97,8 @@ export const Body = () => {
       loans,
       investments,
       sampleDataLoaded,
+      stashedLoans,
+      stashedInvestments,
       scenarios,
       activeScenarioId,
     },
@@ -93,6 +110,7 @@ export const Body = () => {
     updateInvestment,
     deleteInvestment,
     insertInvestmentAt,
+    restoreData,
     loadSampleData,
     clearSampleData,
   } = useFinanceData();
@@ -107,6 +125,11 @@ export const Body = () => {
   // Delete confirmation + soft-undo state (roadmap 0.7).
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
   const [undoableDelete, setUndoableDelete] = useState<UndoableDelete>();
+
+  // Bulk delete confirmation + soft-undo state (roadmap 6.4).
+  const [pendingBulkDelete, setPendingBulkDelete] =
+    useState<PendingBulkDelete>();
+  const [bulkUndo, setBulkUndo] = useState<BulkUndo>();
 
   const onLoadSampleData = () => loadSampleData(sampleLoans, sampleInvestments);
 
@@ -209,6 +232,62 @@ export const Body = () => {
     setUndoableDelete(undefined);
   };
 
+  // Bulk delete (roadmap 6.4). The tables hand up the selected entities; Body
+  // owns the confirm + soft-undo, reusing the snapshot/restore mechanism from
+  // the import undo (6.3) so a whole multi-row delete reverts in one step.
+  const onLoanBulkDelete = (selected: Loan[]) => {
+    if (selected.length > 0) {
+      setPendingBulkDelete({ kind: 'loan', entities: selected });
+    }
+  };
+
+  const onInvestmentBulkDelete = (selected: Investment[]) => {
+    if (selected.length > 0) {
+      setPendingBulkDelete({ kind: 'investment', entities: selected });
+    }
+  };
+
+  const bulkDeleteCount = pendingBulkDelete?.entities.length ?? 0;
+  const bulkDeleteNoun =
+    pendingBulkDelete?.kind === 'investment' ? 'investment' : 'loan';
+  const pluralize = (count: number, noun: string) =>
+    `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+  const onConfirmBulkDelete = () => {
+    if (!pendingBulkDelete) {
+      return;
+    }
+    // Snapshot the restorable data before deleting, so undo restores it whole.
+    const snapshot: DataSnapshot = {
+      loans,
+      investments,
+      scenarios,
+      stashedLoans,
+      stashedInvestments,
+    };
+    if (pendingBulkDelete.kind === 'loan') {
+      pendingBulkDelete.entities.forEach((loan) => deleteLoan(loan.Id));
+    } else {
+      pendingBulkDelete.entities.forEach((inv) => deleteInvestment(inv.Id));
+    }
+    setBulkUndo({
+      snapshot,
+      message: `Deleted ${pluralize(
+        pendingBulkDelete.entities.length,
+        pendingBulkDelete.kind
+      )}`,
+    });
+    setPendingBulkDelete(undefined);
+  };
+
+  const onUndoBulkDelete = () => {
+    if (!bulkUndo) {
+      return;
+    }
+    restoreData(bulkUndo.snapshot);
+    setBulkUndo(undefined);
+  };
+
   const deletedName = undoableDelete?.entity.Name ?? '';
   const bothEmpty = loans.length === 0 && investments.length === 0;
   const activeScenario = scenarios.find((s) => s.Id === activeScenarioId);
@@ -295,6 +374,7 @@ export const Body = () => {
                 onLoanEdit={onLoanAddEdit}
                 onLoanDelete={onLoanDelete}
                 onLoanClone={onLoanClone}
+                onLoanBulkDelete={onLoanBulkDelete}
               />
             ) : (
               <SectionEmptyState
@@ -313,6 +393,7 @@ export const Body = () => {
                 onInvestmentEdit={onInvestmentAddEdit}
                 onInvestmentDelete={onInvestmentDelete}
                 onInvestmentClone={onInvestmentClone}
+                onInvestmentBulkDelete={onInvestmentBulkDelete}
               />
             ) : (
               <SectionEmptyState
@@ -417,6 +498,38 @@ export const Body = () => {
           }
         >
           {`Deleted ${deletedName}`}
+        </Alert>
+      </Snackbar>
+
+      {/* Bulk delete confirmation (roadmap 6.4): one prompt for the whole
+          selection, e.g. "Delete 3 loans?". */}
+      <ConfirmDeleteDialog
+        itemName={
+          pendingBulkDelete
+            ? pluralize(bulkDeleteCount, bulkDeleteNoun)
+            : undefined
+        }
+        onCancel={() => setPendingBulkDelete(undefined)}
+        onConfirm={onConfirmBulkDelete}
+      />
+
+      {/* Soft-undo for a bulk delete: restores the whole pre-delete snapshot. */}
+      <Snackbar
+        open={!!bulkUndo}
+        autoHideDuration={BULK_DELETE_UNDO_DURATION_MS}
+        onClose={() => setBulkUndo(undefined)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="info"
+          sx={{ width: '100%' }}
+          action={
+            <Button color="inherit" size="small" onClick={onUndoBulkDelete}>
+              UNDO
+            </Button>
+          }
+        >
+          {bulkUndo?.message}
         </Alert>
       </Snackbar>
     </Container>

--- a/src/components/bulk-actions-toolbar.tsx
+++ b/src/components/bulk-actions-toolbar.tsx
@@ -1,0 +1,64 @@
+import { Button, IconButton, Toolbar, Typography } from '@mui/material';
+import { Close, ContentCopy, Delete } from '@mui/icons-material';
+
+// Bulk-action bar shown above a table when one or more rows are selected
+// (roadmap 6.4). Owns no selection state itself — the table passes the count
+// and the duplicate/delete/clear handlers — so the loan and investment tables
+// share one consistent affordance.
+export interface BulkActionsToolbarProps {
+  count: number;
+  // Singular noun for the entity kind, e.g. "loan" / "investment".
+  itemLabel: string;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  onClear: () => void;
+}
+
+export const BulkActionsToolbar = ({
+  count,
+  itemLabel,
+  onDuplicate,
+  onDelete,
+  onClear,
+}: BulkActionsToolbarProps) => {
+  if (count === 0) {
+    return null;
+  }
+  const noun = count === 1 ? itemLabel : `${itemLabel}s`;
+  return (
+    <Toolbar
+      disableGutters
+      variant="dense"
+      sx={{
+        px: 1.5,
+        mb: 1,
+        gap: 1,
+        borderRadius: 1,
+        bgcolor: 'action.selected',
+      }}
+    >
+      <IconButton
+        size="small"
+        onClick={onClear}
+        aria-label="Clear selection"
+        title="Clear selection"
+      >
+        <Close fontSize="small" />
+      </IconButton>
+      <Typography variant="subtitle2" sx={{ flexGrow: 1 }}>
+        {count} {noun} selected
+      </Typography>
+      <Button size="small" startIcon={<ContentCopy />} onClick={onDuplicate}>
+        Duplicate
+      </Button>
+      <Button
+        size="small"
+        color="error"
+        startIcon={<Delete />}
+        onClick={onDelete}
+      >
+        Delete
+      </Button>
+    </Toolbar>
+  );
+};

--- a/src/components/table-search-field.tsx
+++ b/src/components/table-search-field.tsx
@@ -1,0 +1,35 @@
+import { InputAdornment, TextField } from '@mui/material';
+import { Search } from '@mui/icons-material';
+
+// Shared search box for the loan/investment tables (roadmap 6.4). Controlled by
+// the table, which owns the query string and applies it via filterBySearch.
+export interface TableSearchFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  // Accessible label, e.g. "Search loans".
+  label: string;
+}
+
+export const TableSearchField = ({
+  value,
+  onChange,
+  label,
+}: TableSearchFieldProps) => (
+  <TextField
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    size="small"
+    label={label}
+    placeholder="Name or provider"
+    slotProps={{
+      input: {
+        startAdornment: (
+          <InputAdornment position="start">
+            <Search fontSize="small" />
+          </InputAdornment>
+        ),
+      },
+    }}
+    sx={{ mb: 1.5, width: '100%', maxWidth: 360 }}
+  />
+);

--- a/src/helpers/filter-helpers.test.ts
+++ b/src/helpers/filter-helpers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { matchesQuery, filterBySearch } from './filter-helpers';
+
+describe('matchesQuery', () => {
+  it('matches everything for an empty or whitespace-only query', () => {
+    expect(matchesQuery(['anything'], '')).toBe(true);
+    expect(matchesQuery(['anything'], '   ')).toBe(true);
+    // Even with no fields, the "no filter" state matches.
+    expect(matchesQuery([], '')).toBe(true);
+  });
+
+  it('is case-insensitive and matches substrings', () => {
+    expect(matchesQuery(['Chase Mortgage'], 'mort')).toBe(true);
+    expect(matchesQuery(['Chase Mortgage'], 'CHASE')).toBe(true);
+    expect(matchesQuery(['Chase Mortgage'], 'ge')).toBe(true);
+  });
+
+  it('matches when any one field contains the query', () => {
+    expect(matchesQuery(['Car loan', 'Toyota'], 'toyo')).toBe(true);
+    expect(matchesQuery(['Car loan', 'Toyota'], 'loan')).toBe(true);
+  });
+
+  it('trims surrounding whitespace from the query before matching', () => {
+    expect(matchesQuery(['Brokerage'], '  broker  ')).toBe(true);
+  });
+
+  it('returns false when no field contains the query', () => {
+    expect(matchesQuery(['Car loan', 'Toyota'], 'mortgage')).toBe(false);
+    // A non-empty query against no fields cannot match.
+    expect(matchesQuery([], 'x')).toBe(false);
+  });
+});
+
+describe('filterBySearch', () => {
+  const rows = [
+    { Id: '1', Name: 'Chase Mortgage', Provider: 'Chase' },
+    { Id: '2', Name: 'Car loan', Provider: 'Toyota' },
+    { Id: '3', Name: 'Brokerage', Provider: 'Fidelity' },
+  ];
+  const fields = (r: (typeof rows)[number]) => [r.Name, r.Provider];
+
+  it('returns all items for an empty query', () => {
+    expect(filterBySearch(rows, '', fields)).toEqual(rows);
+  });
+
+  it('filters to items matching name or provider', () => {
+    expect(filterBySearch(rows, 'toyota', fields).map((r) => r.Id)).toEqual([
+      '2',
+    ]);
+    expect(filterBySearch(rows, 'a', fields).map((r) => r.Id)).toEqual([
+      '1',
+      '2',
+      '3',
+    ]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterBySearch(rows, 'zzz', fields)).toEqual([]);
+  });
+
+  it('preserves order and does not mutate the input', () => {
+    const original = [...rows];
+    const result = filterBySearch(rows, 'e', fields);
+    // 'Chase Mortgage'/'Chase' and 'Brokerage'/'Fidelity' contain 'e'.
+    expect(result.map((r) => r.Id)).toEqual(['1', '3']);
+    expect(rows).toEqual(original);
+  });
+});

--- a/src/helpers/filter-helpers.ts
+++ b/src/helpers/filter-helpers.ts
@@ -1,0 +1,22 @@
+// Text search/filter for the loan & investment tables (roadmap 6.4). Pure and
+// generic so the table UI stays a thin consumer: each table supplies the
+// searchable fields for a row, and the same matching rule applies everywhere.
+
+// Case-insensitive substring match of `query` against an item's searchable
+// `fields`. An empty or whitespace-only query is the "no filter" state and
+// matches everything, so the tables show all rows until the user types.
+export const matchesQuery = (fields: string[], query: string): boolean => {
+  const q = query.trim().toLowerCase();
+  if (q === '') {
+    return true;
+  }
+  return fields.some((field) => field.toLowerCase().includes(q));
+};
+
+// Filter `items` to those whose searchable fields match `query`. Order is
+// preserved and the input array is never mutated.
+export const filterBySearch = <T>(
+  items: T[],
+  query: string,
+  getFields: (item: T) => string[]
+): T[] => items.filter((item) => matchesQuery(getFields(item), query));

--- a/src/hooks/use-row-selection.ts
+++ b/src/hooks/use-row-selection.ts
@@ -1,0 +1,52 @@
+import { useCallback, useState } from 'react';
+
+// Multi-select state for the loan/investment tables (roadmap 6.4). Selection is
+// tracked by entity Id (a Set) so it survives sorting and filtering — a selected
+// row stays selected even when it scrolls out of the current filtered view.
+export interface RowSelection {
+  selectedIds: Set<string>;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string) => void;
+  // Add or remove a batch of ids at once (used by the header "select all").
+  setMany: (ids: string[], selected: boolean) => void;
+  clear: () => void;
+}
+
+export const useRowSelection = (): RowSelection => {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const setMany = useCallback((ids: string[], selected: boolean) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (selected) {
+          next.add(id);
+        } else {
+          next.delete(id);
+        }
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => setSelectedIds(new Set()), []);
+
+  const isSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds]
+  );
+
+  return { selectedIds, isSelected, toggle, setMany, clear };
+};

--- a/src/hooks/use-row-selection.ts
+++ b/src/hooks/use-row-selection.ts
@@ -9,6 +9,10 @@ export interface RowSelection {
   toggle: (id: string) => void;
   // Add or remove a batch of ids at once (used by the header "select all").
   setMany: (ids: string[], selected: boolean) => void;
+  // Drop any selected ids that are not in `ids` — used to keep the selection in
+  // sync with the rows that currently exist, so a deleted row leaves the Set
+  // (and an undo restores it unselected rather than re-selecting it).
+  retain: (ids: string[]) => void;
   clear: () => void;
 }
 
@@ -43,10 +47,28 @@ export const useRowSelection = (): RowSelection => {
 
   const clear = useCallback(() => setSelectedIds(new Set()), []);
 
+  const retain = useCallback((ids: string[]) => {
+    const keep = new Set(ids);
+    setSelectedIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (keep.has(id)) {
+          next.add(id);
+        } else {
+          changed = true;
+        }
+      }
+      // Return the same reference when nothing was pruned so this is a no-op
+      // render (the effect that calls it runs on every rows change).
+      return changed ? next : prev;
+    });
+  }, []);
+
   const isSelected = useCallback(
     (id: string) => selectedIds.has(id),
     [selectedIds]
   );
 
-  return { selectedIds, isSelected, toggle, setMany, clear };
+  return { selectedIds, isSelected, toggle, setMany, retain, clear };
 };

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -33,7 +33,7 @@ import {
   Edit,
   TrendingUp,
 } from '@mui/icons-material';
-import { lazy, Suspense, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import { EntityRowActions, RowAction } from '../components/entity-row-actions';
 import { DialogFallback } from '../components/dialog-fallback';
 import { TableSearchField } from '../components/table-search-field';
@@ -286,6 +286,14 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
   // Search/filter + multi-select (roadmap 6.4).
   const [query, setQuery] = useState('');
   const selection = useRowSelection();
+
+  // Keep the selection in sync with the investments that currently exist: a
+  // deleted row leaves the Set, so a bulk-delete undo restores rows unselected
+  // instead of re-selecting them (PR #109 review follow-up).
+  const { retain } = selection;
+  useEffect(() => {
+    retain(props.investments.map((i) => i.Id));
+  }, [props.investments, retain]);
 
   const handlers: InvestmentRowHandlers = {
     onGrowth: setSelectedGrowth,

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -7,6 +7,7 @@ import {
   TableBody,
   TableFooter,
   TableSortLabel,
+  Checkbox,
   Paper,
   Box,
   Card,
@@ -24,6 +25,7 @@ import {
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
+import { filterBySearch } from '../helpers/filter-helpers';
 import {
   Calculate,
   ContentCopy,
@@ -34,6 +36,9 @@ import {
 import { lazy, Suspense, useMemo, useState } from 'react';
 import { EntityRowActions, RowAction } from '../components/entity-row-actions';
 import { DialogFallback } from '../components/dialog-fallback';
+import { TableSearchField } from '../components/table-search-field';
+import { BulkActionsToolbar } from '../components/bulk-actions-toolbar';
+import { useRowSelection } from '../hooks/use-row-selection';
 
 // Code-split the popouts (roadmap 6.6): modal, opened on demand, and pulling in
 // date pickers + the table virtualizer — kept out of the initial bundle.
@@ -181,19 +186,33 @@ const InvestmentCard = ({
   investment,
   handlers,
   isMobile,
+  selected,
+  onSelect,
 }: {
   investment: Investment;
   handlers: InvestmentRowHandlers;
   isMobile: boolean;
+  selected: boolean;
+  onSelect: () => void;
 }) => (
   <Card sx={{ marginBottom: 2 }}>
     <CardContent>
-      <Typography variant="h6" component="div">
-        {investment.Name}
-      </Typography>
-      <Typography sx={{ color: 'text.secondary', mb: 1.5 }}>
-        {investment.Provider}
-      </Typography>
+      <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+        <Checkbox
+          checked={selected}
+          onChange={onSelect}
+          slotProps={{ input: { 'aria-label': `Select ${investment.Name}` } }}
+          sx={{ mt: -1, ml: -1 }}
+        />
+        <Box sx={{ flexGrow: 1 }}>
+          <Typography variant="h6" component="div">
+            {investment.Name}
+          </Typography>
+          <Typography sx={{ color: 'text.secondary', mb: 1.5 }}>
+            {investment.Provider}
+          </Typography>
+        </Box>
+      </Box>
       <Box sx={{ marginBottom: 1 }}>
         <Grid container spacing={2}>
           <Grid size={{ xs: 12, sm: 6 }}>
@@ -264,6 +283,10 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
     useState<InvestmentColumnId>('AverageReturnRate');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
+  // Search/filter + multi-select (roadmap 6.4).
+  const [query, setQuery] = useState('');
+  const selection = useRowSelection();
+
   const handlers: InvestmentRowHandlers = {
     onGrowth: setSelectedGrowth,
     onPit: setSelectedPit,
@@ -280,6 +303,12 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
     [props.investments, column, sortDirection]
   );
 
+  // Visible rows after the text filter (name or provider).
+  const visibleInvestments = useMemo(
+    () => filterBySearch(sortedInvestments, query, (i) => [i.Name, i.Provider]),
+    [sortedInvestments, query]
+  );
+
   const handleSort = (id: InvestmentColumnId) => {
     if (sortColumn === id) {
       setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
@@ -289,14 +318,34 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
     }
   };
 
-  const totalStarting = props.investments.reduce(
+  // Totals reflect what's currently visible (equal to all when unfiltered).
+  const totalStarting = visibleInvestments.reduce(
     (sum, i) => sum + i.StartingBalance,
     0
   );
-  const totalCurrent = props.investments.reduce(
+  const totalCurrent = visibleInvestments.reduce(
     (sum, i) => sum + currentValue(i),
     0
   );
+
+  // Effective selection: selected investments that still exist.
+  const selectedInvestments = props.investments.filter((i) =>
+    selection.isSelected(i.Id)
+  );
+  const visibleIds = visibleInvestments.map((i) => i.Id);
+  const allVisibleSelected =
+    visibleIds.length > 0 && visibleIds.every((id) => selection.isSelected(id));
+  const someVisibleSelected = visibleIds.some((id) => selection.isSelected(id));
+
+  const onBulkDuplicate = () => {
+    selectedInvestments.forEach((i) => props.onInvestmentClone(i));
+    selection.clear();
+  };
+  // Delete routes through Body for the confirm dialog + soft-undo; selection is
+  // left as-is and the confirmed deletions drop out of the count on their own.
+  const onBulkDelete = () => props.onInvestmentBulkDelete(selectedInvestments);
+
+  const noMatches = visibleInvestments.length === 0 && query.trim() !== '';
 
   return (
     <>
@@ -315,14 +364,33 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
         )}
       </Suspense>
 
-      {isMobile ? (
+      <TableSearchField
+        value={query}
+        onChange={setQuery}
+        label="Search investments"
+      />
+      <BulkActionsToolbar
+        count={selectedInvestments.length}
+        itemLabel="investment"
+        onDuplicate={onBulkDuplicate}
+        onDelete={onBulkDelete}
+        onClear={selection.clear}
+      />
+
+      {noMatches ? (
+        <Typography color="text.secondary" sx={{ py: 2 }}>
+          No investments match “{query}”.
+        </Typography>
+      ) : isMobile ? (
         <Box>
-          {sortedInvestments.map((investment) => (
+          {visibleInvestments.map((investment) => (
             <InvestmentCard
               key={investment.Id}
               investment={investment}
               handlers={handlers}
               isMobile={isMobile}
+              selected={selection.isSelected(investment.Id)}
+              onSelect={() => selection.toggle(investment.Id)}
             />
           ))}
         </Box>
@@ -331,6 +399,18 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
           <Table>
             <TableHead>
               <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected && !allVisibleSelected}
+                    onChange={(e) =>
+                      selection.setMany(visibleIds, e.target.checked)
+                    }
+                    slotProps={{
+                      input: { 'aria-label': 'Select all investments' },
+                    }}
+                  />
+                </TableCell>
                 {INVESTMENT_COLUMNS.map((col) => (
                   <TableCell
                     key={col.id}
@@ -352,33 +432,48 @@ export const InvestmentTable = (props: InvestmentTableProps) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedInvestments.map((row) => (
-                <TableRow key={row.Id}>
-                  <TableCell>{row.Name}</TableCell>
-                  <TableCell>{row.Provider}</TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(row.StartingBalance)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(currentValue(row))}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatPercent(row.AverageReturnRate, 3)}
-                  </TableCell>
-                  <TableCell>
-                    {getCompoundingText(row.CompoundingPeriod)}
-                  </TableCell>
-                  <TableCell align="right">{formatContribution(row)}</TableCell>
-                  <TableCell>
-                    <EntityRowActions
-                      actions={investmentActions(row, handlers)}
-                    />
-                  </TableCell>
-                </TableRow>
-              ))}
+              {visibleInvestments.map((row) => {
+                const isSelected = selection.isSelected(row.Id);
+                return (
+                  <TableRow key={row.Id} selected={isSelected}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={isSelected}
+                        onChange={() => selection.toggle(row.Id)}
+                        slotProps={{
+                          input: { 'aria-label': `Select ${row.Name}` },
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>{row.Name}</TableCell>
+                    <TableCell>{row.Provider}</TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(row.StartingBalance)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(currentValue(row))}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatPercent(row.AverageReturnRate, 3)}
+                    </TableCell>
+                    <TableCell>
+                      {getCompoundingText(row.CompoundingPeriod)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatContribution(row)}
+                    </TableCell>
+                    <TableCell>
+                      <EntityRowActions
+                        actions={investmentActions(row, handlers)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
             <TableFooter>
               <TableRow>
+                <TableCell padding="checkbox" />
                 <TableCell>
                   <strong>Totals</strong>
                 </TableCell>
@@ -407,4 +502,5 @@ export type InvestmentTableProps = {
   onInvestmentEdit: (investment: Investment) => void;
   onInvestmentDelete: (investment: Investment) => void;
   onInvestmentClone: (investment: Investment) => void;
+  onInvestmentBulkDelete: (investments: Investment[]) => void;
 };

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -8,6 +8,7 @@ import {
   TableFooter,
   TableSortLabel,
   LinearProgress,
+  Checkbox,
   Paper,
   Box,
   Card,
@@ -24,6 +25,7 @@ import { getTerms } from '../helpers/loan-helpers';
 import { forecastLoan, getPayoffDate } from '../helpers/forecast-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
+import { filterBySearch } from '../helpers/filter-helpers';
 import {
   Calculate,
   CalendarMonth,
@@ -33,6 +35,9 @@ import {
 } from '@mui/icons-material';
 import { EntityRowActions, RowAction } from '../components/entity-row-actions';
 import { DialogFallback } from '../components/dialog-fallback';
+import { TableSearchField } from '../components/table-search-field';
+import { BulkActionsToolbar } from '../components/bulk-actions-toolbar';
+import { useRowSelection } from '../hooks/use-row-selection';
 
 // Code-split the popouts (roadmap 6.6): they are modal, opened on demand, and
 // pull in date pickers + the table virtualizer, so they stay out of the initial
@@ -163,24 +168,38 @@ const LOAN_COLUMNS: LoanColumn[] = [
 const LoanCard = ({
   row,
   handlers,
+  selected,
+  onSelect,
 }: {
   row: LoanRow;
   handlers: LoanRowHandlers;
+  selected: boolean;
+  onSelect: () => void;
 }) => {
   const { loan } = row;
   return (
     <Card sx={{ marginBottom: 2 }}>
       <CardContent>
-        <Typography variant="h6" component="div" gutterBottom>
-          {loan.Name}
-        </Typography>
-        <Typography
-          variant="body2"
-          gutterBottom
-          sx={{ color: 'text.secondary' }}
-        >
-          {loan.Provider}
-        </Typography>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+          <Checkbox
+            checked={selected}
+            onChange={onSelect}
+            slotProps={{ input: { 'aria-label': `Select ${loan.Name}` } }}
+            sx={{ mt: -1, ml: -1 }}
+          />
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography variant="h6" component="div" gutterBottom>
+              {loan.Name}
+            </Typography>
+            <Typography
+              variant="body2"
+              gutterBottom
+              sx={{ color: 'text.secondary' }}
+            >
+              {loan.Provider}
+            </Typography>
+          </Box>
+        </Box>
         <Grid container spacing={2}>
           <Grid size={6}>
             <Typography variant="body2">
@@ -244,6 +263,10 @@ export const LoanTable = (props: LoanTableProps) => {
   const [sortColumn, setSortColumn] = useState<LoanColumnId>('InterestRate');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
+  // Search/filter + multi-select (roadmap 6.4).
+  const [query, setQuery] = useState('');
+  const selection = useRowSelection();
+
   const handlers: LoanRowHandlers = {
     onAmortization: setSelectedAmortization,
     onPit: setSelectedPit,
@@ -271,6 +294,13 @@ export const LoanTable = (props: LoanTableProps) => {
     [rows, column, sortDirection]
   );
 
+  // Visible rows after the text filter (name or provider).
+  const visibleRows = useMemo(
+    () =>
+      filterBySearch(sortedRows, query, (r) => [r.loan.Name, r.loan.Provider]),
+    [sortedRows, query]
+  );
+
   const handleSort = (id: LoanColumnId) => {
     if (sortColumn === id) {
       setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
@@ -280,12 +310,36 @@ export const LoanTable = (props: LoanTableProps) => {
     }
   };
 
-  const totalPrincipal = props.loans.reduce((sum, l) => sum + l.Principal, 0);
-  const totalCurrent = props.loans.reduce((sum, l) => sum + l.CurrentAmount, 0);
-  const totalPayment = props.loans.reduce(
+  // Totals reflect what's currently visible (equal to all loans when unfiltered).
+  const visibleLoans = visibleRows.map((r) => r.loan);
+  const totalPrincipal = visibleLoans.reduce((sum, l) => sum + l.Principal, 0);
+  const totalCurrent = visibleLoans.reduce(
+    (sum, l) => sum + l.CurrentAmount,
+    0
+  );
+  const totalPayment = visibleLoans.reduce(
     (sum, l) => sum + (l.MonthlyPayment ?? 0),
     0
   );
+
+  // Effective selection: selected loans that still exist. Derived (not the raw
+  // Set) so a bulk delete naturally drops its rows from the count.
+  const selectedLoans = props.loans.filter((l) => selection.isSelected(l.Id));
+  const visibleIds = visibleRows.map((r) => r.loan.Id);
+  const allVisibleSelected =
+    visibleIds.length > 0 && visibleIds.every((id) => selection.isSelected(id));
+  const someVisibleSelected = visibleIds.some((id) => selection.isSelected(id));
+
+  const onBulkDuplicate = () => {
+    selectedLoans.forEach((loan) => props.onLoanClone(loan));
+    selection.clear();
+  };
+  // Delete routes through Body for the confirm dialog + soft-undo. Selection is
+  // left as-is; the confirmed deletions drop out of `selectedLoans` on their
+  // own, and a cancel keeps the selection intact.
+  const onBulkDelete = () => props.onLoanBulkDelete(selectedLoans);
+
+  const noMatches = visibleRows.length === 0 && query.trim() !== '';
 
   return (
     <>
@@ -304,10 +358,33 @@ export const LoanTable = (props: LoanTableProps) => {
         )}
       </Suspense>
 
-      {isMobile ? (
+      <TableSearchField
+        value={query}
+        onChange={setQuery}
+        label="Search loans"
+      />
+      <BulkActionsToolbar
+        count={selectedLoans.length}
+        itemLabel="loan"
+        onDuplicate={onBulkDuplicate}
+        onDelete={onBulkDelete}
+        onClear={selection.clear}
+      />
+
+      {noMatches ? (
+        <Typography color="text.secondary" sx={{ py: 2 }}>
+          No loans match “{query}”.
+        </Typography>
+      ) : isMobile ? (
         <Box>
-          {sortedRows.map((row) => (
-            <LoanCard key={row.loan.Id} row={row} handlers={handlers} />
+          {visibleRows.map((row) => (
+            <LoanCard
+              key={row.loan.Id}
+              row={row}
+              handlers={handlers}
+              selected={selection.isSelected(row.loan.Id)}
+              onSelect={() => selection.toggle(row.loan.Id)}
+            />
           ))}
         </Box>
       ) : (
@@ -315,6 +392,18 @@ export const LoanTable = (props: LoanTableProps) => {
           <Table>
             <TableHead>
               <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected && !allVisibleSelected}
+                    onChange={(e) =>
+                      selection.setMany(visibleIds, e.target.checked)
+                    }
+                    slotProps={{
+                      input: { 'aria-label': 'Select all loans' },
+                    }}
+                  />
+                </TableCell>
                 {LOAN_COLUMNS.map((col) => (
                   <TableCell
                     key={col.id}
@@ -337,54 +426,67 @@ export const LoanTable = (props: LoanTableProps) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedRows.map((row) => (
-                <TableRow key={row.loan.Id}>
-                  <TableCell>{row.loan.Name}</TableCell>
-                  <TableCell>{row.loan.Provider}</TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(row.loan.Principal)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(row.loan.CurrentAmount)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatPercent(row.loan.InterestRate)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(row.loan.MonthlyPayment || 0)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatPayoff(row.payoffDate)}
-                  </TableCell>
-                  <TableCell>
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1,
-                        minWidth: 120,
-                      }}
-                    >
-                      <LinearProgress
-                        variant="determinate"
-                        value={row.principalPaidPct}
-                        sx={{ flexGrow: 1 }}
+              {visibleRows.map((row) => {
+                const isSelected = selection.isSelected(row.loan.Id);
+                return (
+                  <TableRow key={row.loan.Id} selected={isSelected}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={isSelected}
+                        onChange={() => selection.toggle(row.loan.Id)}
+                        slotProps={{
+                          input: { 'aria-label': `Select ${row.loan.Name}` },
+                        }}
                       />
-                      <Typography variant="caption" sx={{ minWidth: 32 }}>
-                        {Math.round(row.principalPaidPct)}%
-                      </Typography>
-                    </Box>
-                  </TableCell>
-                  <TableCell>
-                    <EntityRowActions
-                      actions={loanActions(row.loan, handlers)}
-                    />
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                    <TableCell>{row.loan.Name}</TableCell>
+                    <TableCell>{row.loan.Provider}</TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(row.loan.Principal)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(row.loan.CurrentAmount)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatPercent(row.loan.InterestRate)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(row.loan.MonthlyPayment || 0)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatPayoff(row.payoffDate)}
+                    </TableCell>
+                    <TableCell>
+                      <Box
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          minWidth: 120,
+                        }}
+                      >
+                        <LinearProgress
+                          variant="determinate"
+                          value={row.principalPaidPct}
+                          sx={{ flexGrow: 1 }}
+                        />
+                        <Typography variant="caption" sx={{ minWidth: 32 }}>
+                          {Math.round(row.principalPaidPct)}%
+                        </Typography>
+                      </Box>
+                    </TableCell>
+                    <TableCell>
+                      <EntityRowActions
+                        actions={loanActions(row.loan, handlers)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
             <TableFooter>
               <TableRow>
+                <TableCell padding="checkbox" />
                 <TableCell>
                   <strong>Totals</strong>
                 </TableCell>
@@ -416,4 +518,5 @@ export type LoanTableProps = {
   onLoanEdit: (l: Loan) => void;
   onLoanDelete: (l: Loan) => void;
   onLoanClone: (l: Loan) => void;
+  onLoanBulkDelete: (loans: Loan[]) => void;
 };

--- a/src/loan/loan-table.tsx
+++ b/src/loan/loan-table.tsx
@@ -19,7 +19,7 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import { Loan } from '../models/loan-model';
-import { lazy, Suspense, useMemo, useState } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { getTerms } from '../helpers/loan-helpers';
 import { forecastLoan, getPayoffDate } from '../helpers/forecast-helpers';
@@ -266,6 +266,14 @@ export const LoanTable = (props: LoanTableProps) => {
   // Search/filter + multi-select (roadmap 6.4).
   const [query, setQuery] = useState('');
   const selection = useRowSelection();
+
+  // Keep the selection in sync with the loans that currently exist: a deleted
+  // row leaves the Set, so a bulk-delete undo restores rows unselected instead
+  // of re-selecting them and re-showing the toolbar (PR #109 review follow-up).
+  const { retain } = selection;
+  useEffect(() => {
+    retain(props.loans.map((l) => l.Id));
+  }, [props.loans, retain]);
 
   const handlers: LoanRowHandlers = {
     onAmortization: setSelectedAmortization,


### PR DESCRIPTION
## Summary

Continues **Phase 6 — Quality & Hardening** with item **6.4 (table scale)** — keeping the loan & investment tables usable as Phase 7 fills them with cash, property, and custom-asset rows. Built on `main` (after #107); fully independent of the still-open #108 (no shared files).

### What's new
- **Search / filter** — a search box above each table filters rows by **name or provider** (case-insensitive), backed by a new pure, tested `filterBySearch` helper. Table footers now total the **visible** (filtered) rows.
- **Multi-select** — a checkbox column with a **select-all** header (with an indeterminate state) on desktop, and a checkbox on each card on mobile. Selection is tracked by **Id** (a `useRowSelection` hook), so it survives sorting and filtering.
- **Bulk actions** — a toolbar appears when rows are selected:
  - **Duplicate** the selection (loops the existing per-row clone).
  - **Delete** the selection — routed through `Body` for a single **"Delete N?"** confirmation and a **soft-undo** that restores the pre-delete snapshot, reusing the `RestoreData` mechanism from 6.3.

### Deferred
- **Grouping** (by provider) — the remaining 6.4 sub-item — is left for a follow-up; this PR delivers search/filter + bulk select/duplicate/delete.

## Testing
- `npm test` — **461 passing** (+9 for `filter-helpers`)
- `npm run test:coverage` — `src/helpers/**` still **100%** line+branch
- `npm run check:lint` / `npm run check:format` — clean
- `npm run build` — succeeds; `npm run check:size` — initial JS **201.0 kB gzip**, within the 250 kB budget

New filter logic lives in `src/helpers/` with unit tests per the Charter; selection (UI state) lives in a hook, and the toolbar/search are thin shared components.

## Notes for reviewers
- Bulk delete reuses the existing snapshot/restore undo, so a whole multi-row delete reverts in one step (and the sample-data-loaded path is covered, same as single delete).
- No UI component tests yet (that's 6.2) — the new UI is verified by typecheck + build + the pure helper's tests.
- Selection persists across the filter by design: a bulk action operates on everything selected, even rows currently filtered out of view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJxkQkxeHLJcp8NMg5wiqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJxkQkxeHLJcp8NMg5wiqv)_