### PR TITLE
test(e2e): Playwright smoke test for the optimizer critical path (Phase 6.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,38 @@ jobs:
         # the budget, so a heavy import can't silently regress first paint. Runs
         # against the dist/ produced by the Build step above.
         run: npm run check:size
+
+  e2e:
+    name: E2E smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        # CI has open egress, so the Chromium download (blocked in the dev
+        # sandbox) works here. Only Chromium is needed for the smoke test.
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E smoke test (roadmap 6.2)
+        # Playwright boots the Vite dev server itself (see playwright.config.ts)
+        # and drives the add-positions → optimize → view-as-scenario path in a
+        # real browser — the cross-layer wiring the unit suites can't see.
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ tsconfig.node.tsbuildinfo
 coverage
 reports
 .stryker-tmp
+
+# Playwright e2e artifacts
+playwright-report
+test-results
+/blob-report
+/playwright/.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Post-1.0 **Phase 6 — Quality & Hardening** work and bug fixes, on top of 1.0.0
 - **Accessibility (6.1):** `aria-label`s on the table/card action icon buttons, a
   skip-to-content link, and `header` / `main` landmarks for keyboard and
   screen-reader navigation.
-- **UI test foundation (6.2):** React Testing Library + jsdom component tests for
+- **UI test coverage (6.2):** React Testing Library + jsdom component tests for
   the loan/investment tables, the add/edit forms, and the DataManager import
-  preview/undo flow, running alongside the math suite in Vitest (the 100% line+
-  branch coverage gate stays scoped to the math core).
+  preview/undo flow, plus a Playwright end-to-end smoke test that drives the full
+  add-positions → optimize → view-as-scenario path in a real browser (run as a CI
+  job). The component suite runs alongside the math suite in Vitest; the 100%
+  line+branch coverage gate stays scoped to the math core.
 - **DataManager safety (6.3):** a pre-merge "what changed" preview listing which
   loans, investments, and scenarios an import will _add_ vs. _overwrite_, plus a
   soft-undo that restores the exact pre-merge data. (#107)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,13 +86,9 @@ Declared once, up front, so future feature debates have a reference point. Every
 
 ---
 
-### Phase 6 — Quality & Hardening — _target v1.0.x (patch releases, parallelizable)_
+### Phase 6 — Quality & Hardening — _v1.0.x_ — ✅ Complete
 
-Pay down the UI/test/perf/correctness debt deferred through 1.0. Items are independent and slot in anywhere alongside the feature phases, but are grouped here so the phase has a defined "done."
-
-| #   | Work item                                                                                                                                                                          | Notes / acceptance                                                                                                                                                                                                     |
-| --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 6.2 | **UI test coverage**: component tests (React Testing Library + jsdom) for forms / tables / DataManager; a Playwright smoke test (add positions → run optimizer → view as scenario) | Component tests shipped — see the [CHANGELOG](./CHANGELOG.md). The Playwright smoke test is the one piece left, deferred only because the sandbox can’t reach `cdn.playwright.dev` to fetch a browser; it lands in CI. |
+Paid down the UI/test/perf/correctness debt deferred through 1.0: accessibility, UI test coverage (RTL + jsdom component tests _and_ a Playwright end-to-end smoke test), a CI performance budget, discoverability/SEO, and repo hygiene. Per-item detail lives in the [CHANGELOG](./CHANGELOG.md).
 
 ---
 

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+
+// End-to-end smoke test for PathWise's critical path (roadmap 6.2): add
+// positions → run the "next dollar" optimizer → turn the top plan into a chart
+// scenario. The math core (Vitest, 100% gate) and individual components (RTL +
+// jsdom) are tested elsewhere; this guards the wiring between them in a real
+// browser — the one thing unit tests can't see.
+//
+// Form fields are targeted by ARIA role/name rather than getByLabel: MUI renders
+// the required marker into the <label> ("Name *"), so the label text isn't a
+// clean match, but each control's computed accessible name is ("Name").
+
+const APP_URL = '/finance-calculator/';
+
+// The app persists nothing unless the user opts in, but clear our keys before
+// the bundle boots so a previous run (or a reused dev server) can't seed state.
+const startClean = async (page: Page) => {
+  await page.addInitScript(() => {
+    try {
+      localStorage.removeItem('pathwise:data');
+      localStorage.removeItem('pathwise:persistence-enabled');
+      localStorage.removeItem('pathwise:first-visit-acknowledged');
+    } catch {
+      // localStorage may be unavailable; the app defaults to empty regardless.
+    }
+  });
+};
+
+// MUI X renders a date input as a segmented group of month/day/year spinbuttons.
+// Fill each section explicitly — typing all the digits in one go can drop a
+// section, leaving an invalid (NaN) date.
+const setDate = async (
+  group: Locator,
+  month: string,
+  day: string,
+  year: string
+) => {
+  await group.getByRole('spinbutton', { name: 'Month' }).fill(month);
+  await group.getByRole('spinbutton', { name: 'Day' }).fill(day);
+  await group.getByRole('spinbutton', { name: 'Year' }).fill(year);
+};
+
+test('add positions, optimize, and view the top plan as a scenario', async ({
+  page,
+}) => {
+  await startClean(page);
+  await page.goto(APP_URL);
+
+  // --- Add a loan (the command bar's "Add Loan", not the onboarding CTA) ---
+  await page.getByRole('button', { name: 'Add Loan', exact: true }).click();
+  const loanDialog = page.getByRole('dialog');
+  await expect(
+    loanDialog.getByRole('heading', { name: 'Add new loan' })
+  ).toBeVisible();
+  await loanDialog
+    .getByRole('textbox', { name: 'Name', exact: true })
+    .fill('Test Mortgage');
+  await loanDialog
+    .getByRole('textbox', { name: 'Loan Provider' })
+    .fill('Test Bank');
+  await loanDialog.getByRole('textbox', { name: 'Principal' }).fill('300000');
+  await loanDialog
+    .getByRole('textbox', { name: 'Current Amount' })
+    .fill('280000');
+  await loanDialog.getByRole('textbox', { name: 'Interest Rate' }).fill('5');
+  // End Date defaults to today (== Start Date), which is invalid; push it out so
+  // the monthly payment computes and the form becomes submittable.
+  await setDate(
+    loanDialog.getByRole('group', { name: 'End Date' }),
+    '12',
+    '01',
+    '2054'
+  );
+  const addLoan = loanDialog.getByRole('button', { name: 'Add loan' });
+  await expect(addLoan).toBeEnabled();
+  await addLoan.click();
+  await expect(loanDialog).toBeHidden();
+
+  // --- Add an investment (scope the submit to the dialog: the command bar has a
+  // same-named "Add Investment" button) ---
+  await page
+    .getByRole('button', { name: 'Add Investment', exact: true })
+    .click();
+  const invDialog = page.getByRole('dialog');
+  await expect(
+    invDialog.getByRole('heading', { name: 'Add Investment' })
+  ).toBeVisible();
+  await invDialog
+    .getByRole('textbox', { name: 'Investment Name' })
+    .fill('Test Index Fund');
+  await invDialog
+    .getByRole('textbox', { name: 'Provider', exact: true })
+    .fill('Test Brokerage');
+  await invDialog
+    .getByRole('textbox', { name: 'Starting Balance' })
+    .fill('10000');
+  await invDialog
+    .getByRole('textbox', { name: 'Average Return Rate' })
+    .fill('7');
+  const addInv = invDialog.getByRole('button', {
+    name: 'Add Investment',
+    exact: true,
+  });
+  await expect(addInv).toBeEnabled();
+  await addInv.click();
+  await expect(invDialog).toBeHidden();
+
+  // --- Run the optimizer: it's reactive (a Web Worker), so entering an amount
+  // is the trigger — there's no submit button. ---
+  await page
+    .getByText('Where should my next dollar go?')
+    .scrollIntoViewIfNeeded();
+  await page.getByRole('textbox', { name: 'Extra per month' }).fill('500');
+  await expect(
+    page.getByRole('table', { name: 'Ranked allocation plans' })
+  ).toBeVisible();
+  const viewTopPlan = page
+    .getByRole('button', { name: 'View as scenario' })
+    .first();
+  await expect(viewTopPlan).toBeVisible();
+
+  // --- View the top plan as a scenario: a success snackbar confirms it, and the
+  // impact summary ("… vs. baseline") proves it overlaid on the forecast. ---
+  await viewTopPlan.click();
+  await expect(
+    page.getByText(/now overlaid on the forecast chart above/)
+  ).toBeVisible();
+  await expect(page.getByText(/vs\. baseline/)).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.56.1",
         "@stryker-mutator/core": "^9.6.1",
         "@stryker-mutator/vitest-runner": "^9.6.1",
         "@testing-library/jest-dom": "^6.9.1",
@@ -2063,6 +2064,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -6208,6 +6225,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "check:format": "prettier --check .",
     "check:size": "node scripts/check-bundle-size.mjs",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
@@ -40,6 +41,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.56.1",
     "@stryker-mutator/core": "^9.6.1",
     "@stryker-mutator/vitest-runner": "^9.6.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from '@playwright/test';
+
+// End-to-end smoke-test config (roadmap 6.2). The Chromium binary is provisioned
+// out of band via PLAYWRIGHT_BROWSERS_PATH (the sandbox and CI both point at a
+// pre-installed browser), so `playwright test` never needs to reach
+// cdn.playwright.dev. Playwright boots the Vite dev server itself (see
+// `webServer`) and tears it down when the run ends.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      // Use the bundled Chromium directly (no `channel`) so the provisioned
+      // browser is used rather than a system Chrome install.
+      use: { browserName: 'chromium', viewport: { width: 1280, height: 900 } },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173/finance-calculator/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,14 @@ export default defineConfig({
     // Keep the default ignores and also skip generated dirs — notably the
     // Stryker sandbox, whose copied *.test.ts files would otherwise be
     // discovered and double-counted during a local mutation run.
-    exclude: [...configDefaults.exclude, '**/.stryker-tmp/**', 'coverage/**'],
+    exclude: [
+      ...configDefaults.exclude,
+      '**/.stryker-tmp/**',
+      'coverage/**',
+      // Playwright owns the e2e specs (it imports its own `test`); keep Vitest
+      // from discovering them via the default `*.spec.ts` glob.
+      'e2e/**',
+    ],
     coverage: {
       // Math Correctness Charter §4 enforcement: the math core is held to a
       // hard 100% line+branch gate (UI gets pragmatic targets in Phase 6). The


### PR DESCRIPTION
## Phase 6.2 — Playwright e2e smoke test (the last Phase 6 item)

Completes the end-to-end half of roadmap **6.2** (the component-test half merged in #122). This drives the app's critical path in a **real browser**: add a loan + investment → run the "next dollar" optimizer → view the top plan as a forecast scenario. It guards the cross-layer wiring — React + MUI + the Web Worker optimizer + the scenario overlay — that the Vitest math suite and the RTL/jsdom component tests can't see.

### What's here
- **`e2e/smoke.spec.ts`** — the full flow. Uses ARIA role/name locators (MUI folds the required `*` into the `<label>`, so `getByLabel` isn't a clean match) and per-section `fill()` for the MUI X segmented date field (typing all eight digits at once dropped a section → invalid date).
- **`playwright.config.ts`** — a single Chromium project; Playwright boots the Vite dev server itself (`webServer`) and tears it down after. `forbidOnly` + 2 retries under CI.
- **CI (`ci.yml`)** — a new parallel **`e2e`** job: `npx playwright install --with-deps chromium` (CI has open egress), then `npm run test:e2e`, uploading the Playwright HTML report on failure.
- **`vite.config.ts`** — excludes `e2e/**` from Vitest so its default `*.spec.ts` glob doesn't grab the Playwright specs.
- **`package.json`** — `test:e2e` script + `@playwright/test` devDependency.

### On the earlier "deferred" note
The previous PR documented the smoke test as deferred because `cdn.playwright.dev` is blocked here. That block is only the browser **download** — a compatible Chromium is already provisioned at `PLAYWRIGHT_BROWSERS_PATH`, so I ran and iterated on this **locally**: **3× green, ~4.8s each**. CI installs its own Chromium and runs the same spec.

### Verification (local)
- `npm run test:e2e` — passing (3× via `--repeat-each=3`)
- `npm run test:coverage` — 477 tests, `src/helpers/**` 100% line+branch (the e2e exclude doesn't disturb the unit suite)
- `npm run build`, `check:lint`, `check:format` — all green
- Confirmed Vitest does **not** discover the e2e spec

### Docs
- **ROADMAP**: Phase 6 marked **✅ Complete** (the lone remaining row removed; detail lives in the CHANGELOG).
- **CHANGELOG**: the 6.2 entry now covers both the component tests and this e2e smoke test.

With this, **Phase 6 — Quality & Hardening is fully complete.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJxkQkxeHLJcp8NMg5wiqv

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJxkQkxeHLJcp8NMg5wiqv)_