### PR TITLE
Phase 7: Whole Net Worth — cash, property & custom assets (v1.1)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,13 +24,15 @@ src/
 ├── Footer.tsx           # App footer
 ├── models/              # TypeScript interfaces and types
 │   ├── loan-model.ts
-│   └── investment-model.ts
+│   ├── investment-model.ts
+│   └── asset-model.ts           # Asset interface + AssetType enum (Cash, Property, CustomAsset, CustomLiability)
 ├── helpers/             # Pure business logic and calculations (the math core)
 │   ├── loan-helpers.ts
 │   ├── investment-helpers.ts
 │   ├── forecast-helpers.ts
+│   ├── asset-helpers.ts         # forecastAsset, isAssetLiability, assetNetWorthSign, getAssetValueToday
 │   ├── storage-helpers.ts       # On-device persistence I/O (save/load/clear, issue #20)
-│   ├── migrate-helpers.ts       # D8 versioned schema-migration ladder
+│   ├── migrate-helpers.ts       # D8 versioned schema-migration ladder (current: v4)
 │   ├── *.test.ts             # Co-located unit tests
 │   ├── math-reference.test.ts    # Charter layer 1: oracle tests (Excel/hand-derived)
 │   ├── forecast-consistency.test.ts # Charter layer 2: engine-vs-schedule
@@ -50,11 +52,14 @@ src/
 │   ├── add-edit-loan.tsx
 │   ├── amortization-popout.tsx
 │   └── pit-popout.tsx
-└── investment/          # Investment-related components
-    ├── investment-table.tsx
-    ├── add-edit-investment.tsx
-    ├── growth-schedule-popout.tsx
-    └── pit-popout.tsx
+├── investment/          # Investment-related components
+│   ├── investment-table.tsx
+│   ├── add-edit-investment.tsx
+│   ├── growth-schedule-popout.tsx
+│   └── pit-popout.tsx
+└── asset/               # Asset-related components (Phase 7)
+    ├── asset-table.tsx
+    └── add-edit-asset.tsx
 ```
 
 ## Code Style and Conventions
@@ -139,12 +144,23 @@ npm run deploy     # Deploy to GitHub Pages
 - Support for regular contributions/withdrawals
 - Date-based calculations for accurate projections
 
+### Asset Calculations (Phase 7)
+
+- The `Asset` type covers cash accounts (HYSA/CD/checking), property, and custom assets or liabilities
+- `Balance` is the asset's current value (always positive); `GrowthRate` is an annual % that may be negative (depreciation)
+- `forecastAsset` in `asset-helpers.ts` produces a monthly-axis compound-growth series anchored to today's balance
+- `forecastHomeEquity` in `forecast-helpers.ts` computes property value minus its linked mortgage balance (pointwise), using `LinkedLoanId` to pair an asset to a loan
+- Ordinary assets (`Cash`, `Property`, `CustomAsset`) add to net worth; `CustomLiability` subtracts
+- Assets are included in the `forecastNetWorth` roll-up and appear as individual lines (kind `'asset'`) in the forecast chart
+
 ## Important Notes
 
 - The app is deployed to GitHub Pages with base path `/finance-calculator/`
 - No backend or database; all data is managed in client-side state
-- Models are input-only: derived data (amortization schedules, growth projections, forecasts) is computed on demand by helpers and never stored on models or serialized into exports
+- Models are input-only: derived data (amortization schedules, growth projections, asset forecasts) is computed on demand by helpers and never stored on models or serialized into exports
 - **Core/UI boundary (decision D7)**: `src/helpers/**` and `src/models/**` are a pure, framework-free layer (TypeScript + dayjs only). An ESLint rule forbids them from importing React, MUI, emotion, or any UI component (`*.tsx`). UI depends on the core, never the reverse — put React hooks in `src/hooks/`, not `src/helpers/`.
+- The `Asset` model (`src/models/asset-model.ts`) follows the same input-only convention; the `AssetType` enum values are `Cash`, `Property`, `CustomAsset`, and `CustomLiability`
+- Export/persistence schema is at **v4** (`CURRENT_SCHEMA_VERSION = 4`); importing a v3 file adds an empty `assets` list via the migration ladder in `migrate-helpers.ts`
 - Future plans include file upload/export for data persistence
 - Test data can be toggled in the UI for development purposes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,58 +49,24 @@ jobs:
   e2e:
     name: E2E smoke test
     runs-on: ubuntu-latest
-    # Bound the whole job. A stalled Chromium download once hung the install step
-    # for the full 6-hour default before the runner killed it, leaving the check
-    # "cancelled" and blocking PRs. 20 min is ample for install + one smoke spec,
-    # so a silent CDN stall now fails fast instead of hanging for hours.
-    timeout-minutes: 20
+    # Run inside Playwright's official image, which ships the browsers (and their
+    # OS deps) pre-installed at /ms-playwright. This sidesteps `playwright
+    # install` entirely — that step hung deterministically on this runner,
+    # downloading Chromium to 100% and then stalling in extraction until killed.
+    # The tag MUST track the @playwright/test version in package.json (1.56.1);
+    # bump both together so the bundled browser matches the installed client.
+    container:
+      image: mcr.microsoft.com/playwright:v1.56.1-noble
+    # Safety net so a hung dev server / browser can't sit at the 6-hour default.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          cache: 'npm'
-
       - name: Install dependencies
+        # The image provides Node + npm; no setup-node (it would override the
+        # image's toolchain) and no browser download (already present).
         run: npm ci
-
-      - name: Resolve Playwright version
-        id: playwright
-        # Key the browser cache on the exact Playwright version so a dependency
-        # bump re-provisions the matching browser instead of reusing a stale one.
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browser
-        id: playwright-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
-
-      - name: Install Playwright system dependencies
-        # The apt-installed libraries/fonts live outside the cached browser dir,
-        # so install them every run (fast, and required for Chromium to launch).
-        run: npx playwright install-deps chromium
-
-      - name: Install Playwright browser
-        # Only download Chromium on a cache miss. Wrap each attempt in a hard
-        # `timeout` and retry: a silent CDN stall after the download (no progress,
-        # no error) is exactly what hung this job for 6 hours, so abort a stalled
-        # attempt and retry rather than waiting indefinitely.
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          for attempt in 1 2 3; do
-            echo "Playwright browser install attempt $attempt of 3"
-            if timeout 300 npx playwright install chromium; then
-              exit 0
-            fi
-            echo "Attempt $attempt stalled or failed; retrying..." >&2
-          done
-          echo "Playwright browser install failed after 3 attempts" >&2
-          exit 1
 
       - name: E2E smoke test (roadmap 6.2)
         # Playwright boots the Vite dev server itself (see playwright.config.ts)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,25 @@
 name: CI
 
+# Skip CI when a change touches ONLY docs/meta files that can't affect the
+# lint/format/test/build gates. A mixed change (any code file alongside docs)
+# still runs the full pipeline, because paths-ignore only skips when EVERY
+# changed file matches. Keep this list to files that genuinely have no build/
+# test impact — e.g. never ignore .prettierignore, .npmrc, or the workflows.
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,11 @@ jobs:
   e2e:
     name: E2E smoke test
     runs-on: ubuntu-latest
+    # Bound the whole job. A stalled Chromium download once hung the install step
+    # for the full 6-hour default before the runner killed it, leaving the check
+    # "cancelled" and blocking PRs. 20 min is ample for install + one smoke spec,
+    # so a silent CDN stall now fails fast instead of hanging for hours.
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -62,10 +67,40 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Resolve Playwright version
+        id: playwright
+        # Key the browser cache on the exact Playwright version so a dependency
+        # bump re-provisions the matching browser instead of reusing a stale one.
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browser
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+
+      - name: Install Playwright system dependencies
+        # The apt-installed libraries/fonts live outside the cached browser dir,
+        # so install them every run (fast, and required for Chromium to launch).
+        run: npx playwright install-deps chromium
+
       - name: Install Playwright browser
-        # CI has open egress, so the Chromium download (blocked in the dev
-        # sandbox) works here. Only Chromium is needed for the smoke test.
-        run: npx playwright install --with-deps chromium
+        # Only download Chromium on a cache miss. Wrap each attempt in a hard
+        # `timeout` and retry: a silent CDN stall after the download (no progress,
+        # no error) is exactly what hung this job for 6 hours, so abort a stalled
+        # attempt and retry rather than waiting indefinitely.
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: |
+          for attempt in 1 2 3; do
+            echo "Playwright browser install attempt $attempt of 3"
+            if timeout 300 npx playwright install chromium; then
+              exit 0
+            fi
+            echo "Attempt $attempt stalled or failed; retrying..." >&2
+          done
+          echo "Playwright browser install failed after 3 attempts" >&2
+          exit 1
 
       - name: E2E smoke test (roadmap 6.2)
         # Playwright boots the Vite dev server itself (see playwright.config.ts)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,16 @@
 name: Deploy to GitHub Pages
 
+# A docs-only change to main doesn't alter the built app, so skip the redeploy.
+# Same rule as CI: paths-ignore only skips when every changed file matches.
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/dependabot.yml'
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ an `AssetType` discriminator covering all three Phase 7 items.
   the dashboard summary cards and milestones, the optimizer-adjacent dashboard,
   JSON import/export, and on-device persistence — with an Assets table and
   add/edit dialog in the UI.
+- **Two consolidated entry points** in the command bar (and onboarding): **Add
+  Asset** (Investment · Cash · Property · Custom asset) and **Add Liability**
+  (Loan · Custom liability), each a type menu that opens the matching form.
 - Export **schema v4** (the next D8 migration rung): a v3 file gains an empty
   `assets` list on import; older files keep migrating forward.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ an `AssetType` discriminator covering all three Phase 7 items.
   add/edit dialog in the UI.
 - **Two consolidated entry points** in the command bar (and onboarding): **Add
   Asset** (Investment · Cash · Property · Custom asset) and **Add Liability**
-  (Loan · Custom liability), each a type menu that opens the matching form.
+  (Loan · Custom liability), each a type menu that opens the matching form. The
+  positions display mirrors this: a **Liabilities** section groups loans and
+  custom liabilities together (loans keep their amortization/payoff/PIT table),
+  alongside the Investments and Assets sections.
 - Export **schema v4** (the next D8 migration rung): a v3 file gains an empty
   `assets` list on import; older files keep migrating forward.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ Detailed acceptance criteria for each phase live in the merged PRs and the
 
 ## [Unreleased]
 
+## [1.1.0] — Phase 7: Whole Net Worth
+
+Made the net-worth line _true_ by letting PathWise hold everything a person owns,
+via one simple **Asset** type (a balance plus an annual growth/decline rate) with
+an `AssetType` discriminator covering all three Phase 7 items.
+
+### Added
+
+- **Cash accounts (7.1):** HYSA / CD / checking — a balance plus an APY, the
+  simplest new asset type and the biggest completeness win.
+- **Property + mortgage pairing (7.2):** a home value with an appreciation rate,
+  optionally linked to its mortgage by `LinkedLoanId`, so the app derives a
+  **home-equity** figure (property value − loan balance) and net worth is honest
+  for homeowners.
+- **Custom asset / liability (7.3):** a catch-all with a simple growth/decline
+  rate (a depreciating car, a private loan, collectibles) — the escape hatch so
+  no net worth is blocked on a missing type. Custom liabilities subtract from net
+  worth; everything else adds.
+- Assets flow through the whole stack: the forecast engine (`forecastAsset`,
+  `forecastHomeEquity`), the net-worth roll-up, the chart (one line per asset),
+  the dashboard summary cards and milestones, the optimizer-adjacent dashboard,
+  JSON import/export, and on-device persistence — with an Assets table and
+  add/edit dialog in the UI.
+- Export **schema v4** (the next D8 migration rung): a v3 file gains an empty
+  `assets` list on import; older files keep migrating forward.
+
+Per the Math Correctness Charter, the new asset math ships with reference,
+property, and edge-case tests and keeps `src/helpers/**` at 100% line+branch
+coverage.
+
+## [1.0.x] — Phase 6: Quality & Hardening
+
 Post-1.0 **Phase 6 — Quality & Hardening** work and bug fixes, on top of 1.0.0.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # PathWise
 
-**See all your loans and investments in one place — and decide where your next dollar should go.**
+**See all your loans, investments, and assets in one place — and decide where your next dollar should go.**
 
 [**🌐 Live site**](https://bberardi.github.io/finance-calculator/) · [**🗺️ Roadmap**](./ROADMAP.md) · [**🐛 Issues**](https://github.com/bberardi/finance-calculator/issues)
 
@@ -22,7 +22,7 @@
 
 Free financial calculators handle **one** loan _or_ **one** investment at a time. Real decisions don't work that way — _"should my extra $300/month go toward the mortgage, the car loan, or the brokerage account?"_ requires seeing every position together and comparing what-ifs across all of them.
 
-**PathWise** forecasts your net worth from multiple loans and investments at once, so you can answer that question without exporting everything into a spreadsheet and doing the math by hand.
+**PathWise** forecasts your net worth from multiple loans, investments, and assets at once, so you can answer that question without exporting everything into a spreadsheet and doing the math by hand.
 
 Everything runs in your browser. There's **no backend, no account, and no tracking** — your numbers never leave your device.
 
@@ -31,13 +31,14 @@ Everything runs in your browser. There's **no backend, no account, and no tracki
 - 📊 **Multiple positions at a glance** — manage any number of loans and investments side by side, not one calculator at a time.
 - 🏦 **Loan modeling** — auto-calculated monthly payment, full amortization schedule, and a point-in-time view of any loan on any date.
 - 📈 **Investment modeling** — configurable compounding frequencies, recurring contributions, and yearly step-ups (flat or percentage), with a projected-growth schedule.
-- 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, and overall net worth onto a single shared timeline.
-- 📉 **Interactive forecast chart** — a line per position plus an overall net-worth line, with a show/hide legend, 5Y/10Y/30Y/Full range control, and an accessible "view as table" fallback.
+- 🏠 **Whole net worth** — cash accounts (HYSA/CD/checking), property (with home-equity from a linked mortgage), and custom assets/liabilities feed the net-worth roll-up alongside loans and investments. `CustomLiability` entries subtract from net worth; all others add.
+- 💰 **Net worth forecasting** — a date-indexed engine projects loans, investments, assets, and overall net worth onto a single shared timeline.
+- 📉 **Interactive forecast chart** — a line per position (including one per asset) plus an overall net-worth line, with a show/hide legend, 5Y/10Y/30Y/Full range control, and an accessible "view as table" fallback.
 - 🧮 **Net worth dashboard** — at-a-glance total assets, debt, net worth, and monthly commitments, plus milestone callouts (debt-free date, net worth at +5/+10/+30 years).
 - 🔮 **What-if scenarios** — model extra monthly payments/contributions, overlay them on the chart as dotted lines, and see the impact (net worth at horizon, interest saved, debt-free date moved up).
 - 🎯 **"Next dollar" optimizer** — tell PathWise how much extra you have each month and it ranks where that money does the most good: all toward one position **and** splits across several, scored by long-term net worth impact and interest saved. Pit your own intuition against it with a custom split builder, and send any plan to the chart with one click. The search runs in a Web Worker so the interaction stays smooth.
 - 💾 **On-device persistence** — opt in to "Save on this device" and your data survives a refresh, stored only in your browser's local storage; turning it off clears it.
-- 🔁 **Import / export** — back up and restore your data as JSON, with ID-based smart merge and validation on import.
+- 🔁 **Import / export** — back up and restore your data as JSON (schema v4), with ID-based smart merge and validation on import; v3 files gain an empty asset list on upgrade.
 - 🌗 **Light & dark mode** — a full Material UI theme with a persisted color-mode toggle.
 - 📱 **Responsive** — data tables on desktop, cards on mobile.
 - ✅ **Trustworthy math** — the calculation core is a pure, fully unit-tested TypeScript layer (see the [Math Correctness Charter](./ROADMAP.md#4-math-correctness-charter-non-negotiable)).
@@ -95,8 +96,8 @@ Every change should land with `npm test`, `npm run build`, `npm run check:lint`,
 
 ```
 src/
-├── models/      # Input-only data types (Loan, Investment, forecast)
-├── helpers/     # Pure business logic & math (loans, investments, forecast engine)
+├── models/      # Input-only data types (Loan, Investment, Asset, forecast)
+├── helpers/     # Pure business logic & math (loans, investments, assets, forecast engine)
 ├── state/       # Finance data context, reducer, and sample data
 ├── theme/       # MUI theme and color-mode toggle
 ├── components/  # Shared UI (dialogs, empty states, row actions)
@@ -104,6 +105,7 @@ src/
 ├── optimizer/   # "Next dollar" optimizer panel, custom split builder, Web Worker
 ├── loan/        # Loan table, add/edit form, amortization & PIT popouts
 ├── investment/  # Investment table, add/edit form, growth & PIT popouts
+├── asset/       # Asset table, add/edit form (cash, property, custom assets/liabilities)
 └── data-manager/# JSON import/export
 ```
 
@@ -128,7 +130,11 @@ PathWise reached its headline goal at **v1.0** — a **"next dollar" optimizer**
 4. **Scenario forecasting** — overlay what-if extra payments/contributions on the charts _(issue #24)_ ✅
 5. **"Next dollar" optimizer** — given $X extra per month, rank allocations (all-in-one and splits) by long-term net worth impact ✅
 
-Post-1.0 work (balance check-ins, whole-net-worth modeling, Monte Carlo, and more) is sequenced in the full [**ROADMAP.md**](./ROADMAP.md), alongside phases, technical decisions, and the future horizon.
+**v1.1** extends net worth to the whole balance sheet:
+
+6. **Whole net worth (Phase 7)** — cash accounts (HYSA/CD/checking with APY), property (appreciation rate + home-equity from a linked mortgage), and custom assets/liabilities fill out the net-worth picture; export schema bumped to v4 ✅
+
+Post-1.1 work (balance check-ins, Monte Carlo, and more) is sequenced in the full [**ROADMAP.md**](./ROADMAP.md), alongside phases, technical decisions, and the future horizon.
 
 ## Contributing
 
@@ -141,14 +147,14 @@ Contributions are welcome! A few working agreements from the project conventions
 
 ## Glossary
 
-| Term                      | Meaning                                                                                                          |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| **Amortization schedule** | The month-by-month breakdown of a loan's payments into principal and interest over its term.                     |
-| **Compounding frequency** | How often investment interest is applied (e.g., monthly, quarterly, annually).                                   |
-| **Step-up**               | A scheduled yearly increase to an investment's recurring contribution, as a flat amount or %.                    |
-| **Point-in-time (PIT)**   | The state of a loan or investment on a specific date.                                                            |
-| **Forecast**              | A date-indexed projection of a position's value (or balance) over time.                                          |
-| **Net worth**             | Total investment value minus total outstanding loan balances at a point in time.                                 |
-| **Scenario**              | A named what-if: extra monthly amounts applied on top of existing payments/contributions, overlaid on the chart. |
-| **Allocation plan**       | A way to divide $X extra per month across positions — all to one (single-target) or split across several.        |
-| **Next-dollar optimizer** | The engine that scores and ranks allocation plans by long-term net worth impact and interest saved.              |
+| Term                      | Meaning                                                                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **Amortization schedule** | The month-by-month breakdown of a loan's payments into principal and interest over its term.                                   |
+| **Compounding frequency** | How often investment interest is applied (e.g., monthly, quarterly, annually).                                                 |
+| **Step-up**               | A scheduled yearly increase to an investment's recurring contribution, as a flat amount or %.                                  |
+| **Point-in-time (PIT)**   | The state of a loan or investment on a specific date.                                                                          |
+| **Forecast**              | A date-indexed projection of a position's value (or balance) over time.                                                        |
+| **Net worth**             | Total investment and asset value minus total outstanding loan balances (and any custom liability balances) at a point in time. |
+| **Scenario**              | A named what-if: extra monthly amounts applied on top of existing payments/contributions, overlaid on the chart.               |
+| **Allocation plan**       | A way to divide $X extra per month across positions — all to one (single-target) or split across several.                      |
+| **Next-dollar optimizer** | The engine that scores and ranks allocation plans by long-term net worth impact and interest saved.                            |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # PathWise Roadmap
 
-> **BLUF**: PathWise forecasts net worth from multiple loans and investments to answer one question most calculators can't: _"Where should my extra money go?"_ As of **v1.0.0** that question is answered — this roadmap now sequences what comes after.
+> **BLUF**: PathWise forecasts net worth from all your loans, investments, and assets to answer one question most calculators can't: _"Where should my extra money go?"_ That question was answered at **v1.0.0** — this roadmap now sequences what comes after.
 
 ---
 
@@ -8,21 +8,15 @@
 
 **The gap PathWise fills**: Free calculators handle one loan _or_ one investment at a time. Real decisions ("put $300/mo toward the mortgage, the car loan, or the brokerage account?") require seeing all positions together and comparing what-ifs across them.
 
-**The destination — reached at v1.0.0** (in priority order):
+**The destination — reached at v1.0.0, extended through v1.1**: PathWise already shows all of someone's loans, investments, and assets in one place, persists that data on-device, visualizes every position and overall net worth over time, overlays what-if scenarios on those projections, and — the founding question — ranks where an extra $X/month does the most good. The per-release record of how it got here is in the [CHANGELOG](./CHANGELOG.md).
 
-1. See all loans and investments in one place — _done_
-2. Persist data so it survives a refresh — _done (Phase 1, #20)_
-3. Visualize every position and overall net worth over time — _done (Phase 2, #18)_
-4. Overlay what-if scenarios on those projections — _done (Phase 4, #24)_
-5. **Answer the money question directly**: given $X extra per month, rank allocations — single targets _and_ splits across loans/investments — by long-term net-worth impact — _done (Phase 5, v1.0.0 — the original reason this app exists)_
-
-Everything past this point (Phases 6–11) is post-1.0 expansion, sequenced but revisitable.
+Everything past this point (Phases 8–11) is forward-looking expansion, sequenced but revisitable.
 
 ---
 
-## 2. Current State (June 2026, v1.0.0 — Phases 0–5 complete)
+## 2. Current State (v1.1 — Phases 0–7 shipped)
 
-PathWise is feature-complete against its founding vision (v1.0.0). The shipped, per-release history now lives in [CHANGELOG.md](./CHANGELOG.md), and the current feature list in [README.md](./README.md); what follows is the forward-looking plan.
+PathWise is feature-complete against its founding vision (v1.0.0) and now holds a whole-balance-sheet net worth (v1.1, Phase 7). The shipped, per-release history lives in [CHANGELOG.md](./CHANGELOG.md), and the current feature list in [README.md](./README.md); what follows is the forward-looking plan.
 
 ---
 
@@ -67,40 +61,16 @@ Each layer catches a class of error the others miss; all five are required for t
 
 ## 5. Phased Roadmap
 
-### Phases 0–5 — ✅ COMPLETE (shipped, v0.7.0 → v1.0.0)
-
-The founding vision is fully shipped (v0.7.0 → v1.0.0). The per-release record now lives in [CHANGELOG.md](./CHANGELOG.md); detailed acceptance criteria live in the merged PRs.
-
-Open math-quality follow-ups surfaced by this work are folded into **Phase 6** (items 6.9–6.10).
-
----
+Everything shipped through **v1.1 (Phase 7)** now lives in the [CHANGELOG](./CHANGELOG.md) — this section tracks only what is still planned. Phases keep their original numbers for continuity with the shipped history.
 
 ### Non-goals (identity guardrails for all phases below)
 
-Declared once, up front, so future feature debates have a reference point. Every Phase 6–11 item passes three filters: it serves the core question (forecasting net worth and deciding where money goes), it works with no backend (client-side, data stays on device), and it doesn't turn PathWise into a budgeting app.
+Declared once, up front, so future feature debates have a reference point. Every Phase 8–11 item passes three filters: it serves the core question (forecasting net worth and deciding where money goes), it works with no backend (client-side, data stays on device), and it doesn't turn PathWise into a budgeting app.
 
 - **No transaction/expense tracking, categorization, or budgets** — the BLUF says not a budgeting app; this is the line.
 - **No bank account linking** (Plaid etc.) — requires a backend and credentials; would destroy the privacy story.
 - **No real-time market data** — PathWise models average rates, not tickers; keeps results deterministic and avoids API keys. (The exploratory holdings/property context item in Phase 9 stays within this line: any news feed is user-supplied and opt-in, stored on device, never hosted by PathWise.)
 - **No tax advice** — computing someone's tax return is out of scope.
-
----
-
-### Phase 6 — Quality & Hardening — _v1.0.x_ — ✅ Complete
-
-Paid down the UI/test/perf/correctness debt deferred through 1.0: accessibility, UI test coverage (RTL + jsdom component tests _and_ a Playwright end-to-end smoke test), a CI performance budget, discoverability/SEO, and repo hygiene. Per-item detail lives in the [CHANGELOG](./CHANGELOG.md).
-
----
-
-### Phase 7 — Whole Net Worth — _v1.1_ — ✅ Complete
-
-Made the net-worth line _true_ by holding everything a person owns. Depends only on 1.0; leans on Phase 6.4 (table scale) and bumped the schema to v4 via the D8 ladder. Delivered through one simple **Asset** model (a balance + an annual growth/decline rate) with an `AssetType` discriminator; ordinary assets add to net worth, custom liabilities subtract. The asset math (`forecastAsset`, `forecastHomeEquity`) is charter-verified and the helpers stay at 100% coverage.
-
-| #   | Work item                            | Notes / acceptance                                                                                                                       |
-| --- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| 7.1 | **Cash accounts (HYSA/CD/checking)** | ✅ Simple asset (balance + APY); the biggest completeness win — net worth now holds cash. `AssetType.Cash`.                              |
-| 7.2 | **Property + mortgage pairing**      | ✅ Home value + appreciation rate, linked to its mortgage by `LinkedLoanId` → a **home-equity** figure. Net worth honest for homeowners. |
-| 7.3 | **Custom asset / liability**         | ✅ Catch-all with a simple growth/decline rate (car, private loan, collectibles). Custom liabilities subtract from net worth.            |
 
 ---
 
@@ -120,14 +90,14 @@ Sharpen the optimizer with the inputs that most change its rankings, and let use
 
 ### Phase 9 — Honest Uncertainty — _target v1.3_
 
-Stop overstating certainty on long horizons, and model the growth/decline of what Phase 7 added. Depends on Phase 7 (property) for 9.3–9.4.
+Stop overstating certainty on long horizons, and model the growth/decline of the assets Phase 7 added (shipped v1.1); 9.3–9.4 build on that property model.
 
-| #   | Work item                                                                  | Notes / acceptance                                                                                                                                                  |
-| --- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 9.1 | **Monte Carlo mode**                                                       | Replace the single average-return line with volatility-driven percentile bands (fan chart). Runs in a Web Worker; seeded/reproducible. Biggest credibility upgrade. |
-| 9.2 | **Inflation toggle**                                                       | Real vs. nominal view of every chart and milestone. Engine post-processing.                                                                                         |
-| 9.3 | **Asset appreciation & enhancement** _(needs 7.2)_                         | Model an existing asset appreciating or being enhanced (add a pool/deck, renovation ROI); answers "is this improvement worth it?"                                   |
-| 9.4 | **Holdings & property context (news/research)** _(needs 7.2, exploratory)_ | User-supplied feed for investment-holding research **and area real-estate news**. Zero-backend: user pastes an RSS/news URL or their own API key, stored on device. |
+| #   | Work item                                                                      | Notes / acceptance                                                                                                                                                  |
+| --- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 9.1 | **Monte Carlo mode**                                                           | Replace the single average-return line with volatility-driven percentile bands (fan chart). Runs in a Web Worker; seeded/reproducible. Biggest credibility upgrade. |
+| 9.2 | **Inflation toggle**                                                           | Real vs. nominal view of every chart and milestone. Engine post-processing.                                                                                         |
+| 9.3 | **Asset appreciation & enhancement** _(builds on 7.2, shipped v1.1)_           | Model an existing asset appreciating or being enhanced (add a pool/deck, renovation ROI); answers "is this improvement worth it?"                                   |
+| 9.4 | **Holdings & property context (news/research)** _(builds on 7.2; exploratory)_ | User-supplied feed for investment-holding research **and area real-estate news**. Zero-backend: user pastes an RSS/news URL or their own API key, stored on device. |
 
 ---
 
@@ -159,23 +129,16 @@ Take PathWise off the single device without taking on a backend.
 
 ## 6. Sequencing at a Glance
 
+Phases 0–7 have shipped (v0.7.0 → v1.1); the per-release record is in the [CHANGELOG](./CHANGELOG.md). What remains:
+
 ```
-Phase 0  Foundations + UX overhaul        ✅ DONE   v0.7.0
-   ├── Phase 1  Persistence (#20)         ✅ DONE   v0.8.0
-   └── Phase 2  Charts (#18)              ✅ DONE   v0.9.0
-           └── Phase 3  Dashboard         ✅ DONE   v0.10.0
-                   └── Phase 4  Scenarios (#24)   ✅ DONE   v0.11.0
-                           └── Phase 5  Optimizer ✅ DONE   v1.0.0
-─────────────────────────────────────────────────────────── 1.0 ───
-Phase 6  Quality & Hardening              v1.0.x   (parallel, anytime)
-Phase 7  Whole Net Worth                  ✅ DONE   v1.1
 Phase 8  Better Answers                   v1.2
-Phase 9  Honest Uncertainty               v1.3     (needs Phase 7)
+Phase 9  Honest Uncertainty               v1.3   (builds on the Phase 7 property model)
 Phase 10 From Calculator to Plan          v1.4
 Phase 11 Beyond Personal                  v2.0
 ```
 
-Rationale for the order: completeness first (so the net-worth line is true), then answer quality, then statistical honesty, then planning, then distribution. Phase 6 runs in parallel as capacity allows.
+Rationale for the order: completeness (the true net-worth line) already shipped in Phase 7, so what's left is answer quality, then statistical honesty, then planning, then distribution.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,10 +34,10 @@ Decisions made up front so phases didn't relitigate them. All are now implemente
 - **D2 — State: React Context + `useReducer`.** ✅ Phase 0 (#50). Two collections + UI state in one reducer; no store library. Revisit (Zustand) only if state grows unwieldy.
 - **D3 — Forecast engine: one pure, date-indexed, scenario-aware module.** ✅ `src/helpers/forecast-helpers.ts` is the _only_ place projections are computed (`forecastLoan`/`forecastInvestment`/`forecastNetWorth`, anchored to today's balances); `loan-helpers`/`investment-helpers` remain the inner math on a common monthly axis.
 - **D4 — Persistence: `localStorage`, opt-in, inputs-only, versioned.** ✅ Phase 1 (#20). Explicit toggle, disabling clears storage, hydration reuses import validation and runs the D8 ladder.
-- **D5 — Versioned export schema.** ✅ v2 in Phase 0 (#41), v3 for scenarios in Phase 4. Import accepts older versions via the D8 ladder.
+- **D5 — Versioned export schema.** ✅ v2 in Phase 0 (#41), v3 for scenarios in Phase 4, v4 for assets in Phase 7. Import accepts older versions via the D8 ladder.
 - **D6 — Keep MUI; modernize deps.** ✅ Phase 0 (#54). No UI-library switch; stack modernized in one pass (MUI 6→9, x-date-pickers 7→9, React 18→19, Vite 5→8), which also unblocked x-charts v9.
 - **D7 — Core math is a boundary-enforced layer, not a separate package (yet).** ✅ ESLint forbids `src/helpers/**` and `src/models/**` from importing `react`/`react-dom`/`@mui/*` or any UI folder — purity is a build failure. Kept the engine worker-safe for the Phase 5 optimizer. _Packaging deferred_ until a **graduation trigger**: a genuine second consumer (CLI, second frontend, or publishing `@pathwise/engine`, Phase 11). The boundary makes the eventual `packages/core` extraction a file move, not a refactor.
-- **D8 — One versioned schema-migration ladder.** ✅ Seeded in Phase 1; first real step (v2→v3, scenarios) in Phase 4. JSON import and `localStorage` hydration both route through a single `schemaVersion`-keyed `migrate(data)` ladder, so every future bump adds exactly one tested migration step.
+- **D8 — One versioned schema-migration ladder.** ✅ Seeded in Phase 1; first real step (v2→v3, scenarios) in Phase 4, second (v3→v4, assets) in Phase 7. JSON import and `localStorage` hydration both route through a single `schemaVersion`-keyed `migrate(data)` ladder, so every future bump adds exactly one tested migration step.
 
 ---
 
@@ -92,15 +92,15 @@ Paid down the UI/test/perf/correctness debt deferred through 1.0: accessibility,
 
 ---
 
-### Phase 7 — Whole Net Worth — _target v1.1_
+### Phase 7 — Whole Net Worth — _v1.1_ — ✅ Complete
 
-Make the net-worth line _true_ by holding everything a person owns. Depends only on 1.0; leans on Phase 6.4 (table scale) and bumps the schema via the D8 ladder.
+Made the net-worth line _true_ by holding everything a person owns. Depends only on 1.0; leans on Phase 6.4 (table scale) and bumped the schema to v4 via the D8 ladder. Delivered through one simple **Asset** model (a balance + an annual growth/decline rate) with an `AssetType` discriminator; ordinary assets add to net worth, custom liabilities subtract. The asset math (`forecastAsset`, `forecastHomeEquity`) is charter-verified and the helpers stay at 100% coverage.
 
-| #   | Work item                            | Notes / acceptance                                                                                                                        |
-| --- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 7.1 | **Cash accounts (HYSA/CD/checking)** | Trivial model (balance + APY); big completeness win — most net worth includes cash the app can't currently hold. New simple asset type.   |
-| 7.2 | **Property + mortgage pairing**      | Home value + appreciation rate, linked to its mortgage → a **home-equity** series. Makes net worth honest for homeowners. Entity linking. |
-| 7.3 | **Custom asset / liability**         | Catch-all with a simple growth/decline rate (car, private loan, collectibles). Escape hatch so no net worth is blocked on a missing type. |
+| #   | Work item                            | Notes / acceptance                                                                                                                       |
+| --- | ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 7.1 | **Cash accounts (HYSA/CD/checking)** | ✅ Simple asset (balance + APY); the biggest completeness win — net worth now holds cash. `AssetType.Cash`.                              |
+| 7.2 | **Property + mortgage pairing**      | ✅ Home value + appreciation rate, linked to its mortgage by `LinkedLoanId` → a **home-equity** figure. Net worth honest for homeowners. |
+| 7.3 | **Custom asset / liability**         | ✅ Catch-all with a simple growth/decline rate (car, private loan, collectibles). Custom liabilities subtract from net worth.            |
 
 ---
 
@@ -168,7 +168,7 @@ Phase 0  Foundations + UX overhaul        ✅ DONE   v0.7.0
                            └── Phase 5  Optimizer ✅ DONE   v1.0.0
 ─────────────────────────────────────────────────────────── 1.0 ───
 Phase 6  Quality & Hardening              v1.0.x   (parallel, anytime)
-Phase 7  Whole Net Worth                  v1.1
+Phase 7  Whole Net Worth                  ✅ DONE   v1.1
 Phase 8  Better Answers                   v1.2
 Phase 9  Honest Uncertainty               v1.3     (needs Phase 7)
 Phase 10 From Calculator to Plan          v1.4

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -46,8 +46,11 @@ test('add positions, optimize, and view the top plan as a scenario', async ({
   await startClean(page);
   await page.goto(APP_URL);
 
-  // --- Add a loan (the command bar's "Add Loan", not the onboarding CTA) ---
-  await page.getByRole('button', { name: 'Add Loan', exact: true }).click();
+  // --- Add a loan via the "Add Liability" command-bar menu → "Loan" ---
+  await page
+    .getByRole('button', { name: 'Add Liability', exact: true })
+    .click();
+  await page.getByRole('menuitem', { name: 'Loan', exact: true }).click();
   const loanDialog = page.getByRole('dialog');
   await expect(
     loanDialog.getByRole('heading', { name: 'Add new loan' })
@@ -76,11 +79,11 @@ test('add positions, optimize, and view the top plan as a scenario', async ({
   await addLoan.click();
   await expect(loanDialog).toBeHidden();
 
-  // --- Add an investment (scope the submit to the dialog: the command bar has a
-  // same-named "Add Investment" button) ---
-  await page
-    .getByRole('button', { name: 'Add Investment', exact: true })
-    .click();
+  // --- Add an investment via the "Add Asset" command-bar menu → "Investment".
+  // Scope the submit to the dialog: its own submit button is also "Add
+  // Investment". ---
+  await page.getByRole('button', { name: 'Add Asset', exact: true }).click();
+  await page.getByRole('menuitem', { name: 'Investment', exact: true }).click();
   const invDialog = page.getByRole('dialog');
   await expect(
     invDialog.getByRole('heading', { name: 'Add Investment' })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,10 @@
 import { defineConfig } from '@playwright/test';
 
 // End-to-end smoke-test config (roadmap 6.2). The Chromium binary is provisioned
-// out of band via PLAYWRIGHT_BROWSERS_PATH (the sandbox and CI both point at a
-// pre-installed browser), so `playwright test` never needs to reach
-// cdn.playwright.dev. Playwright boots the Vite dev server itself (see
-// `webServer`) and tears it down when the run ends.
+// out of band — the dev sandbox via PLAYWRIGHT_BROWSERS_PATH, and CI via the
+// official Playwright Docker image (browsers baked in at /ms-playwright) — so
+// `playwright test` never needs to reach cdn.playwright.dev. Playwright boots the
+// Vite dev server itself (see `webServer`) and tears it down when the run ends.
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -21,7 +21,14 @@ export default defineConfig({
       name: 'chromium',
       // Use the bundled Chromium directly (no `channel`) so the provisioned
       // browser is used rather than a system Chrome install.
-      use: { browserName: 'chromium', viewport: { width: 1280, height: 900 } },
+      use: {
+        browserName: 'chromium',
+        viewport: { width: 1280, height: 900 },
+        // The official Playwright CI image runs as root, where Chromium refuses
+        // to start its sandbox; disable it in CI only. Local runs (non-root)
+        // keep the sandbox.
+        launchOptions: process.env.CI ? { args: ['--no-sandbox'] } : {},
+      },
     },
   ],
   webServer: {

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -91,8 +91,8 @@ const DELETE_UNDO_DURATION_MS = 6000;
 // A bulk delete removes many rows at once, so give the undo a little longer.
 const BULK_DELETE_UNDO_DURATION_MS = 8000;
 
-// Command-bar primary actions ("Add Loan" / "Add Investment"): solid white
-// buttons with deep brand-green text. Styled explicitly rather than via
+// Command-bar primary actions ("Add Loan" / "Add Investment" / "Add Asset"):
+// solid white buttons with deep brand-green text. Styled explicitly rather than via
 // `color="inherit"` — a contained inherit button takes its TEXT color from the
 // AppBar (white) but its background from `grey[300]`, rendering white-on-light-
 // grey and unreadable in light mode. White surface + green text stays
@@ -422,6 +422,7 @@ export const Body = () => {
           <OnboardingEmptyState
             onAddLoan={() => onLoanAddEdit()}
             onAddInvestment={() => onInvestmentAddEdit()}
+            onAddAsset={() => onAssetAddEdit()}
             onLoadSampleData={onLoadSampleData}
           />
         </Paper>

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -15,6 +15,8 @@ import { Loan } from './models/loan-model';
 import { LoanTable } from './loan/loan-table';
 import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
+import { Asset } from './models/asset-model';
+import { AssetTable } from './asset/asset-table';
 import { DataManager } from './data-manager/data-manager';
 import { PersistenceToggle } from './persistence/persistence-toggle';
 import { FirstVisitNotice } from './persistence/first-visit-notice';
@@ -33,7 +35,11 @@ import {
   SectionEmptyState,
 } from './components/empty-state';
 import { DialogFallback } from './components/dialog-fallback';
-import { sampleLoans, sampleInvestments } from './state/sample-data';
+import {
+  sampleLoans,
+  sampleInvestments,
+  sampleAssets,
+} from './state/sample-data';
 
 // Code-split the heaviest, non-critical-path chunks (roadmap 6.6): the forecast
 // chart (@mui/x-charts) and the add/edit forms (@mui/x-date-pickers) are kept
@@ -50,23 +56,29 @@ const AddEditInvestment = lazy(() =>
     default: m.AddEditInvestment,
   }))
 );
+const AddEditAsset = lazy(() =>
+  import('./asset/add-edit-asset').then((m) => ({ default: m.AddEditAsset }))
+);
 
 // A delete pending confirmation: which kind of entity, and the entity itself
 // (we need its name for the prompt).
 type PendingDelete =
   | { kind: 'loan'; entity: Loan }
-  | { kind: 'investment'; entity: Investment };
+  | { kind: 'investment'; entity: Investment }
+  | { kind: 'asset'; entity: Asset };
 
 // A delete that just happened and can still be undone: the removed entity plus
 // the index it occupied, so undo can restore it exactly where it was.
 type UndoableDelete =
   | { kind: 'loan'; entity: Loan; index: number }
-  | { kind: 'investment'; entity: Investment; index: number };
+  | { kind: 'investment'; entity: Investment; index: number }
+  | { kind: 'asset'; entity: Asset; index: number };
 
 // A bulk delete pending confirmation: which kind, and the selected entities.
 type PendingBulkDelete =
   | { kind: 'loan'; entities: Loan[] }
-  | { kind: 'investment'; entities: Investment[] };
+  | { kind: 'investment'; entities: Investment[] }
+  | { kind: 'asset'; entities: Asset[] };
 
 // A committed bulk delete that can still be undone: the pre-delete data
 // snapshot (restored wholesale) plus the snackbar message.
@@ -96,9 +108,11 @@ export const Body = () => {
     state: {
       loans,
       investments,
+      assets,
       sampleDataLoaded,
       stashedLoans,
       stashedInvestments,
+      stashedAssets,
       scenarios,
       activeScenarioId,
     },
@@ -110,6 +124,10 @@ export const Body = () => {
     updateInvestment,
     deleteInvestment,
     insertInvestmentAt,
+    addAsset,
+    updateAsset,
+    deleteAsset,
+    insertAssetAt,
     restoreData,
     loadSampleData,
     clearSampleData,
@@ -119,8 +137,10 @@ export const Body = () => {
   const [isAddLoanOpen, setIsAddLoanOpen] = useState<boolean>(false);
   const [isAddInvestmentOpen, setIsAddInvestmentOpen] =
     useState<boolean>(false);
+  const [isAddAssetOpen, setIsAddAssetOpen] = useState<boolean>(false);
   const [editLoan, setEditLoan] = useState<Loan>();
   const [editInvestment, setEditInvestment] = useState<Investment>();
+  const [editAsset, setEditAsset] = useState<Asset>();
 
   // Delete confirmation + soft-undo state (roadmap 0.7).
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
@@ -131,7 +151,8 @@ export const Body = () => {
     useState<PendingBulkDelete>();
   const [bulkUndo, setBulkUndo] = useState<BulkUndo>();
 
-  const onLoadSampleData = () => loadSampleData(sampleLoans, sampleInvestments);
+  const onLoadSampleData = () =>
+    loadSampleData(sampleLoans, sampleInvestments, sampleAssets);
 
   const onLoanAddEdit = (loan?: Loan) => {
     setEditLoan(loan);
@@ -195,6 +216,31 @@ export const Body = () => {
       Name: `${investment.Name} (copy)`,
     });
 
+  const onAssetAddEdit = (asset?: Asset) => {
+    setEditAsset(asset);
+    setIsAddAssetOpen(true);
+  };
+
+  const onAssetAddEditClose = () => {
+    setIsAddAssetOpen(false);
+    setEditAsset(undefined);
+  };
+
+  const onAssetAddEditSave = (newAsset: Asset, oldAsset?: Asset) => {
+    if (!oldAsset) {
+      addAsset(newAsset);
+    } else {
+      updateAsset(newAsset);
+    }
+  };
+
+  const onAssetDelete = (asset: Asset) => {
+    setPendingDelete({ kind: 'asset', entity: asset });
+  };
+
+  const onAssetClone = (asset: Asset) =>
+    addAsset({ ...asset, Id: '', Name: `${asset.Name} (copy)` });
+
   // Step 2: confirmation accepted — actually delete, remembering the original
   // index so the snackbar can offer an exact-position undo.
   const onConfirmDelete = () => {
@@ -205,13 +251,21 @@ export const Body = () => {
       const index = loans.findIndex((l) => l.Id === pendingDelete.entity.Id);
       deleteLoan(pendingDelete.entity.Id);
       setUndoableDelete({ kind: 'loan', entity: pendingDelete.entity, index });
-    } else {
+    } else if (pendingDelete.kind === 'investment') {
       const index = investments.findIndex(
         (i) => i.Id === pendingDelete.entity.Id
       );
       deleteInvestment(pendingDelete.entity.Id);
       setUndoableDelete({
         kind: 'investment',
+        entity: pendingDelete.entity,
+        index,
+      });
+    } else {
+      const index = assets.findIndex((a) => a.Id === pendingDelete.entity.Id);
+      deleteAsset(pendingDelete.entity.Id);
+      setUndoableDelete({
+        kind: 'asset',
         entity: pendingDelete.entity,
         index,
       });
@@ -226,8 +280,10 @@ export const Body = () => {
     }
     if (undoableDelete.kind === 'loan') {
       insertLoanAt(undoableDelete.entity, undoableDelete.index);
-    } else {
+    } else if (undoableDelete.kind === 'investment') {
       insertInvestmentAt(undoableDelete.entity, undoableDelete.index);
+    } else {
+      insertAssetAt(undoableDelete.entity, undoableDelete.index);
     }
     setUndoableDelete(undefined);
   };
@@ -247,9 +303,14 @@ export const Body = () => {
     }
   };
 
+  const onAssetBulkDelete = (selected: Asset[]) => {
+    if (selected.length > 0) {
+      setPendingBulkDelete({ kind: 'asset', entities: selected });
+    }
+  };
+
   const bulkDeleteCount = pendingBulkDelete?.entities.length ?? 0;
-  const bulkDeleteNoun =
-    pendingBulkDelete?.kind === 'investment' ? 'investment' : 'loan';
+  const bulkDeleteNoun = pendingBulkDelete?.kind ?? 'loan';
   const pluralize = (count: number, noun: string) =>
     `${count} ${noun}${count === 1 ? '' : 's'}`;
 
@@ -261,14 +322,18 @@ export const Body = () => {
     const snapshot: DataSnapshot = {
       loans,
       investments,
+      assets,
       scenarios,
       stashedLoans,
       stashedInvestments,
+      stashedAssets,
     };
     if (pendingBulkDelete.kind === 'loan') {
       pendingBulkDelete.entities.forEach((loan) => deleteLoan(loan.Id));
-    } else {
+    } else if (pendingBulkDelete.kind === 'investment') {
       pendingBulkDelete.entities.forEach((inv) => deleteInvestment(inv.Id));
+    } else {
+      pendingBulkDelete.entities.forEach((asset) => deleteAsset(asset.Id));
     }
     setBulkUndo({
       snapshot,
@@ -289,7 +354,8 @@ export const Body = () => {
   };
 
   const deletedName = undoableDelete?.entity.Name ?? '';
-  const bothEmpty = loans.length === 0 && investments.length === 0;
+  const allEmpty =
+    loans.length === 0 && investments.length === 0 && assets.length === 0;
   const activeScenario = scenarios.find((s) => s.Id === activeScenarioId);
 
   return (
@@ -316,6 +382,13 @@ export const Body = () => {
             onClick={() => onInvestmentAddEdit()}
           >
             Add Investment
+          </Button>
+          <Button
+            variant="contained"
+            sx={addActionSx}
+            onClick={() => onAssetAddEdit()}
+          >
+            Add Asset
           </Button>
           <DataManager />
           <PersistenceToggle />
@@ -344,7 +417,7 @@ export const Body = () => {
         </Alert>
       )}
 
-      {bothEmpty ? (
+      {allEmpty ? (
         <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
           <OnboardingEmptyState
             onAddLoan={() => onLoanAddEdit()}
@@ -356,13 +429,21 @@ export const Body = () => {
         <>
           {/* Net-worth dashboard summary cards (roadmap 3.1): lead the content
               with today's totals — the same anchor the forecast chart starts
-              from. */}
+              from. Assets (Phase 7) roll into the totals. */}
           <Box sx={{ marginBottom: SECTION_GAP }}>
-            <NetWorthSummary loans={loans} investments={investments} />
+            <NetWorthSummary
+              loans={loans}
+              investments={investments}
+              assets={assets}
+            />
             {/* Milestone callouts (roadmap 3.2): debt-free date + net worth at
                 +5y/+10y/+30y, cheap reads off the same engine series. */}
             <Box sx={{ marginTop: 2 }}>
-              <MilestoneCallouts loans={loans} investments={investments} />
+              <MilestoneCallouts
+                loans={loans}
+                investments={investments}
+                assets={assets}
+              />
             </Box>
           </Box>
 
@@ -404,9 +485,32 @@ export const Body = () => {
             )}
           </Paper>
 
-          {/* Forecast chart (roadmap 2.2): per-loan, per-investment, and overall
-              net-worth lines from the shared engine. Shown whenever there is at
-              least one position (the enclosing branch already guarantees it). */}
+          {/* Assets section (roadmap 7.1–7.3): cash, property, and custom
+              assets/liabilities that complete the net-worth picture. */}
+          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
+            <Divider>Assets</Divider>
+            {assets.length > 0 ? (
+              <AssetTable
+                assets={assets}
+                loans={loans}
+                onAssetEdit={onAssetAddEdit}
+                onAssetDelete={onAssetDelete}
+                onAssetClone={onAssetClone}
+                onAssetBulkDelete={onAssetBulkDelete}
+              />
+            ) : (
+              <SectionEmptyState
+                message="No assets yet."
+                actionLabel="Add your first asset"
+                onAction={() => onAssetAddEdit()}
+              />
+            )}
+          </Paper>
+
+          {/* Forecast chart (roadmap 2.2): per-loan, per-investment, per-asset,
+              and overall net-worth lines from the shared engine. Shown whenever
+              there is at least one position (the enclosing branch guarantees
+              it). */}
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Forecast</Divider>
             {/* Scenario controls (roadmap 4.2): create/select/delete what-if
@@ -420,6 +524,7 @@ export const Body = () => {
               <ForecastChart
                 loans={loans}
                 investments={investments}
+                assets={assets}
                 scenario={activeScenario}
               />
             </Suspense>
@@ -469,6 +574,16 @@ export const Body = () => {
             onSave={onInvestmentAddEditSave}
             onClose={onInvestmentAddEditClose}
             investment={editInvestment}
+          />
+        )}
+
+        {isAddAssetOpen && (
+          <AddEditAsset
+            open
+            onSave={onAssetAddEditSave}
+            onClose={onAssetAddEditClose}
+            asset={editAsset}
+            loans={loans}
           />
         )}
       </Suspense>

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -11,6 +11,7 @@ import {
   Skeleton,
   Snackbar,
   Toolbar,
+  Typography,
 } from '@mui/material';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { lazy, Suspense, useState } from 'react';
@@ -418,6 +419,15 @@ export const Body = () => {
   };
 
   const deletedName = undoableDelete?.entity.Name ?? '';
+  // Split assets for display: custom liabilities live in the Liabilities section
+  // (next to loans); everything else is a true asset. They remain one collection
+  // in state — this is purely a presentation split.
+  const liabilityAssets = assets.filter(
+    (a) => a.AssetType === AssetType.CustomLiability
+  );
+  const assetHoldings = assets.filter(
+    (a) => a.AssetType !== AssetType.CustomLiability
+  );
   const allEmpty =
     loans.length === 0 && investments.length === 0 && assets.length === 0;
   const activeScenario = scenarios.find((s) => s.Id === activeScenarioId);
@@ -543,25 +553,6 @@ export const Body = () => {
           </Box>
 
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
-            <Divider>Loans</Divider>
-            {loans.length > 0 ? (
-              <LoanTable
-                loans={loans}
-                onLoanEdit={onLoanAddEdit}
-                onLoanDelete={onLoanDelete}
-                onLoanClone={onLoanClone}
-                onLoanBulkDelete={onLoanBulkDelete}
-              />
-            ) : (
-              <SectionEmptyState
-                message="No loans yet."
-                actionLabel="Add your first loan"
-                onAction={() => onLoanAddEdit()}
-              />
-            )}
-          </Paper>
-
-          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Investments</Divider>
             {investments.length > 0 ? (
               <InvestmentTable
@@ -581,12 +572,13 @@ export const Body = () => {
           </Paper>
 
           {/* Assets section (roadmap 7.1–7.3): cash, property, and custom
-              assets/liabilities that complete the net-worth picture. */}
+              assets that complete the net-worth picture. Custom liabilities are
+              shown under Liabilities instead. */}
           <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
             <Divider>Assets</Divider>
-            {assets.length > 0 ? (
+            {assetHoldings.length > 0 ? (
               <AssetTable
-                assets={assets}
+                assets={assetHoldings}
                 loans={loans}
                 onAssetEdit={onAssetAddEdit}
                 onAssetDelete={onAssetDelete}
@@ -599,6 +591,71 @@ export const Body = () => {
                 actionLabel="Add your first asset"
                 onAction={() => onAssetAddEdit()}
               />
+            )}
+          </Paper>
+
+          {/* Liabilities section: loans and custom liabilities together, matching
+              the "Add Liability" entry point. Loans keep their rich table
+              (amortization, payoff, PIT); custom liabilities use the shared asset
+              table with liability-framed labels. */}
+          <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
+            <Divider>Liabilities</Divider>
+            {loans.length === 0 && liabilityAssets.length === 0 ? (
+              <SectionEmptyState
+                message="No liabilities yet."
+                actionLabel="Add your first liability"
+                onAction={(e) => setLiabilityMenuAnchor(e.currentTarget)}
+              />
+            ) : (
+              <>
+                {loans.length > 0 && (
+                  <Box>
+                    {liabilityAssets.length > 0 && (
+                      <Typography
+                        variant="subtitle2"
+                        color="text.secondary"
+                        sx={{ mb: 1 }}
+                      >
+                        Loans
+                      </Typography>
+                    )}
+                    <LoanTable
+                      loans={loans}
+                      onLoanEdit={onLoanAddEdit}
+                      onLoanDelete={onLoanDelete}
+                      onLoanClone={onLoanClone}
+                      onLoanBulkDelete={onLoanBulkDelete}
+                    />
+                  </Box>
+                )}
+                {liabilityAssets.length > 0 && (
+                  <Box sx={{ mt: loans.length > 0 ? 3 : 0 }}>
+                    {loans.length > 0 && (
+                      <Typography
+                        variant="subtitle2"
+                        color="text.secondary"
+                        sx={{ mb: 1 }}
+                      >
+                        Other liabilities
+                      </Typography>
+                    )}
+                    <AssetTable
+                      assets={liabilityAssets}
+                      loans={loans}
+                      onAssetEdit={onAssetAddEdit}
+                      onAssetDelete={onAssetDelete}
+                      onAssetClone={onAssetClone}
+                      onAssetBulkDelete={onAssetBulkDelete}
+                      showTypeColumn={false}
+                      showEquityColumn={false}
+                      searchLabel="Search liabilities"
+                      itemLabel="liability"
+                      itemLabelPlural="liabilities"
+                      balanceHeader="Owed"
+                    />
+                  </Box>
+                )}
+              </>
             )}
           </Paper>
 

--- a/src/Body.tsx
+++ b/src/Body.tsx
@@ -5,17 +5,20 @@ import {
   Button,
   Container,
   Divider,
+  Menu,
+  MenuItem,
   Paper,
   Skeleton,
   Snackbar,
   Toolbar,
 } from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import { lazy, Suspense, useState } from 'react';
 import { Loan } from './models/loan-model';
 import { LoanTable } from './loan/loan-table';
 import { Investment } from './models/investment-model';
 import { InvestmentTable } from './investment/investment-table';
-import { Asset } from './models/asset-model';
+import { Asset, AssetType } from './models/asset-model';
 import { AssetTable } from './asset/asset-table';
 import { DataManager } from './data-manager/data-manager';
 import { PersistenceToggle } from './persistence/persistence-toggle';
@@ -91,7 +94,16 @@ const DELETE_UNDO_DURATION_MS = 6000;
 // A bulk delete removes many rows at once, so give the undo a little longer.
 const BULK_DELETE_UNDO_DURATION_MS = 8000;
 
-// Command-bar primary actions ("Add Loan" / "Add Investment" / "Add Asset"):
+// The non-liability asset types: the group the "Add Asset" entry point and an
+// asset (non-liability) edit offer in the in-dialog type selector.
+const ASSET_TYPE_GROUP: AssetType[] = [
+  AssetType.Cash,
+  AssetType.Property,
+  AssetType.CustomAsset,
+];
+
+// Command-bar primary actions: two menu buttons, "Add Asset" (Investment / Cash
+// / Property / Custom asset) and "Add Liability" (Loan / Custom liability) —
 // solid white buttons with deep brand-green text. Styled explicitly rather than via
 // `color="inherit"` — a contained inherit button takes its TEXT color from the
 // AppBar (white) but its background from `grey[300]`, rendering white-on-light-
@@ -141,6 +153,18 @@ export const Body = () => {
   const [editLoan, setEditLoan] = useState<Loan>();
   const [editInvestment, setEditInvestment] = useState<Investment>();
   const [editAsset, setEditAsset] = useState<Asset>();
+  // Which AssetType options the asset/liability dialog offers, and the type a new
+  // entity seeds with — set by the entry point that opened it.
+  const [assetAllowedTypes, setAssetAllowedTypes] =
+    useState<AssetType[]>(ASSET_TYPE_GROUP);
+  const [assetInitialType, setAssetInitialType] = useState<AssetType>();
+
+  // Anchors for the two command-bar (and onboarding) "Add" type menus.
+  const [assetMenuAnchor, setAssetMenuAnchor] = useState<null | HTMLElement>(
+    null
+  );
+  const [liabilityMenuAnchor, setLiabilityMenuAnchor] =
+    useState<null | HTMLElement>(null);
 
   // Delete confirmation + soft-undo state (roadmap 0.7).
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
@@ -216,9 +240,49 @@ export const Body = () => {
       Name: `${investment.Name} (copy)`,
     });
 
+  // Edit an existing asset/liability from its table row. The allowed-type group
+  // is derived from the entity so a liability can't be retyped into an asset (or
+  // vice versa) mid-edit.
   const onAssetAddEdit = (asset?: Asset) => {
     setEditAsset(asset);
+    setAssetInitialType(undefined);
+    setAssetAllowedTypes(
+      asset?.AssetType === AssetType.CustomLiability
+        ? [AssetType.CustomLiability]
+        : ASSET_TYPE_GROUP
+    );
     setIsAddAssetOpen(true);
+  };
+
+  // Add a new asset/liability of a chosen type (from a command-bar/onboarding
+  // menu). `allowedTypes` keeps the in-dialog selector to the right group.
+  const openAddAsset = (initialType: AssetType, allowedTypes: AssetType[]) => {
+    setEditAsset(undefined);
+    setAssetInitialType(initialType);
+    setAssetAllowedTypes(allowedTypes);
+    setIsAddAssetOpen(true);
+  };
+
+  // "Add Asset" menu: an investment opens its own rich form; the simple holdings
+  // open the shared asset form on the picked type.
+  const onAddAssetType = (type: 'investment' | AssetType) => {
+    setAssetMenuAnchor(null);
+    if (type === 'investment') {
+      onInvestmentAddEdit();
+    } else {
+      openAddAsset(type, ASSET_TYPE_GROUP);
+    }
+  };
+
+  // "Add Liability" menu: a loan opens its own form; a custom liability opens the
+  // shared asset form locked to the liability type.
+  const onAddLiabilityType = (type: 'loan' | AssetType) => {
+    setLiabilityMenuAnchor(null);
+    if (type === 'loan') {
+      onLoanAddEdit();
+    } else {
+      openAddAsset(AssetType.CustomLiability, [AssetType.CustomLiability]);
+    }
   };
 
   const onAssetAddEditClose = () => {
@@ -372,29 +436,60 @@ export const Body = () => {
           <Button
             variant="contained"
             sx={addActionSx}
-            onClick={() => onLoanAddEdit()}
-          >
-            Add Loan
-          </Button>
-          <Button
-            variant="contained"
-            sx={addActionSx}
-            onClick={() => onInvestmentAddEdit()}
-          >
-            Add Investment
-          </Button>
-          <Button
-            variant="contained"
-            sx={addActionSx}
-            onClick={() => onAssetAddEdit()}
+            endIcon={<ArrowDropDownIcon />}
+            aria-haspopup="menu"
+            aria-expanded={Boolean(assetMenuAnchor)}
+            onClick={(e) => setAssetMenuAnchor(e.currentTarget)}
           >
             Add Asset
+          </Button>
+          <Button
+            variant="contained"
+            sx={addActionSx}
+            endIcon={<ArrowDropDownIcon />}
+            aria-haspopup="menu"
+            aria-expanded={Boolean(liabilityMenuAnchor)}
+            onClick={(e) => setLiabilityMenuAnchor(e.currentTarget)}
+          >
+            Add Liability
           </Button>
           <DataManager />
           <PersistenceToggle />
           <ColorModeToggle />
         </Toolbar>
       </AppBar>
+
+      {/* Type selectors for the two "Add" entry points (roadmap 7). The single
+          anchor state per menu means the command bar and the onboarding CTAs can
+          both open the same menu, anchored to whichever button was clicked. */}
+      <Menu
+        anchorEl={assetMenuAnchor}
+        open={Boolean(assetMenuAnchor)}
+        onClose={() => setAssetMenuAnchor(null)}
+      >
+        <MenuItem onClick={() => onAddAssetType('investment')}>
+          Investment
+        </MenuItem>
+        <MenuItem onClick={() => onAddAssetType(AssetType.Cash)}>
+          Cash (HYSA / CD / checking)
+        </MenuItem>
+        <MenuItem onClick={() => onAddAssetType(AssetType.Property)}>
+          Property
+        </MenuItem>
+        <MenuItem onClick={() => onAddAssetType(AssetType.CustomAsset)}>
+          Custom asset
+        </MenuItem>
+      </Menu>
+      <Menu
+        anchorEl={liabilityMenuAnchor}
+        open={Boolean(liabilityMenuAnchor)}
+        onClose={() => setLiabilityMenuAnchor(null)}
+      >
+        <MenuItem onClick={() => onAddLiabilityType('loan')}>Loan</MenuItem>
+        <MenuItem onClick={() => onAddLiabilityType(AssetType.CustomLiability)}>
+          Custom liability
+        </MenuItem>
+      </Menu>
 
       {/* First-visit privacy notice (roadmap 1.3): shown once, explains data
           stays on-device and points at the "Save on this device" toggle. */}
@@ -420,9 +515,8 @@ export const Body = () => {
       {allEmpty ? (
         <Paper sx={{ marginBottom: SECTION_GAP, padding: PAPER_PADDING }}>
           <OnboardingEmptyState
-            onAddLoan={() => onLoanAddEdit()}
-            onAddInvestment={() => onInvestmentAddEdit()}
-            onAddAsset={() => onAssetAddEdit()}
+            onAddAsset={(e) => setAssetMenuAnchor(e.currentTarget)}
+            onAddLiability={(e) => setLiabilityMenuAnchor(e.currentTarget)}
             onLoadSampleData={onLoadSampleData}
           />
         </Paper>
@@ -585,6 +679,8 @@ export const Body = () => {
             onClose={onAssetAddEditClose}
             asset={editAsset}
             loans={loans}
+            allowedTypes={assetAllowedTypes}
+            initialType={assetInitialType}
           />
         )}
       </Suspense>

--- a/src/asset/add-edit-asset.tsx
+++ b/src/asset/add-edit-asset.tsx
@@ -1,0 +1,250 @@
+import {
+  Alert,
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  MenuItem,
+  TextField,
+} from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { Asset, AssetType, emptyAsset } from '../models/asset-model';
+import { CompoundingFrequency } from '../models/investment-model';
+import { Loan } from '../models/loan-model';
+import { NumericFormat } from 'react-number-format';
+import { ResponsiveDialog } from '../components/responsive-dialog';
+import { isAssetValid, validateAsset } from '../helpers/validation-helpers';
+import { fieldHelperText } from '../components/field-helper-text';
+import { useFieldTracking } from '../hooks/use-field-tracking';
+
+// Friendly labels for the AssetType select. Keyed by enum value so the option
+// list and the stored value never drift.
+const ASSET_TYPE_LABELS: Record<AssetType, string> = {
+  [AssetType.Cash]: 'Cash (HYSA / CD / checking)',
+  [AssetType.Property]: 'Property (home / real estate)',
+  [AssetType.CustomAsset]: 'Custom asset',
+  [AssetType.CustomLiability]: 'Custom liability',
+};
+
+const COMPOUNDING_LABELS: Record<CompoundingFrequency, string> = {
+  [CompoundingFrequency.Monthly]: 'Monthly',
+  [CompoundingFrequency.Quarterly]: 'Quarterly',
+  [CompoundingFrequency.Annually]: 'Annually',
+};
+
+// The rate label tracks the asset type so the field reads naturally: an APY for
+// cash, an appreciation rate for property, a growth/decline rate otherwise.
+const rateLabel = (type: AssetType): string => {
+  switch (type) {
+    case AssetType.Cash:
+      return 'Annual percentage yield (APY)';
+    case AssetType.Property:
+      return 'Annual appreciation rate';
+    default:
+      return 'Annual growth / decline rate';
+  }
+};
+
+export const AddEditAsset = (props: AddEditAssetProps) => {
+  const [newAsset, setNewAsset] = useState<Asset>(emptyAsset);
+
+  const validation = useMemo(() => validateAsset(newAsset), [newAsset]);
+  const isFormValid = () => isAssetValid(newAsset);
+
+  const {
+    touch,
+    errorFor,
+    warningFor,
+    resetTracking,
+    markSubmitAttempted,
+    saveDisabledReason,
+  } = useFieldTracking(validation);
+
+  useEffect(() => {
+    setNewAsset(props.asset ?? emptyAsset);
+    resetTracking();
+  }, [props.asset, props.open, resetTracking]);
+
+  const onSave = () => {
+    if (!isFormValid()) {
+      markSubmitAttempted();
+      return;
+    }
+    props.onSave(newAsset, props.asset);
+    props.onClose();
+    setNewAsset(emptyAsset);
+    resetTracking();
+  };
+
+  const onCancel = () => {
+    props.onClose();
+    resetTracking();
+  };
+
+  const isProperty = newAsset.AssetType === AssetType.Property;
+
+  return (
+    <ResponsiveDialog open={props.open} onClose={props.onClose}>
+      <DialogTitle sx={{ textAlign: 'center' }}>
+        {!props.asset ? 'Add new asset' : 'Edit asset'}
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
+          <TextField
+            select
+            label="Type"
+            value={newAsset.AssetType}
+            onChange={(e) =>
+              setNewAsset({
+                ...newAsset,
+                AssetType: e.target.value as AssetType,
+                // Dropping out of Property clears a now-meaningless link.
+                LinkedLoanId:
+                  (e.target.value as AssetType) === AssetType.Property
+                    ? newAsset.LinkedLoanId
+                    : undefined,
+              })
+            }
+          >
+            {Object.values(AssetType).map((type) => (
+              <MenuItem key={type} value={type}>
+                {ASSET_TYPE_LABELS[type]}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            label="Name"
+            value={newAsset.Name}
+            onChange={(e) => setNewAsset({ ...newAsset, Name: e.target.value })}
+            onBlur={() => touch('Name')}
+            error={Boolean(errorFor('Name'))}
+            helperText={fieldHelperText(errorFor('Name'), warningFor('Name'))}
+            required
+          />
+          <TextField
+            label="Provider / Institution"
+            value={newAsset.Provider}
+            onChange={(e) =>
+              setNewAsset({ ...newAsset, Provider: e.target.value })
+            }
+            onBlur={() => touch('Provider')}
+            error={Boolean(errorFor('Provider'))}
+            helperText={fieldHelperText(
+              errorFor('Provider'),
+              warningFor('Provider')
+            )}
+            required
+          />
+          <NumericFormat
+            label="Current Balance / Value"
+            value={newAsset.Balance}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) =>
+              setNewAsset({ ...newAsset, Balance: Number(vs.value) })
+            }
+            onBlur={() => touch('Balance')}
+            error={Boolean(errorFor('Balance'))}
+            helperText={fieldHelperText(
+              errorFor('Balance'),
+              warningFor('Balance')
+            )}
+            required
+          />
+          <NumericFormat
+            label={rateLabel(newAsset.AssetType)}
+            value={newAsset.GrowthRate}
+            thousandSeparator
+            decimalScale={3}
+            suffix={'%'}
+            allowNegative
+            customInput={TextField}
+            onValueChange={(vs) =>
+              setNewAsset({ ...newAsset, GrowthRate: Number(vs.value) })
+            }
+            onBlur={() => touch('GrowthRate')}
+            error={Boolean(errorFor('GrowthRate'))}
+            helperText={fieldHelperText(
+              errorFor('GrowthRate'),
+              warningFor('GrowthRate')
+            )}
+            required
+          />
+          <TextField
+            select
+            label="Compounding"
+            value={newAsset.CompoundingPeriod ?? CompoundingFrequency.Monthly}
+            onChange={(e) =>
+              setNewAsset({
+                ...newAsset,
+                CompoundingPeriod: e.target.value as CompoundingFrequency,
+              })
+            }
+          >
+            {Object.values(CompoundingFrequency).map((freq) => (
+              <MenuItem key={freq} value={freq}>
+                {COMPOUNDING_LABELS[freq]}
+              </MenuItem>
+            ))}
+          </TextField>
+          {/* 7.2 entity linking: pair a property to its mortgage so net worth
+              reflects home equity. Only shown for property; "None" clears it. */}
+          {isProperty && (
+            <TextField
+              select
+              label="Linked mortgage (optional)"
+              value={newAsset.LinkedLoanId ?? ''}
+              onChange={(e) =>
+                setNewAsset({
+                  ...newAsset,
+                  LinkedLoanId: e.target.value || undefined,
+                })
+              }
+              helperText="Pair this property with its mortgage to track home equity."
+            >
+              <MenuItem value="">None</MenuItem>
+              {props.loans.map((loan) => (
+                <MenuItem key={loan.Id} value={loan.Id}>
+                  {loan.Name}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        </Box>
+      </DialogContent>
+      <Box sx={{ px: 3 }}>
+        {!isFormValid() && (
+          <Alert severity="info" sx={{ mb: 1 }}>
+            {saveDisabledReason}
+          </Alert>
+        )}
+      </Box>
+      <DialogActions>
+        <Button type="reset" color="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          color="primary"
+          onClick={onSave}
+          disabled={!isFormValid()}
+        >
+          {!props.asset ? 'Add asset' : 'Save asset'}
+        </Button>
+      </DialogActions>
+    </ResponsiveDialog>
+  );
+};
+
+export interface AddEditAssetProps {
+  open: boolean;
+  onSave: (newAsset: Asset, oldAsset?: Asset) => void;
+  onClose: () => void;
+  asset?: Asset;
+  // Loans available to pair with a property (7.2 entity linking).
+  loans: Loan[];
+}

--- a/src/asset/add-edit-asset.tsx
+++ b/src/asset/add-edit-asset.tsx
@@ -33,6 +33,9 @@ const COMPOUNDING_LABELS: Record<CompoundingFrequency, string> = {
   [CompoundingFrequency.Annually]: 'Annually',
 };
 
+// Every type, the default when an entry point doesn't constrain the selector.
+const ALL_ASSET_TYPES: AssetType[] = Object.values(AssetType);
+
 // The rate label tracks the asset type so the field reads naturally: an APY for
 // cash, an appreciation rate for property, a growth/decline rate otherwise.
 const rateLabel = (type: AssetType): string => {
@@ -46,7 +49,15 @@ const rateLabel = (type: AssetType): string => {
   }
 };
 
+// Shared form for every simple holding (Phase 7). The owning "Add Asset" /
+// "Add Liability" entry point decides which AssetType options the selector
+// offers (`allowedTypes`) and which type a new entity starts as (`initialType`);
+// a custom liability flows through here too, so the copy (title, balance label,
+// buttons) adapts to whether the current type is a liability.
 export const AddEditAsset = (props: AddEditAssetProps) => {
+  const allowedTypes = props.allowedTypes ?? ALL_ASSET_TYPES;
+  const seedType = props.initialType ?? allowedTypes[0] ?? AssetType.Cash;
+
   const [newAsset, setNewAsset] = useState<Asset>(emptyAsset);
 
   const validation = useMemo(() => validateAsset(newAsset), [newAsset]);
@@ -62,9 +73,11 @@ export const AddEditAsset = (props: AddEditAssetProps) => {
   } = useFieldTracking(validation);
 
   useEffect(() => {
-    setNewAsset(props.asset ?? emptyAsset);
+    // Edit reuses the passed entity; add seeds an empty entity of the type the
+    // entry point chose, so the form opens already on (say) "Custom liability".
+    setNewAsset(props.asset ?? { ...emptyAsset, AssetType: seedType });
     resetTracking();
-  }, [props.asset, props.open, resetTracking]);
+  }, [props.asset, props.open, seedType, resetTracking]);
 
   const onSave = () => {
     if (!isFormValid()) {
@@ -83,36 +96,42 @@ export const AddEditAsset = (props: AddEditAssetProps) => {
   };
 
   const isProperty = newAsset.AssetType === AssetType.Property;
+  const isLiability = newAsset.AssetType === AssetType.CustomLiability;
+  const noun = isLiability ? 'liability' : 'asset';
 
   return (
     <ResponsiveDialog open={props.open} onClose={props.onClose}>
       <DialogTitle sx={{ textAlign: 'center' }}>
-        {!props.asset ? 'Add new asset' : 'Edit asset'}
+        {!props.asset ? `Add new ${noun}` : `Edit ${noun}`}
       </DialogTitle>
       <DialogContent>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, mt: 1 }}>
-          <TextField
-            select
-            label="Type"
-            value={newAsset.AssetType}
-            onChange={(e) =>
-              setNewAsset({
-                ...newAsset,
-                AssetType: e.target.value as AssetType,
-                // Dropping out of Property clears a now-meaningless link.
-                LinkedLoanId:
-                  (e.target.value as AssetType) === AssetType.Property
-                    ? newAsset.LinkedLoanId
-                    : undefined,
-              })
-            }
-          >
-            {Object.values(AssetType).map((type) => (
-              <MenuItem key={type} value={type}>
-                {ASSET_TYPE_LABELS[type]}
-              </MenuItem>
-            ))}
-          </TextField>
+          {/* The entry point's type selector. Hidden when it would offer a single
+              option (the type is fixed, e.g. a custom liability). */}
+          {allowedTypes.length > 1 && (
+            <TextField
+              select
+              label="Type"
+              value={newAsset.AssetType}
+              onChange={(e) =>
+                setNewAsset({
+                  ...newAsset,
+                  AssetType: e.target.value as AssetType,
+                  // Dropping out of Property clears a now-meaningless link.
+                  LinkedLoanId:
+                    (e.target.value as AssetType) === AssetType.Property
+                      ? newAsset.LinkedLoanId
+                      : undefined,
+                })
+              }
+            >
+              {allowedTypes.map((type) => (
+                <MenuItem key={type} value={type}>
+                  {ASSET_TYPE_LABELS[type]}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
           <TextField
             label="Name"
             value={newAsset.Name}
@@ -137,7 +156,7 @@ export const AddEditAsset = (props: AddEditAssetProps) => {
             required
           />
           <NumericFormat
-            label="Current Balance / Value"
+            label={isLiability ? 'Amount owed' : 'Current Balance / Value'}
             value={newAsset.Balance}
             thousandSeparator
             decimalScale={2}
@@ -233,7 +252,7 @@ export const AddEditAsset = (props: AddEditAssetProps) => {
           onClick={onSave}
           disabled={!isFormValid()}
         >
-          {!props.asset ? 'Add asset' : 'Save asset'}
+          {!props.asset ? `Add ${noun}` : `Save ${noun}`}
         </Button>
       </DialogActions>
     </ResponsiveDialog>
@@ -247,4 +266,10 @@ export interface AddEditAssetProps {
   asset?: Asset;
   // Loans available to pair with a property (7.2 entity linking).
   loans: Loan[];
+  // The AssetType options the in-dialog selector offers. When only one type is
+  // allowed the selector is hidden (the type is fixed by the entry point, e.g. a
+  // custom liability). Defaults to every type.
+  allowedTypes?: AssetType[];
+  // The type a brand-new (add-mode) entity starts as; ignored when editing.
+  initialType?: AssetType;
 }

--- a/src/asset/asset-table.tsx
+++ b/src/asset/asset-table.tsx
@@ -1,0 +1,401 @@
+import {
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody,
+  TableFooter,
+  TableSortLabel,
+  Checkbox,
+  Paper,
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Grid,
+  useTheme,
+  useMediaQuery,
+} from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { Asset, AssetType } from '../models/asset-model';
+import { Loan } from '../models/loan-model';
+import { forecastHomeEquity } from '../helpers/forecast-helpers';
+import { isAssetLiability } from '../helpers/asset-helpers';
+import { formatCurrency, formatPercent } from '../helpers/format-helpers';
+import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
+import { filterBySearch } from '../helpers/filter-helpers';
+import { ContentCopy, Delete, Edit } from '@mui/icons-material';
+import { EntityRowActions, RowAction } from '../components/entity-row-actions';
+import { TableSearchField } from '../components/table-search-field';
+import { BulkActionsToolbar } from '../components/bulk-actions-toolbar';
+import { useRowSelection } from '../hooks/use-row-selection';
+
+// Human-readable labels for each asset type, used in the table and cards.
+const ASSET_TYPE_LABELS: Record<AssetType, string> = {
+  [AssetType.Cash]: 'Cash',
+  [AssetType.Property]: 'Property',
+  [AssetType.CustomAsset]: 'Custom asset',
+  [AssetType.CustomLiability]: 'Custom liability',
+};
+
+interface AssetRowHandlers {
+  onEdit: (asset: Asset) => void;
+  onClone: (asset: Asset) => void;
+  onDelete: (asset: Asset) => void;
+}
+
+// An asset plus its engine-derived display value: today's home equity for a
+// property linked to a mortgage (7.2), undefined for everything else.
+interface AssetRow {
+  asset: Asset;
+  equity?: number;
+}
+
+const assetActions = (
+  asset: Asset,
+  handlers: AssetRowHandlers
+): RowAction[] => [
+  {
+    icon: <Edit />,
+    title: 'Edit Asset',
+    onClick: () => handlers.onEdit(asset),
+  },
+  {
+    icon: <ContentCopy />,
+    title: 'Duplicate Asset',
+    onClick: () => handlers.onClone(asset),
+  },
+  {
+    icon: <Delete />,
+    title: 'Delete Asset',
+    onClick: () => handlers.onDelete(asset),
+    color: 'error',
+  },
+];
+
+type AssetColumnId =
+  | 'Name'
+  | 'Provider'
+  | 'AssetType'
+  | 'Balance'
+  | 'GrowthRate';
+
+interface AssetColumn {
+  id: AssetColumnId;
+  label: string;
+  numeric: boolean;
+  value: (row: AssetRow) => SortValue;
+}
+
+const ASSET_COLUMNS: AssetColumn[] = [
+  { id: 'Name', label: 'Name', numeric: false, value: (r) => r.asset.Name },
+  {
+    id: 'Provider',
+    label: 'Provider',
+    numeric: false,
+    value: (r) => r.asset.Provider,
+  },
+  {
+    id: 'AssetType',
+    label: 'Type',
+    numeric: false,
+    value: (r) => ASSET_TYPE_LABELS[r.asset.AssetType],
+  },
+  {
+    id: 'Balance',
+    label: 'Balance',
+    numeric: true,
+    value: (r) => r.asset.Balance,
+  },
+  {
+    id: 'GrowthRate',
+    label: 'Rate',
+    numeric: true,
+    value: (r) => r.asset.GrowthRate,
+  },
+];
+
+const equityText = (row: AssetRow): string =>
+  row.equity === undefined ? '—' : formatCurrency(row.equity);
+
+const AssetCard = ({
+  row,
+  handlers,
+  selected,
+  onSelect,
+}: {
+  row: AssetRow;
+  handlers: AssetRowHandlers;
+  selected: boolean;
+  onSelect: () => void;
+}) => {
+  const { asset } = row;
+  return (
+    <Card sx={{ marginBottom: 2 }}>
+      <CardContent>
+        <Box sx={{ display: 'flex', alignItems: 'flex-start' }}>
+          <Checkbox
+            checked={selected}
+            onChange={onSelect}
+            slotProps={{ input: { 'aria-label': `Select ${asset.Name}` } }}
+            sx={{ mt: -1, ml: -1 }}
+          />
+          <Box sx={{ flexGrow: 1 }}>
+            <Typography variant="h6" component="div" gutterBottom>
+              {asset.Name}
+            </Typography>
+            <Typography
+              variant="body2"
+              gutterBottom
+              sx={{ color: 'text.secondary' }}
+            >
+              {asset.Provider} · {ASSET_TYPE_LABELS[asset.AssetType]}
+            </Typography>
+          </Box>
+        </Box>
+        <Grid container spacing={2}>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>{isAssetLiability(asset) ? 'Owed:' : 'Balance:'}</strong>{' '}
+              {formatCurrency(asset.Balance)}
+            </Typography>
+          </Grid>
+          <Grid size={6}>
+            <Typography variant="body2">
+              <strong>Rate:</strong> {formatPercent(asset.GrowthRate)}
+            </Typography>
+          </Grid>
+          {row.equity !== undefined && (
+            <Grid size={6}>
+              <Typography variant="body2">
+                <strong>Equity:</strong> {equityText(row)}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+        <Box sx={{ marginTop: 2 }}>
+          <EntityRowActions actions={assetActions(asset, handlers)} isMobile />
+        </Box>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const AssetTable = (props: AssetTableProps) => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+
+  const [sortColumn, setSortColumn] = useState<AssetColumnId>('Balance');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  const [query, setQuery] = useState('');
+  const selection = useRowSelection();
+
+  const { retain } = selection;
+  useEffect(() => {
+    retain(props.assets.map((a) => a.Id));
+  }, [props.assets, retain]);
+
+  const handlers: AssetRowHandlers = {
+    onEdit: props.onAssetEdit,
+    onClone: props.onAssetClone,
+    onDelete: props.onAssetDelete,
+  };
+
+  // Engine-derived rows: today's home equity for a property linked to a
+  // mortgage that still exists (7.2). Memoized so it recomputes only when the
+  // assets or loans change.
+  const today = useMemo(() => new Date(), []);
+  const rows = useMemo<AssetRow[]>(() => {
+    return props.assets.map((asset) => {
+      const linkedLoan =
+        asset.AssetType === AssetType.Property && asset.LinkedLoanId
+          ? props.loans.find((l) => l.Id === asset.LinkedLoanId)
+          : undefined;
+      const equity = linkedLoan
+        ? forecastHomeEquity(asset, linkedLoan, today, today)[0].Value
+        : undefined;
+      return { asset, equity };
+    });
+  }, [props.assets, props.loans, today]);
+
+  const column =
+    ASSET_COLUMNS.find((c) => c.id === sortColumn) ?? ASSET_COLUMNS[0];
+  const sortedRows = useMemo(
+    () => sortBy(rows, column.value, sortDirection),
+    [rows, column, sortDirection]
+  );
+
+  const visibleRows = useMemo(
+    () =>
+      filterBySearch(sortedRows, query, (r) => [
+        r.asset.Name,
+        r.asset.Provider,
+      ]),
+    [sortedRows, query]
+  );
+
+  const handleSort = (id: AssetColumnId) => {
+    if (sortColumn === id) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortColumn(id);
+      setSortDirection('asc');
+    }
+  };
+
+  const visibleAssets = visibleRows.map((r) => r.asset);
+  const totalBalance = visibleAssets.reduce((sum, a) => sum + a.Balance, 0);
+
+  const selectedAssets = props.assets.filter((a) => selection.isSelected(a.Id));
+  const visibleIds = visibleRows.map((r) => r.asset.Id);
+  const allVisibleSelected =
+    visibleIds.length > 0 && visibleIds.every((id) => selection.isSelected(id));
+  const someVisibleSelected = visibleIds.some((id) => selection.isSelected(id));
+
+  const onBulkDuplicate = () => {
+    selectedAssets.forEach((asset) => props.onAssetClone(asset));
+    selection.clear();
+  };
+  const onBulkDelete = () => props.onAssetBulkDelete(selectedAssets);
+
+  const noMatches = visibleRows.length === 0 && query.trim() !== '';
+
+  return (
+    <>
+      <TableSearchField
+        value={query}
+        onChange={setQuery}
+        label="Search assets"
+      />
+      <BulkActionsToolbar
+        count={selectedAssets.length}
+        itemLabel="asset"
+        onDuplicate={onBulkDuplicate}
+        onDelete={onBulkDelete}
+        onClear={selection.clear}
+      />
+
+      {noMatches ? (
+        <Typography color="text.secondary" sx={{ py: 2 }}>
+          No assets match “{query}”.
+        </Typography>
+      ) : isMobile ? (
+        <Box>
+          {visibleRows.map((row) => (
+            <AssetCard
+              key={row.asset.Id}
+              row={row}
+              handlers={handlers}
+              selected={selection.isSelected(row.asset.Id)}
+              onSelect={() => selection.toggle(row.asset.Id)}
+            />
+          ))}
+        </Box>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell padding="checkbox">
+                  <Checkbox
+                    checked={allVisibleSelected}
+                    indeterminate={someVisibleSelected && !allVisibleSelected}
+                    onChange={(e) =>
+                      selection.setMany(visibleIds, e.target.checked)
+                    }
+                    slotProps={{
+                      input: { 'aria-label': 'Select all assets' },
+                    }}
+                  />
+                </TableCell>
+                {ASSET_COLUMNS.map((col) => (
+                  <TableCell
+                    key={col.id}
+                    align={col.numeric ? 'right' : 'left'}
+                    sortDirection={
+                      sortColumn === col.id ? sortDirection : false
+                    }
+                  >
+                    <TableSortLabel
+                      active={sortColumn === col.id}
+                      direction={sortColumn === col.id ? sortDirection : 'asc'}
+                      onClick={() => handleSort(col.id)}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  </TableCell>
+                ))}
+                <TableCell align="right">Equity</TableCell>
+                <TableCell>Actions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {visibleRows.map((row) => {
+                const isSelected = selection.isSelected(row.asset.Id);
+                return (
+                  <TableRow key={row.asset.Id} selected={isSelected}>
+                    <TableCell padding="checkbox">
+                      <Checkbox
+                        checked={isSelected}
+                        onChange={() => selection.toggle(row.asset.Id)}
+                        slotProps={{
+                          input: {
+                            'aria-label': `Select ${row.asset.Name}`,
+                          },
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>{row.asset.Name}</TableCell>
+                    <TableCell>{row.asset.Provider}</TableCell>
+                    <TableCell>
+                      {ASSET_TYPE_LABELS[row.asset.AssetType]}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(row.asset.Balance)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatPercent(row.asset.GrowthRate)}
+                    </TableCell>
+                    <TableCell align="right">{equityText(row)}</TableCell>
+                    <TableCell>
+                      <EntityRowActions
+                        actions={assetActions(row.asset, handlers)}
+                      />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell padding="checkbox" />
+                <TableCell>
+                  <strong>Totals</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell align="right">
+                  <strong>{formatCurrency(totalBalance)}</strong>
+                </TableCell>
+                <TableCell />
+                <TableCell />
+                <TableCell />
+              </TableRow>
+            </TableFooter>
+          </Table>
+        </TableContainer>
+      )}
+    </>
+  );
+};
+
+export type AssetTableProps = {
+  assets: Asset[];
+  loans: Loan[];
+  onAssetEdit: (a: Asset) => void;
+  onAssetDelete: (a: Asset) => void;
+  onAssetClone: (a: Asset) => void;
+  onAssetBulkDelete: (assets: Asset[]) => void;
+};

--- a/src/asset/asset-table.tsx
+++ b/src/asset/asset-table.tsx
@@ -17,7 +17,7 @@ import {
   useTheme,
   useMediaQuery,
 } from '@mui/material';
-import { useEffect, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { Asset, AssetType } from '../models/asset-model';
 import { Loan } from '../models/loan-model';
 import { forecastHomeEquity } from '../helpers/forecast-helpers';
@@ -58,17 +58,17 @@ const assetActions = (
 ): RowAction[] => [
   {
     icon: <Edit />,
-    title: 'Edit Asset',
+    title: 'Edit',
     onClick: () => handlers.onEdit(asset),
   },
   {
     icon: <ContentCopy />,
-    title: 'Duplicate Asset',
+    title: 'Duplicate',
     onClick: () => handlers.onClone(asset),
   },
   {
     icon: <Delete />,
-    title: 'Delete Asset',
+    title: 'Delete',
     onClick: () => handlers.onDelete(asset),
     color: 'error',
   },
@@ -86,35 +86,8 @@ interface AssetColumn {
   label: string;
   numeric: boolean;
   value: (row: AssetRow) => SortValue;
+  render: (row: AssetRow) => ReactNode;
 }
-
-const ASSET_COLUMNS: AssetColumn[] = [
-  { id: 'Name', label: 'Name', numeric: false, value: (r) => r.asset.Name },
-  {
-    id: 'Provider',
-    label: 'Provider',
-    numeric: false,
-    value: (r) => r.asset.Provider,
-  },
-  {
-    id: 'AssetType',
-    label: 'Type',
-    numeric: false,
-    value: (r) => ASSET_TYPE_LABELS[r.asset.AssetType],
-  },
-  {
-    id: 'Balance',
-    label: 'Balance',
-    numeric: true,
-    value: (r) => r.asset.Balance,
-  },
-  {
-    id: 'GrowthRate',
-    label: 'Rate',
-    numeric: true,
-    value: (r) => r.asset.GrowthRate,
-  },
-];
 
 const equityText = (row: AssetRow): string =>
   row.equity === undefined ? '—' : formatCurrency(row.equity);
@@ -124,11 +97,13 @@ const AssetCard = ({
   handlers,
   selected,
   onSelect,
+  showType,
 }: {
   row: AssetRow;
   handlers: AssetRowHandlers;
   selected: boolean;
   onSelect: () => void;
+  showType: boolean;
 }) => {
   const { asset } = row;
   return (
@@ -150,7 +125,8 @@ const AssetCard = ({
               gutterBottom
               sx={{ color: 'text.secondary' }}
             >
-              {asset.Provider} · {ASSET_TYPE_LABELS[asset.AssetType]}
+              {asset.Provider}
+              {showType ? ` · ${ASSET_TYPE_LABELS[asset.AssetType]}` : ''}
             </Typography>
           </Box>
         </Box>
@@ -182,7 +158,20 @@ const AssetCard = ({
   );
 };
 
+// Table of simple holdings (Phase 7). Reused for two groups with different
+// framing: the Assets section (cash / property / custom assets — Type and Equity
+// columns shown) and the Liabilities section's custom liabilities (a single
+// type, so those columns are hidden and the labels read "liability"/"Owed").
 export const AssetTable = (props: AssetTableProps) => {
+  const {
+    showTypeColumn = true,
+    showEquityColumn = true,
+    searchLabel = 'Search assets',
+    itemLabel = 'asset',
+    itemLabelPlural = 'assets',
+    balanceHeader = 'Balance',
+  } = props;
+
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -203,6 +192,53 @@ export const AssetTable = (props: AssetTableProps) => {
     onDelete: props.onAssetDelete,
   };
 
+  // Sortable data columns, built from props so the Type column can be dropped
+  // and the balance header relabelled per group.
+  const columns = useMemo<AssetColumn[]>(() => {
+    const cols: AssetColumn[] = [
+      {
+        id: 'Name',
+        label: 'Name',
+        numeric: false,
+        value: (r) => r.asset.Name,
+        render: (r) => r.asset.Name,
+      },
+      {
+        id: 'Provider',
+        label: 'Provider',
+        numeric: false,
+        value: (r) => r.asset.Provider,
+        render: (r) => r.asset.Provider,
+      },
+    ];
+    if (showTypeColumn) {
+      cols.push({
+        id: 'AssetType',
+        label: 'Type',
+        numeric: false,
+        value: (r) => ASSET_TYPE_LABELS[r.asset.AssetType],
+        render: (r) => ASSET_TYPE_LABELS[r.asset.AssetType],
+      });
+    }
+    cols.push(
+      {
+        id: 'Balance',
+        label: balanceHeader,
+        numeric: true,
+        value: (r) => r.asset.Balance,
+        render: (r) => formatCurrency(r.asset.Balance),
+      },
+      {
+        id: 'GrowthRate',
+        label: 'Rate',
+        numeric: true,
+        value: (r) => r.asset.GrowthRate,
+        render: (r) => formatPercent(r.asset.GrowthRate),
+      }
+    );
+    return cols;
+  }, [showTypeColumn, balanceHeader]);
+
   // Engine-derived rows: today's home equity for a property linked to a
   // mortgage that still exists (7.2). Memoized so it recomputes only when the
   // assets or loans change.
@@ -220,8 +256,7 @@ export const AssetTable = (props: AssetTableProps) => {
     });
   }, [props.assets, props.loans, today]);
 
-  const column =
-    ASSET_COLUMNS.find((c) => c.id === sortColumn) ?? ASSET_COLUMNS[0];
+  const column = columns.find((c) => c.id === sortColumn) ?? columns[0];
   const sortedRows = useMemo(
     () => sortBy(rows, column.value, sortDirection),
     [rows, column, sortDirection]
@@ -264,14 +299,11 @@ export const AssetTable = (props: AssetTableProps) => {
 
   return (
     <>
-      <TableSearchField
-        value={query}
-        onChange={setQuery}
-        label="Search assets"
-      />
+      <TableSearchField value={query} onChange={setQuery} label={searchLabel} />
       <BulkActionsToolbar
         count={selectedAssets.length}
-        itemLabel="asset"
+        itemLabel={itemLabel}
+        itemLabelPlural={itemLabelPlural}
         onDuplicate={onBulkDuplicate}
         onDelete={onBulkDelete}
         onClear={selection.clear}
@@ -279,7 +311,7 @@ export const AssetTable = (props: AssetTableProps) => {
 
       {noMatches ? (
         <Typography color="text.secondary" sx={{ py: 2 }}>
-          No assets match “{query}”.
+          No {itemLabelPlural} match “{query}”.
         </Typography>
       ) : isMobile ? (
         <Box>
@@ -290,6 +322,7 @@ export const AssetTable = (props: AssetTableProps) => {
               handlers={handlers}
               selected={selection.isSelected(row.asset.Id)}
               onSelect={() => selection.toggle(row.asset.Id)}
+              showType={showTypeColumn}
             />
           ))}
         </Box>
@@ -306,11 +339,11 @@ export const AssetTable = (props: AssetTableProps) => {
                       selection.setMany(visibleIds, e.target.checked)
                     }
                     slotProps={{
-                      input: { 'aria-label': 'Select all assets' },
+                      input: { 'aria-label': `Select all ${itemLabelPlural}` },
                     }}
                   />
                 </TableCell>
-                {ASSET_COLUMNS.map((col) => (
+                {columns.map((col) => (
                   <TableCell
                     key={col.id}
                     align={col.numeric ? 'right' : 'left'}
@@ -327,7 +360,9 @@ export const AssetTable = (props: AssetTableProps) => {
                     </TableSortLabel>
                   </TableCell>
                 ))}
-                <TableCell align="right">Equity</TableCell>
+                {showEquityColumn && (
+                  <TableCell align="right">Equity</TableCell>
+                )}
                 <TableCell>Actions</TableCell>
               </TableRow>
             </TableHead>
@@ -347,18 +382,17 @@ export const AssetTable = (props: AssetTableProps) => {
                         }}
                       />
                     </TableCell>
-                    <TableCell>{row.asset.Name}</TableCell>
-                    <TableCell>{row.asset.Provider}</TableCell>
-                    <TableCell>
-                      {ASSET_TYPE_LABELS[row.asset.AssetType]}
-                    </TableCell>
-                    <TableCell align="right">
-                      {formatCurrency(row.asset.Balance)}
-                    </TableCell>
-                    <TableCell align="right">
-                      {formatPercent(row.asset.GrowthRate)}
-                    </TableCell>
-                    <TableCell align="right">{equityText(row)}</TableCell>
+                    {columns.map((col) => (
+                      <TableCell
+                        key={col.id}
+                        align={col.numeric ? 'right' : 'left'}
+                      >
+                        {col.render(row)}
+                      </TableCell>
+                    ))}
+                    {showEquityColumn && (
+                      <TableCell align="right">{equityText(row)}</TableCell>
+                    )}
                     <TableCell>
                       <EntityRowActions
                         actions={assetActions(row.asset, handlers)}
@@ -371,16 +405,29 @@ export const AssetTable = (props: AssetTableProps) => {
             <TableFooter>
               <TableRow>
                 <TableCell padding="checkbox" />
-                <TableCell>
-                  <strong>Totals</strong>
-                </TableCell>
-                <TableCell />
-                <TableCell />
-                <TableCell align="right">
-                  <strong>{formatCurrency(totalBalance)}</strong>
-                </TableCell>
-                <TableCell />
-                <TableCell />
+                {columns.map((col) => {
+                  if (col.id === 'Name') {
+                    return (
+                      <TableCell key={col.id}>
+                        <strong>Totals</strong>
+                      </TableCell>
+                    );
+                  }
+                  if (col.id === 'Balance') {
+                    return (
+                      <TableCell key={col.id} align="right">
+                        <strong>{formatCurrency(totalBalance)}</strong>
+                      </TableCell>
+                    );
+                  }
+                  return (
+                    <TableCell
+                      key={col.id}
+                      align={col.numeric ? 'right' : 'left'}
+                    />
+                  );
+                })}
+                {showEquityColumn && <TableCell />}
                 <TableCell />
               </TableRow>
             </TableFooter>
@@ -398,4 +445,11 @@ export type AssetTableProps = {
   onAssetDelete: (a: Asset) => void;
   onAssetClone: (a: Asset) => void;
   onAssetBulkDelete: (assets: Asset[]) => void;
+  // Display tuning so the same table serves the Assets and Liabilities groups.
+  showTypeColumn?: boolean;
+  showEquityColumn?: boolean;
+  searchLabel?: string;
+  itemLabel?: string;
+  itemLabelPlural?: string;
+  balanceHeader?: string;
 };

--- a/src/chart/forecast-chart.tsx
+++ b/src/chart/forecast-chart.tsx
@@ -11,6 +11,7 @@ import {
 import { LineChart } from '@mui/x-charts/LineChart';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { ScenarioInput } from '../models/forecast-model';
 import { getDefaultHorizon } from '../helpers/forecast-helpers';
 import {
@@ -34,6 +35,7 @@ import { ForecastDataTable } from './forecast-data-table';
 interface ForecastChartProps {
   loans: Loan[];
   investments: Investment[];
+  assets?: Asset[];
   scenario?: ScenarioInput;
   height?: number;
 }
@@ -64,6 +66,7 @@ const RANGE_LABELS: { value: TimeRange; label: string }[] = [
 export const ForecastChart = ({
   loans,
   investments,
+  assets,
   scenario,
   height,
 }: ForecastChartProps) => {
@@ -79,6 +82,7 @@ export const ForecastChart = ({
 
   // Baseline (solid) lines always; when a scenario is active, add color-matched
   // dotted overlay lines (suffix-tagged ids) on top — originals remain (4.3).
+  const assetList = useMemo(() => assets ?? [], [assets]);
   const fullData = useMemo<ForecastChartData>(() => {
     const horizon = getDefaultHorizon(loans, investments, today);
     const baseline = buildForecastChartData(
@@ -86,7 +90,8 @@ export const ForecastChart = ({
       investments,
       horizon,
       undefined,
-      today
+      today,
+      assetList
     );
     if (!scenario) {
       return baseline;
@@ -96,7 +101,8 @@ export const ForecastChart = ({
       investments,
       horizon,
       scenario,
-      today
+      today,
+      assetList
     );
     const scenarioSeries = overlay.series.map((s) => ({
       ...s,
@@ -107,7 +113,7 @@ export const ForecastChart = ({
       dates: baseline.dates,
       series: [...baseline.series, ...scenarioSeries],
     };
-  }, [loans, investments, scenario, today]);
+  }, [loans, investments, assetList, scenario, today]);
 
   const [range, setRange] = useState<TimeRange>('full');
 

--- a/src/components/app-error-boundary.tsx
+++ b/src/components/app-error-boundary.tsx
@@ -14,9 +14,12 @@ export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
     state: {
       loans,
       investments,
+      assets,
+      scenarios,
       sampleDataLoaded,
       stashedLoans,
       stashedInvestments,
+      stashedAssets,
     },
   } = useFinanceData();
 
@@ -25,7 +28,9 @@ export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
   const realInvestments = sampleDataLoaded
     ? (stashedInvestments ?? [])
     : investments;
-  const canExport = realLoans.length > 0 || realInvestments.length > 0;
+  const realAssets = sampleDataLoaded ? (stashedAssets ?? []) : assets;
+  const canExport =
+    realLoans.length > 0 || realInvestments.length > 0 || realAssets.length > 0;
 
   return (
     <ErrorBoundary
@@ -33,7 +38,14 @@ export const AppErrorBoundary = ({ children }: { children: ReactNode }) => {
         <AppErrorFallback
           error={error}
           onReload={() => window.location.reload()}
-          onExport={() => downloadJsonExport(realLoans, realInvestments)}
+          onExport={() =>
+            downloadJsonExport(
+              realLoans,
+              realInvestments,
+              scenarios,
+              realAssets
+            )
+          }
           canExport={canExport}
         />
       )}

--- a/src/components/bulk-actions-toolbar.tsx
+++ b/src/components/bulk-actions-toolbar.tsx
@@ -9,6 +9,9 @@ export interface BulkActionsToolbarProps {
   count: number;
   // Singular noun for the entity kind, e.g. "loan" / "investment".
   itemLabel: string;
+  // Plural noun, when simple "+s" is wrong (e.g. "liability" → "liabilities").
+  // Defaults to `${itemLabel}s`.
+  itemLabelPlural?: string;
   onDuplicate: () => void;
   onDelete: () => void;
   onClear: () => void;
@@ -17,6 +20,7 @@ export interface BulkActionsToolbarProps {
 export const BulkActionsToolbar = ({
   count,
   itemLabel,
+  itemLabelPlural,
   onDuplicate,
   onDelete,
   onClear,
@@ -24,7 +28,7 @@ export const BulkActionsToolbar = ({
   if (count === 0) {
     return null;
   }
-  const noun = count === 1 ? itemLabel : `${itemLabel}s`;
+  const noun = count === 1 ? itemLabel : (itemLabelPlural ?? `${itemLabel}s`);
   return (
     <Toolbar
       disableGutters

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -74,7 +74,9 @@ export const OnboardingEmptyState = ({
 export interface SectionEmptyStateProps {
   message: string;
   actionLabel: string;
-  onAction: () => void;
+  // Receives the click event so an action can anchor a menu to the button
+  // (callers that just open a dialog can ignore it).
+  onAction: (event: MouseEvent<HTMLElement>) => void;
 }
 
 export const SectionEmptyState = ({

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,11 +1,14 @@
+import { MouseEvent } from 'react';
 import { Box, Button, Stack, Typography } from '@mui/material';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
 // Onboarding & empty states (roadmap 0.9).
 //
 // Two flavors:
 //  - <OnboardingEmptyState>: shown when there are NO loans, investments, OR
-//    assets. Explains what PathWise does and offers the first-run CTAs (add a
-//    loan, an investment, an asset, or load sample data).
+//    assets. Explains what PathWise does and offers the first-run CTAs, which
+//    open the same "Add Asset" / "Add Liability" type menus as the command bar
+//    (anchored to the clicked button), or load sample data.
 //  - <SectionEmptyState>: a lighter per-section empty state shown when only ONE
 //    collection is empty (e.g. loans exist but investments don't), with that
 //    section's single "Add" CTA.
@@ -14,16 +17,15 @@ import { Box, Button, Stack, Typography } from '@mui/material';
 // read correctly in light and dark mode.
 
 export interface OnboardingEmptyStateProps {
-  onAddLoan: () => void;
-  onAddInvestment: () => void;
-  onAddAsset: () => void;
+  // Receive the click event so the caller can anchor its type menu to the button.
+  onAddAsset: (event: MouseEvent<HTMLElement>) => void;
+  onAddLiability: (event: MouseEvent<HTMLElement>) => void;
   onLoadSampleData: () => void;
 }
 
 export const OnboardingEmptyState = ({
-  onAddLoan,
-  onAddInvestment,
   onAddAsset,
+  onAddLiability,
   onLoadSampleData,
 }: OnboardingEmptyStateProps) => (
   <Box sx={{ textAlign: 'center', paddingY: 5, paddingX: 2 }}>
@@ -35,24 +37,32 @@ export const OnboardingEmptyState = ({
       color="text.secondary"
       sx={{ maxWidth: 560, marginX: 'auto', marginBottom: 3 }}
     >
-      PathWise forecasts your net worth across all of your loans, investments,
-      and assets at once, so you can see your whole financial position and
-      decide where your extra money should go. Add your first entry, or load
-      some sample data to explore.
+      PathWise forecasts your net worth across all of your assets and
+      liabilities at once — investments, cash, property, loans, and more — so
+      you can see your whole financial position and decide where your extra
+      money should go. Add your first entry, or load some sample data to
+      explore.
     </Typography>
     <Stack
       direction={{ xs: 'column', sm: 'row' }}
       spacing={1.5}
       sx={{ justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap' }}
     >
-      <Button variant="contained" onClick={onAddLoan}>
-        Add your first loan
+      <Button
+        variant="contained"
+        endIcon={<ArrowDropDownIcon />}
+        aria-haspopup="menu"
+        onClick={onAddAsset}
+      >
+        Add an asset
       </Button>
-      <Button variant="contained" onClick={onAddInvestment}>
-        Add your first investment
-      </Button>
-      <Button variant="contained" onClick={onAddAsset}>
-        Add your first asset
+      <Button
+        variant="contained"
+        endIcon={<ArrowDropDownIcon />}
+        aria-haspopup="menu"
+        onClick={onAddLiability}
+      >
+        Add a liability
       </Button>
       <Button variant="outlined" onClick={onLoadSampleData}>
         Load sample data

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -3,9 +3,9 @@ import { Box, Button, Stack, Typography } from '@mui/material';
 // Onboarding & empty states (roadmap 0.9).
 //
 // Two flavors:
-//  - <OnboardingEmptyState>: shown when there are NO loans AND NO investments.
-//    Explains what PathWise does and offers all three first-run CTAs (add a
-//    loan, add an investment, load sample data).
+//  - <OnboardingEmptyState>: shown when there are NO loans, investments, OR
+//    assets. Explains what PathWise does and offers the first-run CTAs (add a
+//    loan, an investment, an asset, or load sample data).
 //  - <SectionEmptyState>: a lighter per-section empty state shown when only ONE
 //    collection is empty (e.g. loans exist but investments don't), with that
 //    section's single "Add" CTA.
@@ -16,12 +16,14 @@ import { Box, Button, Stack, Typography } from '@mui/material';
 export interface OnboardingEmptyStateProps {
   onAddLoan: () => void;
   onAddInvestment: () => void;
+  onAddAsset: () => void;
   onLoadSampleData: () => void;
 }
 
 export const OnboardingEmptyState = ({
   onAddLoan,
   onAddInvestment,
+  onAddAsset,
   onLoadSampleData,
 }: OnboardingEmptyStateProps) => (
   <Box sx={{ textAlign: 'center', paddingY: 5, paddingX: 2 }}>
@@ -33,21 +35,24 @@ export const OnboardingEmptyState = ({
       color="text.secondary"
       sx={{ maxWidth: 560, marginX: 'auto', marginBottom: 3 }}
     >
-      PathWise forecasts your net worth across all of your loans and investments
-      at once, so you can see your whole financial position and decide where
-      your extra money should go. Add your first entry, or load some sample data
-      to explore.
+      PathWise forecasts your net worth across all of your loans, investments,
+      and assets at once, so you can see your whole financial position and
+      decide where your extra money should go. Add your first entry, or load
+      some sample data to explore.
     </Typography>
     <Stack
       direction={{ xs: 'column', sm: 'row' }}
       spacing={1.5}
-      sx={{ justifyContent: 'center', alignItems: 'center' }}
+      sx={{ justifyContent: 'center', alignItems: 'center', flexWrap: 'wrap' }}
     >
       <Button variant="contained" onClick={onAddLoan}>
         Add your first loan
       </Button>
       <Button variant="contained" onClick={onAddInvestment}>
         Add your first investment
+      </Button>
+      <Button variant="contained" onClick={onAddAsset}>
+        Add your first asset
       </Button>
       <Button variant="outlined" onClick={onLoadSampleData}>
         Load sample data

--- a/src/dashboard/milestone-callouts.tsx
+++ b/src/dashboard/milestone-callouts.tsx
@@ -3,24 +3,28 @@ import dayjs from 'dayjs';
 import { Stack, Typography } from '@mui/material';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { computeMilestones } from '../helpers/milestone-helpers';
 import { formatCurrency } from '../helpers/format-helpers';
 
 interface MilestoneCalloutsProps {
   loans: Loan[];
   investments: Investment[];
+  assets: Asset[];
 }
 
 // Dashboard milestone callouts (Phase 3.2): projected debt-free date and net
 // worth at +5y / +10y / +30y, derived from the forecast engine via
-// computeMilestones. Debt-free is shown only when there are loans.
+// computeMilestones. Assets (Phase 7) flow into the net-worth figures. Debt-free
+// is shown only when there are loans.
 export const MilestoneCallouts = ({
   loans,
   investments,
+  assets,
 }: MilestoneCalloutsProps) => {
   const { debtFreeDate, netWorthAt } = useMemo(
-    () => computeMilestones(loans, investments),
-    [loans, investments]
+    () => computeMilestones(loans, investments, undefined, assets),
+    [loans, investments, assets]
   );
 
   return (

--- a/src/dashboard/net-worth-summary.tsx
+++ b/src/dashboard/net-worth-summary.tsx
@@ -2,25 +2,29 @@ import { useMemo } from 'react';
 import { Box, Card, CardContent, Typography } from '@mui/material';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { summarizePositions } from '../helpers/summary-helpers';
 import { formatCurrency } from '../helpers/format-helpers';
 
 interface NetWorthSummaryProps {
   loans: Loan[];
   investments: Investment[];
+  assets: Asset[];
 }
 
 // Net-worth dashboard summary cards (Phase 3.1). Total assets, total debt, net
 // worth, and monthly commitments at today's anchor — the same numbers the
-// forecast chart starts from (via summarizePositions). Net worth is colored by
-// sign so an underwater position reads at a glance.
+// forecast chart starts from (via summarizePositions). Assets (cash/property/
+// custom, Phase 7) roll into the totals. Net worth is colored by sign so an
+// underwater position reads at a glance.
 export const NetWorthSummary = ({
   loans,
   investments,
+  assets,
 }: NetWorthSummaryProps) => {
   const summary = useMemo(
-    () => summarizePositions(loans, investments),
-    [loans, investments]
+    () => summarizePositions(loans, investments, undefined, assets),
+    [loans, investments, assets]
   );
 
   const cards: {

--- a/src/data-manager/data-manager.tsx
+++ b/src/data-manager/data-manager.tsx
@@ -7,6 +7,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import { useFinanceData } from '../state/use-finance-data';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { DataSnapshot } from '../state/finance-reducer';
 import {
@@ -20,6 +21,7 @@ interface PendingImport {
   loans: Loan[];
   investments: Investment[];
   scenarios: Scenario[];
+  assets: Asset[];
   sections: ImportPreviewSection[];
 }
 
@@ -37,10 +39,12 @@ export const DataManager = () => {
     state: {
       loans,
       investments,
+      assets,
       scenarios,
       sampleDataLoaded,
       stashedLoans,
       stashedInvestments,
+      stashedAssets,
     },
     importMerge,
     restoreData,
@@ -61,12 +65,14 @@ export const DataManager = () => {
   const realInvestments = sampleDataLoaded
     ? (stashedInvestments ?? [])
     : investments;
+  const realAssets = sampleDataLoaded ? (stashedAssets ?? []) : assets;
 
-  const hasData = realLoans.length > 0 || realInvestments.length > 0;
+  const hasData =
+    realLoans.length > 0 || realInvestments.length > 0 || realAssets.length > 0;
 
   const handleExport = () => {
     try {
-      downloadJsonExport(realLoans, realInvestments, scenarios);
+      downloadJsonExport(realLoans, realInvestments, scenarios, realAssets);
       setExportMessage('Data exported successfully!');
     } catch (error) {
       // Log full error details for debugging
@@ -106,6 +112,7 @@ export const DataManager = () => {
           loans: importedLoans,
           investments: importedInvestments,
           scenarios: importedScenarios,
+          assets: importedAssets,
         } = importFromJson(content);
 
         // Compute the add-vs-overwrite preview against the *real* data (the
@@ -118,14 +125,17 @@ export const DataManager = () => {
           importedInvestments
         );
         const scenarioPreview = previewMerge(scenarios, importedScenarios);
+        const assetPreview = previewMerge(realAssets, importedAssets);
 
         setPendingImport({
           loans: importedLoans,
           investments: importedInvestments,
           scenarios: importedScenarios,
+          assets: importedAssets,
           sections: [
             { label: 'Loans', ...loanPreview },
             { label: 'Investments', ...investmentPreview },
+            { label: 'Assets', ...assetPreview },
             { label: 'Scenarios', ...scenarioPreview },
           ],
         });
@@ -157,9 +167,11 @@ export const DataManager = () => {
     const snapshot: DataSnapshot = {
       loans,
       investments,
+      assets,
       scenarios,
       stashedLoans,
       stashedInvestments,
+      stashedAssets,
     };
 
     const added = pendingImport.sections.reduce(
@@ -174,7 +186,8 @@ export const DataManager = () => {
     importMerge(
       pendingImport.loans,
       pendingImport.investments,
-      pendingImport.scenarios
+      pendingImport.scenarios,
+      pendingImport.assets
     );
     setPendingImport(null);
     setImportUndo({

--- a/src/data-manager/export-download.ts
+++ b/src/data-manager/export-download.ts
@@ -1,5 +1,6 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { exportToJson } from '../helpers/data-helpers';
 
@@ -10,9 +11,10 @@ import { exportToJson } from '../helpers/data-helpers';
 export const downloadJsonExport = (
   loans: Loan[],
   investments: Investment[],
-  scenarios: Scenario[] = []
+  scenarios: Scenario[] = [],
+  assets: Asset[] = []
 ): void => {
-  const jsonData = exportToJson(loans, investments, scenarios);
+  const jsonData = exportToJson(loans, investments, scenarios, assets);
   const blob = new Blob([jsonData], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');

--- a/src/helpers/asset-helpers.test.ts
+++ b/src/helpers/asset-helpers.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { Asset, AssetType } from '../models/asset-model';
+import { CompoundingFrequency, Investment } from '../models/investment-model';
+import { Loan } from '../models/loan-model';
+import {
+  assetNetWorthSign,
+  forecastAsset,
+  getAssetValueToday,
+  isAssetLiability,
+} from './asset-helpers';
+import {
+  forecastHomeEquity,
+  forecastInvestment,
+  forecastLoan,
+  forecastNetWorth,
+} from './forecast-helpers';
+import { buildForecastChartData } from './forecast-series';
+import { summarizePositions } from './summary-helpers';
+import { computeMilestones } from './milestone-helpers';
+
+// Charter (§4) coverage for Phase 7's simple-asset math. forecastAsset is a
+// plain geometric series anchored to today's balance, so its oracle is a
+// hand-evaluated compound-growth formula; the integration tests pin the
+// net-worth roll-up (assets add, custom liabilities subtract).
+
+const baseAsset = (overrides: Partial<Asset> = {}): Asset => ({
+  Id: 'asset-1',
+  Provider: 'Sample Bank',
+  Name: 'HYSA',
+  AssetType: AssetType.Cash,
+  Balance: 10000,
+  GrowthRate: 0,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...overrides,
+});
+
+const TODAY = new Date(2025, 0, 1);
+
+describe('isAssetLiability / assetNetWorthSign', () => {
+  it('treats only the custom liability as a liability', () => {
+    expect(isAssetLiability(baseAsset({ AssetType: AssetType.Cash }))).toBe(
+      false
+    );
+    expect(isAssetLiability(baseAsset({ AssetType: AssetType.Property }))).toBe(
+      false
+    );
+    expect(
+      isAssetLiability(baseAsset({ AssetType: AssetType.CustomAsset }))
+    ).toBe(false);
+    expect(
+      isAssetLiability(baseAsset({ AssetType: AssetType.CustomLiability }))
+    ).toBe(true);
+  });
+
+  it('signs ordinary assets +1 and liabilities −1', () => {
+    expect(assetNetWorthSign(baseAsset({ AssetType: AssetType.Cash }))).toBe(1);
+    expect(
+      assetNetWorthSign(baseAsset({ AssetType: AssetType.CustomLiability }))
+    ).toBe(-1);
+  });
+});
+
+describe('getAssetValueToday', () => {
+  it('returns the balance rounded to cents', () => {
+    expect(getAssetValueToday(baseAsset({ Balance: 1234.567 }))).toBe(1234.57);
+  });
+});
+
+describe('forecastAsset', () => {
+  it('anchors index 0 at today’s balance', () => {
+    const horizon = new Date(2030, 0, 1);
+    const series = forecastAsset(baseAsset({ Balance: 5000 }), horizon, TODAY);
+    expect(series[0].Value).toBe(5000);
+    expect(series[0].Date).toEqual(TODAY);
+  });
+
+  // Reference 1: monthly compounding. 12% APY → 1% monthly. 10000·1.01^n,
+  // hand-evaluated: month 1 = 10100, month 12 = 10000·1.01^12 = 11268.2503…
+  it('compounds monthly against a hand-derived oracle', () => {
+    const horizon = new Date(2026, 0, 1);
+    const series = forecastAsset(
+      baseAsset({ Balance: 10000, GrowthRate: 12 }),
+      horizon,
+      TODAY
+    );
+    expect(series[1].Value).toBe(10100);
+    expect(series[12].Value).toBe(11268.25);
+  });
+
+  // Reference 2: quarterly compounding. 8%/yr → 2% per quarter, boundaries at
+  // months 3,6,9,12. 10000·1.02^4 = 10824.3216 at one year; months between
+  // boundaries hold flat.
+  it('compounds only on quarterly boundaries', () => {
+    const horizon = new Date(2026, 0, 1);
+    const series = forecastAsset(
+      baseAsset({
+        Balance: 10000,
+        GrowthRate: 8,
+        CompoundingPeriod: CompoundingFrequency.Quarterly,
+      }),
+      horizon,
+      TODAY
+    );
+    expect(series[1].Value).toBe(10000); // no boundary yet
+    expect(series[2].Value).toBe(10000);
+    expect(series[3].Value).toBe(10200); // first quarter
+    expect(series[12].Value).toBe(10824.32);
+  });
+
+  // Reference 3: annual compounding holds flat for 11 months then steps once.
+  it('compounds once a year for annual compounding', () => {
+    const horizon = new Date(2026, 0, 1);
+    const series = forecastAsset(
+      baseAsset({
+        Balance: 10000,
+        GrowthRate: 5,
+        CompoundingPeriod: CompoundingFrequency.Annually,
+      }),
+      horizon,
+      TODAY
+    );
+    expect(series[11].Value).toBe(10000);
+    expect(series[12].Value).toBe(10500);
+  });
+
+  it('defaults to monthly compounding when CompoundingPeriod is unset', () => {
+    const horizon = new Date(2026, 0, 1);
+    const asset = baseAsset({ Balance: 10000, GrowthRate: 12 });
+    delete asset.CompoundingPeriod;
+    const series = forecastAsset(asset, horizon, TODAY);
+    expect(series[1].Value).toBe(10100);
+    expect(series[12].Value).toBe(11268.25);
+  });
+
+  it('declines geometrically toward zero for a negative growth rate', () => {
+    const horizon = new Date(2026, 0, 1);
+    const series = forecastAsset(
+      baseAsset({
+        Balance: 20000,
+        GrowthRate: -12,
+        AssetType: AssetType.CustomAsset,
+      }),
+      horizon,
+      TODAY
+    );
+    expect(series[1].Value).toBe(19800); // 20000·0.99
+    expect(series[12].Value).toBeGreaterThan(0);
+    expect(series[12].Value).toBeLessThan(20000);
+  });
+
+  it('returns only the anchor when the horizon is today', () => {
+    const series = forecastAsset(baseAsset({ Balance: 7500 }), TODAY, TODAY);
+    expect(series).toHaveLength(1);
+    expect(series[0].Value).toBe(7500);
+  });
+
+  // Property: a non-negative balance can never produce a negative value, for any
+  // rate above −100%/yr (the only regime where a monthly factor stays positive).
+  it('never goes negative for a non-negative balance (property)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1_000_000, noNaN: true }),
+        fc.double({ min: -90, max: 90, noNaN: true }),
+        (balance, rate) => {
+          const series = forecastAsset(
+            baseAsset({ Balance: balance, GrowthRate: rate }),
+            new Date(2035, 0, 1),
+            TODAY
+          );
+          return series.every((p) => p.Value >= 0);
+        }
+      )
+    );
+  });
+
+  // Property: a positive growth rate is monotonically non-decreasing.
+  it('is non-decreasing for a non-negative growth rate (property)', () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 500_000, noNaN: true }),
+        fc.double({ min: 0, max: 50, noNaN: true }),
+        (balance, rate) => {
+          const series = forecastAsset(
+            baseAsset({ Balance: balance, GrowthRate: rate }),
+            new Date(2032, 0, 1),
+            TODAY
+          );
+          for (let i = 1; i < series.length; i++) {
+            if (series[i].Value < series[i - 1].Value - 1e-6) return false;
+          }
+          return true;
+        }
+      )
+    );
+  });
+});
+
+describe('forecastNetWorth with assets', () => {
+  const horizon = new Date(2026, 0, 1);
+
+  it('adds ordinary assets and subtracts custom liabilities at the anchor', () => {
+    const cash = baseAsset({ Id: 'cash', Balance: 10000, GrowthRate: 0 });
+    const liability = baseAsset({
+      Id: 'liab',
+      Name: 'Loan to friend',
+      AssetType: AssetType.CustomLiability,
+      Balance: 4000,
+      GrowthRate: 0,
+    });
+    const nw = forecastNetWorth([], [], horizon, undefined, TODAY, [
+      cash,
+      liability,
+    ]);
+    // 10000 (cash) − 4000 (liability) = 6000.
+    expect(nw[0].Value).toBe(6000);
+  });
+
+  it('matches the component sum month for month (cross-consistency)', () => {
+    const loan: Loan = {
+      Id: 'l1',
+      Provider: 'Bank',
+      Name: 'Loan',
+      InterestRate: 5,
+      StartDate: new Date(2020, 0, 1),
+      EndDate: new Date(2030, 0, 1),
+      Principal: 20000,
+      CurrentAmount: 15000,
+      MonthlyPayment: 300,
+    };
+    const investment: Investment = {
+      Id: 'i1',
+      Provider: 'Brokerage',
+      Name: 'Fund',
+      StartDate: new Date(2020, 0, 1),
+      StartingBalance: 5000,
+      AverageReturnRate: 6,
+      CompoundingPeriod: CompoundingFrequency.Monthly,
+      CurrentValue: 8000,
+    };
+    const cash = baseAsset({ Id: 'cash', Balance: 12000, GrowthRate: 3 });
+    const liability = baseAsset({
+      Id: 'liab',
+      AssetType: AssetType.CustomLiability,
+      Balance: 2000,
+      GrowthRate: 6,
+    });
+
+    const nw = forecastNetWorth(
+      [loan],
+      [investment],
+      horizon,
+      undefined,
+      TODAY,
+      [cash, liability]
+    );
+    const loanSeries = forecastLoan(loan, horizon, 0, TODAY);
+    const investmentSeries = forecastInvestment(investment, horizon, 0, TODAY);
+    const cashSeries = forecastAsset(cash, horizon, TODAY);
+    const liabilitySeries = forecastAsset(liability, horizon, TODAY);
+
+    // Net worth must equal investments + cash − loan − liability at every month,
+    // reusing the same per-entity series (PRECISION.md: round the net sum once).
+    for (let m = 0; m < nw.length; m++) {
+      const expected =
+        Math.round(
+          (investmentSeries[m].Value +
+            cashSeries[m].Value -
+            loanSeries[m].Value -
+            liabilitySeries[m].Value) *
+            100
+        ) / 100;
+      expect(nw[m].Value).toBe(expected);
+    }
+    // Spot-check the anchor exactly: 8000 + 12000 − 15000 − 2000 = 3000.
+    expect(nw[0].Value).toBe(3000);
+  });
+});
+
+describe('forecastHomeEquity', () => {
+  const horizon = new Date(2030, 0, 1);
+  const property = baseAsset({
+    Id: 'home',
+    Name: 'Home',
+    AssetType: AssetType.Property,
+    Balance: 400000,
+    GrowthRate: 0,
+  });
+  const mortgage: Loan = {
+    Id: 'm1',
+    Provider: 'Bank',
+    Name: 'Mortgage',
+    InterestRate: 6,
+    StartDate: new Date(2020, 0, 1),
+    EndDate: new Date(2050, 0, 1),
+    Principal: 350000,
+    CurrentAmount: 300000,
+    MonthlyPayment: 2000,
+  };
+
+  it('is property value minus the linked loan balance, pointwise', () => {
+    const equity = forecastHomeEquity(property, mortgage, horizon, TODAY);
+    const propertySeries = forecastAsset(property, horizon, TODAY);
+    const loanSeries = forecastLoan(mortgage, horizon, 0, TODAY);
+    expect(equity[0].Value).toBe(100000); // 400000 − 300000
+    // Equity grows as the loan amortizes (flat property value here).
+    expect(equity[12].Value).toBe(
+      Math.round((propertySeries[12].Value - loanSeries[12].Value) * 100) / 100
+    );
+    expect(equity[12].Value).toBeGreaterThan(equity[0].Value);
+  });
+});
+
+describe('buildForecastChartData with assets', () => {
+  const horizon = new Date(2026, 0, 1);
+
+  it('emits an asset line and folds signed assets into net worth', () => {
+    const cash = baseAsset({ Id: 'cash', Name: 'Cash', Balance: 10000 });
+    const liability = baseAsset({
+      Id: 'liab',
+      Name: 'IOU',
+      AssetType: AssetType.CustomLiability,
+      Balance: 3000,
+    });
+    const data = buildForecastChartData([], [], horizon, undefined, TODAY, [
+      cash,
+      liability,
+    ]);
+    const cashSeries = data.series.find((s) => s.id === 'cash');
+    const liabilitySeries = data.series.find((s) => s.id === 'liab');
+    const netWorth = data.series.find((s) => s.kind === 'networth');
+
+    expect(cashSeries?.kind).toBe('asset');
+    expect(liabilitySeries?.kind).toBe('asset');
+    expect(cashSeries?.values[0]).toBe(10000);
+    expect(liabilitySeries?.values[0]).toBe(3000);
+    // Net worth nets the liability out: 10000 − 3000 = 7000.
+    expect(netWorth?.values[0]).toBe(7000);
+  });
+});
+
+describe('summarizePositions with assets', () => {
+  it('rolls ordinary assets into assets and liabilities into debt', () => {
+    const cash = baseAsset({ Id: 'cash', Balance: 10000 });
+    const liability = baseAsset({
+      Id: 'liab',
+      AssetType: AssetType.CustomLiability,
+      Balance: 2500,
+    });
+    const summary = summarizePositions([], [], TODAY, [cash, liability]);
+    expect(summary.totalAssets).toBe(10000);
+    expect(summary.totalDebt).toBe(2500);
+    expect(summary.netWorth).toBe(7500);
+    // Passive holdings add no monthly commitment.
+    expect(summary.monthlyCommitments).toBe(0);
+  });
+});
+
+describe('computeMilestones with assets', () => {
+  it('includes asset value in the net-worth milestones', () => {
+    const cash = baseAsset({ Id: 'cash', Balance: 50000, GrowthRate: 0 });
+    const withAsset = computeMilestones([], [], TODAY, [cash]);
+    const withoutAsset = computeMilestones([], [], TODAY, []);
+    const at5With = withAsset.netWorthAt.find((m) => m.years === 5)?.value ?? 0;
+    const at5Without =
+      withoutAsset.netWorthAt.find((m) => m.years === 5)?.value ?? 0;
+    expect(at5With - at5Without).toBe(50000);
+  });
+});

--- a/src/helpers/asset-helpers.ts
+++ b/src/helpers/asset-helpers.ts
@@ -1,0 +1,78 @@
+import dayjs from 'dayjs';
+import { Asset, AssetType } from '../models/asset-model';
+import { CompoundingFrequency } from '../models/investment-model';
+import { ForecastPoint } from '../models/forecast-model';
+import { getPeriodsPerYear } from './investment-helpers';
+
+// Phase 7 forecast math for simple holdings (cash / property / custom). A pure,
+// leaf module (D7): it computes the value series for a single Asset and never
+// imports the rest of the forecast engine, so forecast-helpers can depend on it
+// without a cycle. The net-worth composition (forecastNetWorth, the chart
+// series, the dashboard summary) layers these on top of loans/investments.
+
+const roundToCents = (value: number): number => Math.round(value * 100) / 100;
+
+// Number of whole month-steps from start to end, rounded up so a series always
+// spans at least to the requested end date (never negative). Identical to the
+// axis forecastLoan/forecastInvestment use, so asset points line up index-for-
+// index with the rest of the engine and series can be summed pointwise.
+const getMonthsBetween = (start: Date, end: Date): number =>
+  Math.max(0, Math.ceil(dayjs(end).diff(dayjs(start), 'month', true)));
+
+// True for the asset types that subtract from net worth. Only the custom
+// liability does; cash and property are always positive holdings.
+export const isAssetLiability = (asset: Asset): boolean =>
+  asset.AssetType === AssetType.CustomLiability;
+
+// Signed contribution to net worth: ordinary assets add (+1), liabilities
+// subtract (−1). The displayed/forecast Balance series stays positive in both
+// cases (a liability shows its outstanding amount, like a loan balance); only
+// the net-worth roll-up applies the sign.
+export const assetNetWorthSign = (asset: Asset): number =>
+  isAssetLiability(asset) ? -1 : 1;
+
+// Forecast an asset's value month by month from today to the horizon. The
+// series is anchored to today's Balance and compounds at GrowthRate on the
+// asset's CompoundingPeriod (monthly by default), with boundaries measured from
+// today (an asset has no historical StartDate cadence to honor). Index 0 is
+// today. The running value is kept unrounded between months and each emitted
+// point is rounded to cents (PRECISION.md, matching forecastInvestment).
+//
+// A negative GrowthRate (a depreciating car, a shrinking custom balance) decays
+// the value geometrically toward — but never below — zero, so summed series
+// stay well-defined.
+export const forecastAsset = (
+  asset: Asset,
+  horizon: Date,
+  today: Date = new Date()
+): ForecastPoint[] => {
+  const months = getMonthsBetween(today, horizon);
+  const start = dayjs(today);
+  const frequency = asset.CompoundingPeriod ?? CompoundingFrequency.Monthly;
+  const periodsPerYear = getPeriodsPerYear(frequency);
+  const periodRate = asset.GrowthRate / 100 / periodsPerYear;
+  const compoundingInterval = 12 / periodsPerYear;
+
+  let value = asset.Balance;
+  const points: ForecastPoint[] = [
+    { Date: start.toDate(), Value: roundToCents(value) },
+  ];
+
+  for (let month = 1; month <= months; month++) {
+    if (month % compoundingInterval === 0) {
+      value *= 1 + periodRate;
+    }
+    points.push({
+      Date: start.add(month, 'month').toDate(),
+      Value: roundToCents(value),
+    });
+  }
+
+  return points;
+};
+
+// Today's value of an asset (the series' index-0 anchor), rounded to cents.
+// Used by the dashboard summary so the cards and the chart agree on the anchor:
+// forecastAsset(asset, today)[0].Value is exactly this value.
+export const getAssetValueToday = (asset: Asset): number =>
+  roundToCents(asset.Balance);

--- a/src/helpers/asset-persistence.test.ts
+++ b/src/helpers/asset-persistence.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import { Asset, AssetType } from '../models/asset-model';
+import { CompoundingFrequency } from '../models/investment-model';
+import {
+  ASSET_GROWTH_WARNING_THRESHOLD,
+  isAssetValid,
+  validateAsset,
+} from './validation-helpers';
+import { exportToJson, importFromJson } from './data-helpers';
+
+// Charter coverage for the Phase 7 input boundary: the form validator
+// (validateAsset) and the JSON import/export validator (parseAssets, reached
+// through importFromJson). The two must agree — a value the form saves must
+// round-trip through export/import, and vice versa.
+
+const validAsset = (overrides: Partial<Asset> = {}): Asset => ({
+  Id: 'a1',
+  Provider: 'Sample Bank',
+  Name: 'HYSA',
+  AssetType: AssetType.Cash,
+  Balance: 10000,
+  GrowthRate: 4.25,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...overrides,
+});
+
+describe('validateAsset', () => {
+  it('accepts a well-formed asset', () => {
+    const result = validateAsset(validAsset());
+    expect(result.errors).toEqual({});
+    expect(isAssetValid(validAsset())).toBe(true);
+  });
+
+  it('accepts a negative growth rate (a depreciating asset)', () => {
+    const result = validateAsset(
+      validAsset({ AssetType: AssetType.CustomAsset, GrowthRate: -10 })
+    );
+    expect(result.errors).toEqual({});
+  });
+
+  it('requires a name', () => {
+    expect(validateAsset(validAsset({ Name: '   ' })).errors.Name).toBeTruthy();
+  });
+
+  it('requires a provider', () => {
+    expect(
+      validateAsset(validAsset({ Provider: '' })).errors.Provider
+    ).toBeTruthy();
+  });
+
+  it('rejects a negative balance', () => {
+    expect(
+      validateAsset(validAsset({ Balance: -1 })).errors.Balance
+    ).toBeTruthy();
+  });
+
+  it('rejects a non-finite growth rate', () => {
+    expect(
+      validateAsset(validAsset({ GrowthRate: Number.NaN })).errors.GrowthRate
+    ).toBeTruthy();
+    // A NaN rate is not finite, so no growth warning is added alongside the error.
+    expect(
+      validateAsset(validAsset({ GrowthRate: Number.NaN })).warnings.GrowthRate
+    ).toBeUndefined();
+  });
+
+  it('warns on an unusually large growth rate in either direction', () => {
+    expect(
+      validateAsset(
+        validAsset({ GrowthRate: ASSET_GROWTH_WARNING_THRESHOLD + 5 })
+      ).warnings.GrowthRate
+    ).toBeTruthy();
+    expect(
+      validateAsset(
+        validAsset({
+          AssetType: AssetType.CustomAsset,
+          GrowthRate: -(ASSET_GROWTH_WARNING_THRESHOLD + 5),
+        })
+      ).warnings.GrowthRate
+    ).toBeTruthy();
+  });
+
+  it('does not warn on an in-range growth rate', () => {
+    expect(
+      validateAsset(validAsset({ GrowthRate: 5 })).warnings.GrowthRate
+    ).toBeUndefined();
+  });
+
+  it('isAssetValid is false when any error is present', () => {
+    expect(isAssetValid(validAsset({ Balance: -1 }))).toBe(false);
+  });
+});
+
+// Build a schema-v4 export payload string with the given raw assets array.
+const makeJson = (assets: unknown): string =>
+  JSON.stringify({
+    schemaVersion: 4,
+    loans: [],
+    investments: [],
+    scenarios: [],
+    assets,
+  });
+
+describe('importFromJson — assets (parseAssets)', () => {
+  it('round-trips a valid asset through export and import', () => {
+    const asset = validAsset({
+      AssetType: AssetType.Property,
+      Balance: 400000,
+      GrowthRate: 3,
+      LinkedLoanId: 'loan-1',
+    });
+    const json = exportToJson([], [], [], [asset]);
+    expect(JSON.parse(json).schemaVersion).toBe(4);
+    const { assets } = importFromJson(json);
+    expect(assets).toEqual([asset]);
+  });
+
+  it('treats a missing assets array as no assets', () => {
+    const json = JSON.stringify({
+      schemaVersion: 4,
+      loans: [],
+      investments: [],
+    });
+    expect(importFromJson(json).assets).toEqual([]);
+  });
+
+  it('imports an asset with no optional fields, dropping unknown keys', () => {
+    const json = makeJson([
+      {
+        Id: 'a1',
+        Provider: 'Bank',
+        Name: 'Checking',
+        AssetType: AssetType.Cash,
+        Balance: 1000,
+        GrowthRate: 0,
+        bogus: 'dropped',
+      },
+    ]);
+    const { assets } = importFromJson(json);
+    expect(assets).toHaveLength(1);
+    expect(assets[0].LinkedLoanId).toBeUndefined();
+    expect(assets[0].CompoundingPeriod).toBeUndefined();
+    expect(assets[0]).not.toHaveProperty('bogus');
+  });
+
+  it('rejects an assets value that is not an array', () => {
+    expect(() => importFromJson(makeJson('nope'))).toThrow(
+      'assets must be an array'
+    );
+  });
+
+  it('rejects a non-object asset entry', () => {
+    expect(() => importFromJson(makeJson([42]))).toThrow('expected an object');
+  });
+
+  it('rejects an asset with a missing/invalid Id', () => {
+    expect(() => importFromJson(makeJson([{ Id: '  ' }]))).toThrow(
+      'Invalid or missing ID in asset'
+    );
+  });
+
+  it('rejects an asset with an empty provider', () => {
+    expect(() =>
+      importFromJson(makeJson([{ Id: 'a1', Provider: '' }]))
+    ).toThrow("Required field 'Provider' cannot be empty");
+  });
+
+  it('rejects an asset with an empty name', () => {
+    expect(() =>
+      importFromJson(makeJson([{ Id: 'a1', Provider: 'Bank', Name: '' }]))
+    ).toThrow("Required field 'Name' cannot be empty");
+  });
+
+  it('rejects an invalid AssetType', () => {
+    expect(() =>
+      importFromJson(
+        makeJson([
+          { Id: 'a1', Provider: 'Bank', Name: 'X', AssetType: 'gold-bars' },
+        ])
+      )
+    ).toThrow("Invalid value for 'AssetType'");
+  });
+
+  it('rejects a non-numeric balance', () => {
+    expect(() =>
+      importFromJson(
+        makeJson([
+          {
+            Id: 'a1',
+            Provider: 'Bank',
+            Name: 'X',
+            AssetType: AssetType.Cash,
+            Balance: 'lots',
+            GrowthRate: 0,
+          },
+        ])
+      )
+    ).toThrow("Invalid value for 'Balance'");
+  });
+
+  it('rejects a negative balance', () => {
+    expect(() =>
+      importFromJson(
+        makeJson([
+          {
+            Id: 'a1',
+            Provider: 'Bank',
+            Name: 'X',
+            AssetType: AssetType.Cash,
+            Balance: -5,
+            GrowthRate: 0,
+          },
+        ])
+      )
+    ).toThrow("Invalid value for 'Balance'");
+  });
+
+  it('rejects a non-finite growth rate', () => {
+    expect(() =>
+      importFromJson(
+        makeJson([
+          {
+            Id: 'a1',
+            Provider: 'Bank',
+            Name: 'X',
+            AssetType: AssetType.Cash,
+            Balance: 100,
+            GrowthRate: 'fast',
+          },
+        ])
+      )
+    ).toThrow("Invalid value for 'GrowthRate'");
+  });
+
+  it('accepts a valid CompoundingPeriod and rejects an invalid one', () => {
+    const base = {
+      Id: 'a1',
+      Provider: 'Bank',
+      Name: 'X',
+      AssetType: AssetType.Cash,
+      Balance: 100,
+      GrowthRate: 1,
+    };
+    expect(
+      importFromJson(
+        makeJson([
+          { ...base, CompoundingPeriod: CompoundingFrequency.Quarterly },
+        ])
+      ).assets[0].CompoundingPeriod
+    ).toBe(CompoundingFrequency.Quarterly);
+    expect(() =>
+      importFromJson(makeJson([{ ...base, CompoundingPeriod: 'hourly' }]))
+    ).toThrow("Invalid value for 'CompoundingPeriod'");
+  });
+
+  it('accepts a valid LinkedLoanId and rejects a blank one', () => {
+    const base = {
+      Id: 'a1',
+      Provider: 'Bank',
+      Name: 'Home',
+      AssetType: AssetType.Property,
+      Balance: 100,
+      GrowthRate: 1,
+    };
+    expect(
+      importFromJson(makeJson([{ ...base, LinkedLoanId: 'loan-9' }])).assets[0]
+        .LinkedLoanId
+    ).toBe('loan-9');
+    expect(() =>
+      importFromJson(makeJson([{ ...base, LinkedLoanId: '   ' }]))
+    ).toThrow("Invalid value for 'LinkedLoanId'");
+  });
+});

--- a/src/helpers/data-helpers.test.ts
+++ b/src/helpers/data-helpers.test.ts
@@ -1137,7 +1137,7 @@ describe('scenario import/export (schema v3)', () => {
       },
     ];
     const json = exportToJson([], [], scenarios);
-    expect(JSON.parse(json).schemaVersion).toBe(3);
+    expect(JSON.parse(json).schemaVersion).toBe(4);
     expect(importFromJson(json).scenarios).toEqual(scenarios);
   });
 

--- a/src/helpers/data-helpers.ts
+++ b/src/helpers/data-helpers.ts
@@ -4,12 +4,14 @@ import {
   CompoundingFrequency,
   StepUpType,
 } from '../models/investment-model';
+import { Asset, AssetType } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { CURRENT_SCHEMA_VERSION, RawData, migrate } from './migrate-helpers';
 import packageJson from '../../package.json';
 
-// Schema v3 (Phase 4.5): inputs only — loans, investments, and named scenarios.
-// v2 files (no scenarios) import forward via the D8 migration ladder; v1 and
+// Schema v4 (Phase 7): inputs only — loans, investments, named scenarios, and
+// simple assets (cash/property/custom). Older files import forward via the D8
+// migration ladder (v2 gains scenarios, v3 gains assets); v1 and
 // newer-than-current versions are rejected there.
 export const EXPORT_SCHEMA_VERSION = CURRENT_SCHEMA_VERSION;
 
@@ -23,11 +25,15 @@ export interface SerializedInvestment extends Omit<Investment, 'StartDate'> {
   StartDate: string;
 }
 
+// Assets carry no Date fields, so they serialize one-to-one.
+export type SerializedAsset = Asset;
+
 export interface ExportData {
   schemaVersion: number;
   loans: SerializedLoan[];
   investments: SerializedInvestment[];
   scenarios: Scenario[];
+  assets: SerializedAsset[];
   exportDate: string;
   version: string;
 }
@@ -132,6 +138,9 @@ const VALID_COMPOUNDING_FREQUENCIES: string[] =
 /** Valid StepUpType values derived from the enum */
 const VALID_STEP_UP_TYPES: string[] = Object.values(StepUpType);
 
+/** Valid AssetType values derived from the enum */
+const VALID_ASSET_TYPES: string[] = Object.values(AssetType);
+
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -202,13 +211,109 @@ const parseScenarios = (value: unknown): Scenario[] => {
 };
 
 /**
- * Serialize loans, investments, and scenarios to a JSON string (schema v3,
- * inputs only). Converts Date objects to ISO strings for JSON compatibility.
+ * Validate and normalize the assets array (schema v4, Phase 7). A missing array
+ * imports as no assets; malformed entries throw, matching the strictness of
+ * loan/investment validation. Picks fields explicitly so unknown properties are
+ * dropped at the import boundary.
+ */
+const parseAssets = (value: unknown): Asset[] => {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error('Invalid data format: assets must be an array.');
+  }
+  return value.map((raw, index) => {
+    if (!isPlainObject(raw)) {
+      throw new Error(`Invalid asset at index ${index}: expected an object.`);
+    }
+    if (!isValidId(raw.Id as string | undefined)) {
+      throw new Error(
+        `Invalid or missing ID in asset at index ${index}. All items must have a non-empty ID.`
+      );
+    }
+    if (typeof raw.Provider !== 'string' || raw.Provider.trim() === '') {
+      throw new Error(
+        `Required field 'Provider' cannot be empty in asset at index ${index}.`
+      );
+    }
+    if (typeof raw.Name !== 'string' || raw.Name.trim() === '') {
+      throw new Error(
+        `Required field 'Name' cannot be empty in asset at index ${index}.`
+      );
+    }
+    if (!VALID_ASSET_TYPES.includes(raw.AssetType as string)) {
+      throw new Error(
+        `Invalid value for 'AssetType' in asset at index ${index}: expected one of ${VALID_ASSET_TYPES.join(
+          ', '
+        )}, got ${JSON.stringify(raw.AssetType)}.`
+      );
+    }
+    // Balance must be a non-negative finite number (a liability's debt is still
+    // stored as a positive balance).
+    validateNumericField(
+      raw.Balance,
+      'Balance',
+      'asset',
+      index,
+      (n) => n >= 0,
+      'a non-negative finite number'
+    );
+    // GrowthRate must be finite but MAY be negative (a depreciating asset).
+    validateNumericField(
+      raw.GrowthRate,
+      'GrowthRate',
+      'asset',
+      index,
+      () => true,
+      'a finite number'
+    );
+    // Optional CompoundingPeriod, validated against the shared frequency enum.
+    if (
+      raw.CompoundingPeriod !== undefined &&
+      raw.CompoundingPeriod !== null &&
+      !VALID_COMPOUNDING_FREQUENCIES.includes(raw.CompoundingPeriod as string)
+    ) {
+      throw new Error(
+        `Invalid value for 'CompoundingPeriod' in asset at index ${index}: expected one of ${VALID_COMPOUNDING_FREQUENCIES.join(
+          ', '
+        )}, got ${JSON.stringify(raw.CompoundingPeriod)}.`
+      );
+    }
+    // Optional LinkedLoanId (7.2): a non-empty string when present.
+    if (
+      raw.LinkedLoanId !== undefined &&
+      raw.LinkedLoanId !== null &&
+      (typeof raw.LinkedLoanId !== 'string' || raw.LinkedLoanId.trim() === '')
+    ) {
+      throw new Error(
+        `Invalid value for 'LinkedLoanId' in asset at index ${index}: expected a non-empty string.`
+      );
+    }
+
+    return {
+      Id: raw.Id as string,
+      Provider: raw.Provider,
+      Name: raw.Name,
+      AssetType: raw.AssetType as AssetType,
+      Balance: raw.Balance as number,
+      GrowthRate: raw.GrowthRate as number,
+      LinkedLoanId: raw.LinkedLoanId as string | undefined,
+      CompoundingPeriod: raw.CompoundingPeriod as
+        | CompoundingFrequency
+        | undefined,
+    };
+  });
+};
+
+/**
+ * Serialize loans, investments, scenarios, and assets to a JSON string (schema
+ * v4, inputs only). Converts Date objects to ISO strings for JSON
+ * compatibility; assets carry no dates and serialize one-to-one.
  */
 export const exportToJson = (
   loans: Loan[],
   investments: Investment[],
-  scenarios: Scenario[] = []
+  scenarios: Scenario[] = [],
+  assets: Asset[] = []
 ): string => {
   const serializedLoans: SerializedLoan[] = loans.map((loan) => ({
     ...loan,
@@ -228,6 +333,7 @@ export const exportToJson = (
     loans: serializedLoans,
     investments: serializedInvestments,
     scenarios,
+    assets,
     exportDate: new Date().toISOString(),
     version: packageJson.version,
   };
@@ -244,7 +350,12 @@ export const exportToJson = (
  */
 export const importFromJson = (
   jsonString: string
-): { loans: Loan[]; investments: Investment[]; scenarios: Scenario[] } => {
+): {
+  loans: Loan[];
+  investments: Investment[];
+  scenarios: Scenario[];
+  assets: Asset[];
+} => {
   try {
     const raw = JSON.parse(jsonString) as ExportData;
 
@@ -531,8 +642,9 @@ export const importFromJson = (
     });
 
     const scenarios = parseScenarios(data.scenarios);
+    const assets = parseAssets(data.assets);
 
-    return { loans, investments, scenarios };
+    return { loans, investments, scenarios, assets };
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new Error('Invalid JSON format: unable to parse file', {

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -1,8 +1,10 @@
 import dayjs from 'dayjs';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { ForecastPoint, ScenarioInput } from '../models/forecast-model';
 import { getMonthlyPayment } from './loan-helpers';
+import { assetNetWorthSign, forecastAsset } from './asset-helpers';
 import {
   generateInvestmentGrowth,
   getContributionForYear,
@@ -301,15 +303,19 @@ export const forecastInvestment = (
   return points;
 };
 
-// Forecast overall net worth (total investment value minus total loan
-// balance) on a shared monthly axis from today to the horizon. Scenario
-// extras are applied to the matching entities by ID.
+// Forecast overall net worth on a shared monthly axis from today to the
+// horizon: total investment value, plus simple assets (cash/property/custom,
+// Phase 7), minus total loan balance and any custom-liability assets. Scenario
+// extras are applied to the matching loans/investments by ID. `assets` is an
+// optional trailing parameter so the many existing call sites keep working
+// unchanged; passive holdings take no scenario extras.
 export const forecastNetWorth = (
   loans: Loan[],
   investments: Investment[],
   horizon: Date,
   scenario?: ScenarioInput,
-  today: Date = new Date()
+  today: Date = new Date(),
+  assets: Asset[] = []
 ): ForecastPoint[] => {
   const months = getMonthsBetween(today, horizon);
   const start = dayjs(today);
@@ -330,11 +336,20 @@ export const forecastNetWorth = (
       today
     )
   );
+  const assetSeries = assets.map((asset) =>
+    forecastAsset(asset, horizon, today)
+  );
 
   const points: ForecastPoint[] = [];
   for (let month = 0; month <= months; month++) {
-    const assets = investmentSeries.reduce(
+    const investmentValue = investmentSeries.reduce(
       (sum, series) => sum + series[month].Value,
+      0
+    );
+    // Ordinary assets add, custom liabilities subtract (assetNetWorthSign).
+    const assetValue = assetSeries.reduce(
+      (sum, series, index) =>
+        sum + assetNetWorthSign(assets[index]) * series[month].Value,
       0
     );
     const debts = loanSeries.reduce(
@@ -343,11 +358,31 @@ export const forecastNetWorth = (
     );
     points.push({
       Date: start.add(month, 'month').toDate(),
-      Value: roundToCents(assets - debts),
+      Value: roundToCents(investmentValue + assetValue - debts),
     });
   }
 
   return points;
+};
+
+// Forecast a property's home equity (Phase 7.2): the linked mortgage's
+// remaining balance subtracted from the property's projected value, month by
+// month on the shared axis. Makes net worth honest for homeowners — the same
+// figure the aggregate net-worth line already reflects, surfaced on its own so
+// the property row can show equity directly. Pure composition of forecastAsset
+// and forecastLoan, both already rounded per point.
+export const forecastHomeEquity = (
+  property: Asset,
+  loan: Loan,
+  horizon: Date,
+  today: Date = new Date()
+): ForecastPoint[] => {
+  const propertySeries = forecastAsset(property, horizon, today);
+  const loanSeries = forecastLoan(loan, horizon, 0, today);
+  return propertySeries.map((point, index) => ({
+    Date: point.Date,
+    Value: roundToCents(point.Value - loanSeries[index].Value),
+  }));
 };
 
 // First date a forecast series reaches zero, or undefined if it never does

--- a/src/helpers/forecast-series.ts
+++ b/src/helpers/forecast-series.ts
@@ -1,11 +1,13 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { ScenarioInput } from '../models/forecast-model';
 import {
   forecastInvestment,
   forecastLoan,
   forecastNetWorth,
 } from './forecast-helpers';
+import { assetNetWorthSign, forecastAsset } from './asset-helpers';
 
 // Chart-ready shaping of the forecast engine (Phase 2). The engine already
 // produces every series on a shared monthly date axis anchored to today; this
@@ -16,7 +18,7 @@ import {
 
 const roundToCents = (value: number): number => Math.round(value * 100) / 100;
 
-export type ForecastSeriesKind = 'loan' | 'investment' | 'networth';
+export type ForecastSeriesKind = 'loan' | 'investment' | 'asset' | 'networth';
 
 export interface ForecastSeries {
   // Entity Id for loans/investments, or the literal 'networth'.
@@ -38,17 +40,21 @@ export const NET_WORTH_SERIES_ID = 'networth';
 
 /**
  * Build the chart series for the given positions over a horizon. Order is
- * loans, then investments, then the aggregate net-worth line. Loan lines are the
- * remaining balance (declining to 0 at payoff); investment lines are projected
- * value; the net-worth line is Σ investments − Σ loans, computed the same way as
- * `forecastNetWorth` so the chart and any net-worth readout never disagree.
+ * loans, investments, then simple assets (cash/property/custom, Phase 7),
+ * followed by the aggregate net-worth line. Loan lines are the remaining
+ * balance (declining to 0 at payoff); investment and asset lines are projected
+ * value; the net-worth line is Σ investments + Σ assets − Σ loans − Σ liability
+ * assets, computed the same way as `forecastNetWorth` so the chart and any
+ * net-worth readout never disagree. `assets` is an optional trailing parameter
+ * so existing call sites keep working unchanged.
  */
 export const buildForecastChartData = (
   loans: Loan[],
   investments: Investment[],
   horizon: Date,
   scenario?: ScenarioInput,
-  today: Date = new Date()
+  today: Date = new Date(),
+  assets: Asset[] = []
 ): ForecastChartData => {
   const loanForecasts = loans.map((loan) =>
     forecastLoan(
@@ -66,6 +72,9 @@ export const buildForecastChartData = (
       today
     )
   );
+  const assetForecasts = assets.map((asset) =>
+    forecastAsset(asset, horizon, today)
+  );
 
   // A reference series with no entities gives the shared date axis even when
   // there are no positions yet (an empty forecast is still a date-stamped axis).
@@ -73,15 +82,21 @@ export const buildForecastChartData = (
   const dates = reference.map((point) => point.Date);
 
   const netWorthValues = dates.map((_, month) => {
-    const assets = investmentForecasts.reduce(
+    const investmentValue = investmentForecasts.reduce(
       (sum, series) => sum + series[month].Value,
+      0
+    );
+    // Ordinary assets add, custom liabilities subtract (assetNetWorthSign).
+    const assetValue = assetForecasts.reduce(
+      (sum, series, index) =>
+        sum + assetNetWorthSign(assets[index]) * series[month].Value,
       0
     );
     const debts = loanForecasts.reduce(
       (sum, series) => sum + series[month].Value,
       0
     );
-    return roundToCents(assets - debts);
+    return roundToCents(investmentValue + assetValue - debts);
   });
 
   const series: ForecastSeries[] = [
@@ -96,6 +111,12 @@ export const buildForecastChartData = (
       label: investment.Name,
       kind: 'investment' as const,
       values: investmentForecasts[index].map((point) => point.Value),
+    })),
+    ...assets.map((asset, index) => ({
+      id: asset.Id,
+      label: asset.Name,
+      kind: 'asset' as const,
+      values: assetForecasts[index].map((point) => point.Value),
     })),
     {
       id: NET_WORTH_SERIES_ID,

--- a/src/helpers/migrate-helpers.test.ts
+++ b/src/helpers/migrate-helpers.test.ts
@@ -4,7 +4,7 @@ import { EXPORT_SCHEMA_VERSION } from './data-helpers';
 
 describe('migrate (D8 migration ladder)', () => {
   it('exposes the current schema version, matching the export schema', () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(3);
+    expect(CURRENT_SCHEMA_VERSION).toBe(4);
     expect(CURRENT_SCHEMA_VERSION).toBe(EXPORT_SCHEMA_VERSION);
   });
 
@@ -14,13 +14,16 @@ describe('migrate (D8 migration ladder)', () => {
       loans: [],
       investments: [],
       scenarios: [],
+      assets: [],
     };
     expect(migrate(data)).toBe(data);
   });
 
   it('migrates v2 to v3 by adding an empty scenarios list', () => {
     const migrated = migrate({ schemaVersion: 2, loans: [], investments: [] });
-    expect(migrated.schemaVersion).toBe(3);
+    // The ladder runs every step in turn, so a v2 payload climbs to the current
+    // version (gaining scenarios at v3 and assets at v4 along the way).
+    expect(migrated.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
     expect(migrated.scenarios).toEqual([]);
   });
 
@@ -28,6 +31,23 @@ describe('migrate (D8 migration ladder)', () => {
     const scenarios = [{ Id: 's1', Name: 'A' }];
     const migrated = migrate({ schemaVersion: 2, scenarios });
     expect(migrated.scenarios).toBe(scenarios);
+  });
+
+  it('migrates v3 to v4 by adding an empty assets list', () => {
+    const migrated = migrate({
+      schemaVersion: 3,
+      loans: [],
+      investments: [],
+      scenarios: [],
+    });
+    expect(migrated.schemaVersion).toBe(4);
+    expect(migrated.assets).toEqual([]);
+  });
+
+  it('preserves an assets array already present on a v3 payload', () => {
+    const assets = [{ Id: 'a1', Name: 'Cash' }];
+    const migrated = migrate({ schemaVersion: 3, assets });
+    expect(migrated.assets).toBe(assets);
   });
 
   it('rejects a missing schemaVersion as a legacy v1 file', () => {

--- a/src/helpers/migrate-helpers.ts
+++ b/src/helpers/migrate-helpers.ts
@@ -9,7 +9,7 @@
 
 // The current schema version. data-helpers re-exports this as
 // EXPORT_SCHEMA_VERSION; kept here so the ladder owns the "current" definition.
-export const CURRENT_SCHEMA_VERSION = 3;
+export const CURRENT_SCHEMA_VERSION = 4;
 
 // A parsed payload: a numeric schemaVersion plus arbitrary other fields the
 // individual migration steps and the downstream validator interpret.
@@ -19,12 +19,19 @@ export type RawData = { schemaVersion: number } & Record<string, unknown>;
 type MigrationStep = (data: RawData) => RawData;
 
 // Keyed by the version each step upgrades FROM. v2 → v3 introduces the
-// `scenarios` array (Phase 4.5); a v2 file simply gains an empty list.
+// `scenarios` array (Phase 4.5); a v2 file simply gains an empty list. v3 → v4
+// introduces the `assets` array (Phase 7, Whole Net Worth); a v3 file simply
+// gains an empty list, so an older file with no assets migrates cleanly.
 const MIGRATIONS: Record<number, MigrationStep> = {
   2: (data) => ({
     ...data,
     schemaVersion: 3,
     scenarios: Array.isArray(data.scenarios) ? data.scenarios : [],
+  }),
+  3: (data) => ({
+    ...data,
+    schemaVersion: 4,
+    assets: Array.isArray(data.assets) ? data.assets : [],
   }),
 };
 

--- a/src/helpers/milestone-helpers.ts
+++ b/src/helpers/milestone-helpers.ts
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import {
   forecastLoan,
   forecastNetWorth,
@@ -28,7 +29,8 @@ export interface Milestones {
 export const computeMilestones = (
   loans: Loan[],
   investments: Investment[],
-  today: Date = new Date()
+  today: Date = new Date(),
+  assets: Asset[] = []
 ): Milestones => {
   // Extend the horizon to at least 30 years so the +30y milestone always exists,
   // while still covering a longer loan schedule for the debt-free date.
@@ -38,12 +40,16 @@ export const computeMilestones = (
     ? defaultHorizon
     : thirtyYears;
 
+  // Assets (cash/property/custom) flow into the net-worth milestones; the
+  // debt-free date below stays loan-only (a custom liability has no payoff
+  // schedule — it just decays at its rate).
   const netWorth = forecastNetWorth(
     loans,
     investments,
     horizon,
     undefined,
-    today
+    today,
+    assets
   );
 
   const netWorthAt = MILESTONE_YEARS.map((years) => ({

--- a/src/helpers/storage-helpers.test.ts
+++ b/src/helpers/storage-helpers.test.ts
@@ -120,7 +120,7 @@ describe('saveData / loadData round-trip', () => {
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!);
     // Same serializer the export path uses: current schema, derived data stripped.
-    expect(parsed.schemaVersion).toBe(3);
+    expect(parsed.schemaVersion).toBe(4);
     expect(parsed.loans).toHaveLength(1);
     expect(parsed.loans[0].Id).toBe(sampleLoan.Id);
     // Inputs only — no computed amortization schedule rides along.

--- a/src/helpers/storage-helpers.ts
+++ b/src/helpers/storage-helpers.ts
@@ -16,6 +16,7 @@
 
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { exportToJson, importFromJson } from './data-helpers';
 
@@ -48,12 +49,13 @@ const isQuotaExceededError = (error: unknown): boolean =>
 export const saveData = (
   loans: Loan[],
   investments: Investment[],
-  scenarios: Scenario[] = []
+  scenarios: Scenario[] = [],
+  assets: Asset[] = []
 ): SaveStatus => {
   try {
     globalThis.localStorage.setItem(
       STORAGE_DATA_KEY,
-      exportToJson(loans, investments, scenarios)
+      exportToJson(loans, investments, scenarios, assets)
     );
     return 'saved';
   } catch (error) {
@@ -71,6 +73,7 @@ export const loadData = (): {
   loans: Loan[];
   investments: Investment[];
   scenarios: Scenario[];
+  assets: Asset[];
 } | null => {
   let raw: string | null;
   try {

--- a/src/helpers/summary-helpers.ts
+++ b/src/helpers/summary-helpers.ts
@@ -1,11 +1,13 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import {
   forecastInvestment,
   forecastLoan,
   getEffectiveMonthlyPayment,
 } from './forecast-helpers';
 import { getPeriodsPerYear } from './investment-helpers';
+import { getAssetValueToday, isAssetLiability } from './asset-helpers';
 
 // "Today" net-worth summary metrics for the dashboard (Phase 3.1). Debt and
 // asset totals are read from the forecast engine's today-anchor (index 0), so
@@ -29,21 +31,32 @@ export interface PositionSummary {
 export const summarizePositions = (
   loans: Loan[],
   investments: Investment[],
-  today: Date = new Date()
+  today: Date = new Date(),
+  assets: Asset[] = []
 ): PositionSummary => {
+  // Ordinary assets (cash/property/custom) count toward assets at today's
+  // value; custom liabilities count toward debt — a single source of truth with
+  // the net-worth roll-up.
+  const assetHoldings = assets.filter((asset) => !isAssetLiability(asset));
+  const liabilityHoldings = assets.filter((asset) => isAssetLiability(asset));
+
   // forecast*(…, today, 0, today) yields a single point at today's anchor.
   const totalDebt = roundToCents(
     loans.reduce(
       (sum, loan) => sum + forecastLoan(loan, today, 0, today)[0].Value,
       0
-    )
+    ) +
+      liabilityHoldings.reduce(
+        (sum, asset) => sum + getAssetValueToday(asset),
+        0
+      )
   );
   const totalAssets = roundToCents(
     investments.reduce(
       (sum, investment) =>
         sum + forecastInvestment(investment, today, 0, today)[0].Value,
       0
-    )
+    ) + assetHoldings.reduce((sum, asset) => sum + getAssetValueToday(asset), 0)
   );
 
   // Use the engine's effective payment (the same value forecastLoan applies),

--- a/src/helpers/validation-helpers.ts
+++ b/src/helpers/validation-helpers.ts
@@ -19,6 +19,7 @@ import {
   Investment,
   StepUpType,
 } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 
 export interface ValidationResult<TField extends string> {
   errors: Partial<Record<TField, string>>;
@@ -260,3 +261,49 @@ export const validateInvestment = (
 
 export const isInvestmentValid = (investment: Investment): boolean =>
   Object.keys(validateInvestment(investment).errors).length === 0;
+
+// A growth/decline rate beyond this magnitude (in %/yr) is almost always a
+// data-entry slip for any of the asset types Phase 7 covers: a HYSA APY, a
+// home's appreciation, or a custom asset's drift. Warn (don't block) — a value
+// this large is type-valid and still forecasts.
+export const ASSET_GROWTH_WARNING_THRESHOLD = 25;
+
+export type AssetField = 'Name' | 'Provider' | 'Balance' | 'GrowthRate';
+
+export const validateAsset = (asset: Asset): ValidationResult<AssetField> => {
+  const errors: Partial<Record<AssetField, string>> = {};
+  const warnings: Partial<Record<AssetField, string>> = {};
+  const formErrors: string[] = [];
+
+  // --- Blocking errors ---
+  if (asset.Name.trim() === '') {
+    errors.Name = 'Name is required.';
+  }
+  if (asset.Provider.trim() === '') {
+    errors.Provider = 'Provider is required.';
+  }
+  // Balance is the current value (a liability's debt is stored positive too), so
+  // it must be non-negative — mirrors the JSON import boundary (data-helpers,
+  // >= 0) so a saved asset round-trips through export/import.
+  if (!(asset.Balance >= 0)) {
+    errors.Balance = 'Balance cannot be negative.';
+  }
+  // GrowthRate may be negative (a depreciating asset), so the only error is a
+  // non-finite value (NaN/Infinity), which the import boundary also rejects.
+  if (!Number.isFinite(asset.GrowthRate)) {
+    errors.GrowthRate = 'Growth rate must be a number.';
+  }
+
+  // --- Non-blocking sanity warnings ---
+  if (
+    Number.isFinite(asset.GrowthRate) &&
+    Math.abs(asset.GrowthRate) > ASSET_GROWTH_WARNING_THRESHOLD
+  ) {
+    warnings.GrowthRate = `A rate beyond ±${ASSET_GROWTH_WARNING_THRESHOLD}%/yr is unusual — double-check the value.`;
+  }
+
+  return { errors, warnings, formErrors };
+};
+
+export const isAssetValid = (asset: Asset): boolean =>
+  Object.keys(validateAsset(asset).errors).length === 0;

--- a/src/models/asset-model.ts
+++ b/src/models/asset-model.ts
@@ -1,0 +1,54 @@
+import { CompoundingFrequency } from './investment-model';
+
+// Phase 7 (Whole Net Worth). A single, simple holding whose value grows or
+// declines at a fixed annual rate — the catch-all that finally lets the
+// net-worth line hold *everything* a person owns:
+//
+//   - Cash (7.1): HYSA / CD / checking — a balance plus an APY.
+//   - Property (7.2): a home value appreciating at a rate, optionally linked to
+//     its mortgage (a Loan) so net worth reflects home *equity*.
+//   - Custom asset / liability (7.3): an escape hatch for anything else (a car
+//     that depreciates, a private loan, collectibles) with a simple growth or
+//     decline rate.
+//
+// One model with an AssetType discriminator covers all three; the math is the
+// same simple compound-growth curve in every case (asset-helpers). Input-only
+// (D3/D7): the forecast value series is computed on demand, never stored or
+// serialized.
+
+export enum AssetType {
+  Cash = 'cash',
+  Property = 'property',
+  CustomAsset = 'custom-asset',
+  CustomLiability = 'custom-liability',
+}
+
+export interface Asset {
+  Id: string;
+  Provider: string;
+  Name: string;
+  AssetType: AssetType;
+  // Today's value, always a positive balance (a liability's debt is positive
+  // too). Forecasts anchor here, exactly as loans anchor on CurrentAmount and
+  // investments on CurrentValue.
+  Balance: number;
+  // Annual percentage. May be negative (a depreciating asset). For cash this is
+  // the APY; for property the appreciation rate; for custom the growth/decline.
+  GrowthRate: number;
+  // 7.2 entity linking: the Loan Id of the mortgage paired to a property, so the
+  // app can derive home equity (property value − loan balance). Optional and
+  // only meaningful for AssetType.Property.
+  LinkedLoanId?: string;
+  // Compounding cadence for the growth rate; defaults to monthly when unset.
+  CompoundingPeriod?: CompoundingFrequency;
+}
+
+export const emptyAsset: Asset = {
+  Id: '',
+  Provider: '',
+  Name: '',
+  AssetType: AssetType.Cash,
+  Balance: 0,
+  GrowthRate: 0,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+};

--- a/src/persistence/use-persistence.ts
+++ b/src/persistence/use-persistence.ts
@@ -35,10 +35,12 @@ export const usePersistence = (): PersistenceController => {
   const {
     loans,
     investments,
+    assets,
     scenarios,
     sampleDataLoaded,
     stashedLoans,
     stashedInvestments,
+    stashedAssets,
   } = state;
 
   const [enabled, setEnabled] = useState<boolean>(() => isPersistenceEnabled());
@@ -56,6 +58,10 @@ export const usePersistence = (): PersistenceController => {
     () => (sampleDataLoaded ? (stashedInvestments ?? []) : investments),
     [sampleDataLoaded, stashedInvestments, investments]
   );
+  const realAssets = useMemo(
+    () => (sampleDataLoaded ? (stashedAssets ?? []) : assets),
+    [sampleDataLoaded, stashedAssets, assets]
+  );
 
   // Hydrate once on mount when persistence is on. Initial context state is
   // empty, so a merge is effectively a load; the ref makes it run a single time
@@ -69,7 +75,12 @@ export const usePersistence = (): PersistenceController => {
     if (isPersistenceEnabled()) {
       const loaded = loadData();
       if (loaded) {
-        importMerge(loaded.loans, loaded.investments, loaded.scenarios);
+        importMerge(
+          loaded.loans,
+          loaded.investments,
+          loaded.scenarios,
+          loaded.assets
+        );
       }
     }
   }, [importMerge]);
@@ -99,10 +110,19 @@ export const usePersistence = (): PersistenceController => {
       return;
     }
     const handle = setTimeout(() => {
-      reportSaveProblem(saveData(realLoans, realInvestments, scenarios));
+      reportSaveProblem(
+        saveData(realLoans, realInvestments, scenarios, realAssets)
+      );
     }, AUTO_SAVE_DEBOUNCE_MS);
     return () => clearTimeout(handle);
-  }, [enabled, realLoans, realInvestments, scenarios, reportSaveProblem]);
+  }, [
+    enabled,
+    realLoans,
+    realInvestments,
+    scenarios,
+    realAssets,
+    reportSaveProblem,
+  ]);
 
   const toggle = useCallback(() => {
     const next = !enabled;
@@ -110,7 +130,12 @@ export const usePersistence = (): PersistenceController => {
     setPersistenceEnabled(next);
     if (next) {
       // Save immediately on enable so a reload right away still restores data.
-      const status = saveData(realLoans, realInvestments, scenarios);
+      const status = saveData(
+        realLoans,
+        realInvestments,
+        scenarios,
+        realAssets
+      );
       if (status === 'saved') {
         setFeedback({
           severity: 'success',
@@ -127,7 +152,14 @@ export const usePersistence = (): PersistenceController => {
         message: 'Saved data cleared from this device.',
       });
     }
-  }, [enabled, realLoans, realInvestments, scenarios, reportSaveProblem]);
+  }, [
+    enabled,
+    realLoans,
+    realInvestments,
+    scenarios,
+    realAssets,
+    reportSaveProblem,
+  ]);
 
   const clearFeedback = useCallback(() => setFeedback(null), []);
 

--- a/src/state/finance-data-context.tsx
+++ b/src/state/finance-data-context.tsx
@@ -1,6 +1,7 @@
 import { createContext, Dispatch, ReactNode, useMemo, useReducer } from 'react';
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { generateId } from '../helpers/id-helpers';
 import {
@@ -26,14 +27,25 @@ export interface FinanceDataContextValue {
   deleteInvestment: (id: string) => void;
   // Undo an investment delete by restoring it at its original index.
   insertInvestmentAt: (investment: Investment, index: number) => void;
+  // Asset actions (Phase 7). Id assignment happens here so the reducer stays pure.
+  addAsset: (asset: Asset) => void;
+  updateAsset: (asset: Asset) => void;
+  deleteAsset: (id: string) => void;
+  // Undo an asset delete by restoring it at its original index.
+  insertAssetAt: (asset: Asset, index: number) => void;
   importMerge: (
     loans: Loan[],
     investments: Investment[],
-    scenarios?: Scenario[]
+    scenarios?: Scenario[],
+    assets?: Asset[]
   ) => void;
   // Undo an import merge by restoring a pre-merge snapshot (roadmap 6.3).
   restoreData: (snapshot: DataSnapshot) => void;
-  loadSampleData: (loans: Loan[], investments: Investment[]) => void;
+  loadSampleData: (
+    loans: Loan[],
+    investments: Investment[],
+    assets: Asset[]
+  ) => void;
   clearSampleData: () => void;
   // Scenario actions (Phase 4). addScenario assigns an Id and returns it so the
   // caller can immediately make the new scenario active.
@@ -76,15 +88,35 @@ export const FinanceDataProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'DeleteInvestment', id }),
       insertInvestmentAt: (investment: Investment, index: number) =>
         dispatch({ type: 'InsertInvestmentAt', investment, index }),
+      addAsset: (asset: Asset) =>
+        dispatch({
+          type: 'AddAsset',
+          asset: { ...asset, Id: asset.Id || generateId() },
+        }),
+      updateAsset: (asset: Asset) => dispatch({ type: 'UpdateAsset', asset }),
+      deleteAsset: (id: string) => dispatch({ type: 'DeleteAsset', id }),
+      insertAssetAt: (asset: Asset, index: number) =>
+        dispatch({ type: 'InsertAssetAt', asset, index }),
       importMerge: (
         loans: Loan[],
         investments: Investment[],
-        scenarios?: Scenario[]
-      ) => dispatch({ type: 'ImportMerge', loans, investments, scenarios }),
+        scenarios?: Scenario[],
+        assets?: Asset[]
+      ) =>
+        dispatch({
+          type: 'ImportMerge',
+          loans,
+          investments,
+          scenarios,
+          assets,
+        }),
       restoreData: (snapshot: DataSnapshot) =>
         dispatch({ type: 'RestoreData', snapshot }),
-      loadSampleData: (loans: Loan[], investments: Investment[]) =>
-        dispatch({ type: 'LoadSampleData', loans, investments }),
+      loadSampleData: (
+        loans: Loan[],
+        investments: Investment[],
+        assets: Asset[]
+      ) => dispatch({ type: 'LoadSampleData', loans, investments, assets }),
       clearSampleData: () => dispatch({ type: 'ClearSampleData' }),
       addScenario: (scenario: Scenario) => {
         const id = scenario.Id || generateId();

--- a/src/state/finance-reducer.test.ts
+++ b/src/state/finance-reducer.test.ts
@@ -6,6 +6,7 @@ import {
 } from './finance-reducer';
 import { Loan } from '../models/loan-model';
 import { Investment, CompoundingFrequency } from '../models/investment-model';
+import { Asset, AssetType } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 
 const makeLoan = (id: string, overrides: Partial<Loan> = {}): Loan => ({
@@ -31,6 +32,17 @@ const makeInvestment = (
   StartDate: new Date('2024-01-01'),
   StartingBalance: 10000,
   AverageReturnRate: 7,
+  CompoundingPeriod: CompoundingFrequency.Monthly,
+  ...overrides,
+});
+
+const makeAsset = (id: string, overrides: Partial<Asset> = {}): Asset => ({
+  Id: id,
+  Provider: `Provider ${id}`,
+  Name: `Asset ${id}`,
+  AssetType: AssetType.Cash,
+  Balance: 10000,
+  GrowthRate: 4,
   CompoundingPeriod: CompoundingFrequency.Monthly,
   ...overrides,
 });
@@ -285,6 +297,55 @@ describe('financeReducer', () => {
     });
   });
 
+  describe('Asset actions (Phase 7)', () => {
+    it('AddAsset appends an asset', () => {
+      const next = financeReducer(initialFinanceState, {
+        type: 'AddAsset',
+        asset: makeAsset('a'),
+      });
+      expect(next.assets.map((a) => a.Id)).toEqual(['a']);
+    });
+
+    it('UpdateAsset replaces in place, preserving order', () => {
+      const start = stateWith({
+        assets: [makeAsset('a'), makeAsset('b'), makeAsset('c')],
+      });
+      const updated = makeAsset('b', { Name: 'Renamed' });
+      const next = financeReducer(start, {
+        type: 'UpdateAsset',
+        asset: updated,
+      });
+      expect(next.assets.map((a) => a.Id)).toEqual(['a', 'b', 'c']);
+      expect(next.assets[1]).toEqual(updated);
+    });
+
+    it('DeleteAsset removes by Id', () => {
+      const start = stateWith({ assets: [makeAsset('a'), makeAsset('b')] });
+      const next = financeReducer(start, { type: 'DeleteAsset', id: 'a' });
+      expect(next.assets.map((a) => a.Id)).toEqual(['b']);
+    });
+
+    it('InsertAssetAt restores an asset at its original index', () => {
+      const start = stateWith({ assets: [makeAsset('a'), makeAsset('c')] });
+      const next = financeReducer(start, {
+        type: 'InsertAssetAt',
+        asset: makeAsset('b'),
+        index: 1,
+      });
+      expect(next.assets.map((a) => a.Id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('InsertAssetAt is a no-op when the same Id is already present', () => {
+      const start = stateWith({ assets: [makeAsset('a')] });
+      const next = financeReducer(start, {
+        type: 'InsertAssetAt',
+        asset: makeAsset('a', { Name: 'Dup' }),
+        index: 0,
+      });
+      expect(next).toBe(start);
+    });
+  });
+
   describe('ImportMerge', () => {
     it('adds new items by Id', () => {
       const start = stateWith({
@@ -309,6 +370,26 @@ describe('financeReducer', () => {
       });
       expect(next.loans).toHaveLength(1);
       expect(next.loans[0].Name).toBe('New');
+    });
+
+    it('merges assets by Id, leaving them untouched when omitted', () => {
+      const start = stateWith({ assets: [makeAsset('a', { Name: 'Old' })] });
+      const withAssets = financeReducer(start, {
+        type: 'ImportMerge',
+        loans: [],
+        investments: [],
+        assets: [makeAsset('a', { Name: 'New' }), makeAsset('b')],
+      });
+      expect(withAssets.assets.map((a) => a.Id).sort()).toEqual(['a', 'b']);
+      expect(withAssets.assets.find((a) => a.Id === 'a')?.Name).toBe('New');
+
+      // Omitting assets entirely leaves the existing list unchanged.
+      const untouched = financeReducer(start, {
+        type: 'ImportMerge',
+        loans: [],
+        investments: [],
+      });
+      expect(untouched.assets).toBe(start.assets);
     });
 
     it('mixes adds and updates in a single merge', () => {
@@ -348,6 +429,7 @@ describe('financeReducer', () => {
       const withUserData = stateWith({ loans: [makeLoan('real')] });
       const loaded = financeReducer(withUserData, {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample')],
         investments: [],
       });
@@ -384,9 +466,11 @@ describe('financeReducer', () => {
       const snapshot = {
         loans: before.loans,
         investments: before.investments,
+        assets: before.assets,
         scenarios: before.scenarios,
         stashedLoans: before.stashedLoans,
         stashedInvestments: before.stashedInvestments,
+        stashedAssets: before.stashedAssets,
       };
 
       // A merge clobbers loan 'a' and adds loan 'b'.
@@ -411,9 +495,11 @@ describe('financeReducer', () => {
       const snapshot = {
         loans: [makeLoan('sample')],
         investments: [],
+        assets: [],
         scenarios: [],
         stashedLoans: [makeLoan('real')],
         stashedInvestments: [makeInvestment('real-inv')],
+        stashedAssets: null,
       };
       const dirtied = stateWith({
         sampleDataLoaded: true,
@@ -440,9 +526,11 @@ describe('financeReducer', () => {
       const snapshot = {
         loans: [makeLoan('b')],
         investments: [],
+        assets: [],
         scenarios: [],
         stashedLoans: null,
         stashedInvestments: null,
+        stashedAssets: null,
       };
       financeReducer(start, { type: 'RestoreData', snapshot });
       expect(start.loans.map((l) => l.Id)).toEqual(['a']);
@@ -462,6 +550,7 @@ describe('financeReducer', () => {
 
       const next = financeReducer(start, {
         type: 'LoadSampleData',
+        assets: [],
         loans: sampleLoans,
         investments: sampleInvestments,
       });
@@ -471,6 +560,23 @@ describe('financeReducer', () => {
       expect(next.investments).toEqual(sampleInvestments);
       expect(next.stashedLoans).toEqual(userLoans);
       expect(next.stashedInvestments).toEqual(userInvestments);
+    });
+
+    it('stashes and restores user assets across load/clear', () => {
+      const userAssets = [makeAsset('user-asset')];
+      const start = stateWith({ assets: userAssets });
+      const loaded = financeReducer(start, {
+        type: 'LoadSampleData',
+        loans: [],
+        investments: [],
+        assets: [makeAsset('sample-asset')],
+      });
+      expect(loaded.assets.map((a) => a.Id)).toEqual(['sample-asset']);
+      expect(loaded.stashedAssets).toEqual(userAssets);
+
+      const cleared = financeReducer(loaded, { type: 'ClearSampleData' });
+      expect(cleared.assets).toEqual(userAssets);
+      expect(cleared.stashedAssets).toBeNull();
     });
 
     it('ClearSampleData restores the stashed user data and clears sample data', () => {
@@ -503,6 +609,7 @@ describe('financeReducer', () => {
 
       const loaded = financeReducer(start, {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample')],
         investments: [makeInvestment('sample-inv')],
       });
@@ -517,6 +624,7 @@ describe('financeReducer', () => {
       const start = initialFinanceState;
       const loaded = financeReducer(start, {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample')],
         investments: [],
       });
@@ -532,6 +640,7 @@ describe('financeReducer', () => {
       // Load sample data, then the user fiddles with the samples.
       const loaded = financeReducer(start, {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample')],
         investments: [],
       });
@@ -554,11 +663,13 @@ describe('financeReducer', () => {
       const userLoans = [makeLoan('real')];
       const loaded = financeReducer(stateWith({ loans: userLoans }), {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample-1')],
         investments: [],
       });
       const loadedAgain = financeReducer(loaded, {
         type: 'LoadSampleData',
+        assets: [],
         loans: [makeLoan('sample-2')],
         investments: [],
       });

--- a/src/state/finance-reducer.ts
+++ b/src/state/finance-reducer.ts
@@ -1,5 +1,6 @@
 import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
+import { Asset } from '../models/asset-model';
 import { Scenario } from '../models/scenario-model';
 import { mergeData } from '../helpers/data-helpers';
 
@@ -12,10 +13,13 @@ import { mergeData } from '../helpers/data-helpers';
 export interface FinanceState {
   loans: Loan[];
   investments: Investment[];
+  // Simple holdings — cash / property / custom (Phase 7, Whole Net Worth).
+  assets: Asset[];
   sampleDataLoaded: boolean;
   // User data stashed while sample data is loaded; null otherwise.
   stashedLoans: Loan[] | null;
   stashedInvestments: Investment[] | null;
+  stashedAssets: Asset[] | null;
   // Named what-if scenarios (Phase 4). Session-scoped until 4.5 persists them.
   scenarios: Scenario[];
   // Which scenario is currently overlaid on the chart, or null for none.
@@ -29,17 +33,21 @@ export interface FinanceState {
 export interface DataSnapshot {
   loans: Loan[];
   investments: Investment[];
+  assets: Asset[];
   scenarios: Scenario[];
   stashedLoans: Loan[] | null;
   stashedInvestments: Investment[] | null;
+  stashedAssets: Asset[] | null;
 }
 
 export const initialFinanceState: FinanceState = {
   loans: [],
   investments: [],
+  assets: [],
   sampleDataLoaded: false,
   stashedLoans: null,
   stashedInvestments: null,
+  stashedAssets: null,
   scenarios: [],
   activeScenarioId: null,
 };
@@ -61,16 +69,28 @@ export type FinanceAction =
   | { type: 'UpdateInvestment'; investment: Investment }
   | { type: 'DeleteInvestment'; id: string }
   | { type: 'InsertInvestmentAt'; investment: Investment; index: number }
+  // Asset actions (Phase 7). Like loans/investments, Id generation happens at
+  // the dispatch call site so the reducer stays pure.
+  | { type: 'AddAsset'; asset: Asset }
+  | { type: 'UpdateAsset'; asset: Asset }
+  | { type: 'DeleteAsset'; id: string }
+  | { type: 'InsertAssetAt'; asset: Asset; index: number }
   | {
       type: 'ImportMerge';
       loans: Loan[];
       investments: Investment[];
       scenarios?: Scenario[];
+      assets?: Asset[];
     }
   // Soft-undo for an import merge (roadmap 6.3): restore the data captured
   // immediately before the merge, reverting a merge-by-Id clobber.
   | { type: 'RestoreData'; snapshot: DataSnapshot }
-  | { type: 'LoadSampleData'; loans: Loan[]; investments: Investment[] }
+  | {
+      type: 'LoadSampleData';
+      loans: Loan[];
+      investments: Investment[];
+      assets: Asset[];
+    }
   | { type: 'ClearSampleData' }
   // Scenario actions (Phase 4). Like entities, Id generation happens at the
   // dispatch call site so the reducer stays pure.
@@ -161,11 +181,41 @@ export const financeReducer = (
         ),
       };
 
+    case 'AddAsset':
+      return { ...state, assets: [...state.assets, action.asset] };
+
+    case 'UpdateAsset':
+      // Replace in place, preserving order (regression for #48).
+      return {
+        ...state,
+        assets: state.assets.map((asset) =>
+          asset.Id === action.asset.Id ? action.asset : asset
+        ),
+      };
+
+    case 'DeleteAsset':
+      return {
+        ...state,
+        assets: state.assets.filter((asset) => asset.Id !== action.id),
+      };
+
+    case 'InsertAssetAt':
+      // Restore a deleted asset at its original index (undo).
+      if (state.assets.some((asset) => asset.Id === action.asset.Id)) {
+        return state;
+      }
+      return {
+        ...state,
+        assets: insertAt(state.assets, action.asset, action.index),
+      };
+
     case 'ImportMerge': {
       // Scenarios merge by Id too (Phase 4.5); omitted means "leave unchanged".
       const mergedScenarios = action.scenarios
         ? mergeData(state.scenarios, action.scenarios).items
         : state.scenarios;
+      // Assets merge by Id (Phase 7); omitted means "leave unchanged".
+      const importedAssets = action.assets;
 
       // While sample data is loaded, the visible loans/investments are the
       // samples and the user's real data is parked in the stash. Merge imports
@@ -182,10 +232,14 @@ export const financeReducer = (
           state.stashedInvestments ?? [],
           action.investments
         );
+        const mergedStashedAssets = importedAssets
+          ? mergeData(state.stashedAssets ?? [], importedAssets).items
+          : state.stashedAssets;
         return {
           ...state,
           stashedLoans: mergedLoans,
           stashedInvestments: mergedInvestments,
+          stashedAssets: mergedStashedAssets,
           scenarios: mergedScenarios,
         };
       }
@@ -196,10 +250,14 @@ export const financeReducer = (
         state.investments,
         action.investments
       );
+      const mergedAssets = importedAssets
+        ? mergeData(state.assets, importedAssets).items
+        : state.assets;
       return {
         ...state,
         loans: mergedLoans,
         investments: mergedInvestments,
+        assets: mergedAssets,
         scenarios: mergedScenarios,
       };
     }
@@ -211,9 +269,11 @@ export const financeReducer = (
         ...state,
         loans: action.snapshot.loans,
         investments: action.snapshot.investments,
+        assets: action.snapshot.assets,
         scenarios: action.snapshot.scenarios,
         stashedLoans: action.snapshot.stashedLoans,
         stashedInvestments: action.snapshot.stashedInvestments,
+        stashedAssets: action.snapshot.stashedAssets,
       };
 
     case 'LoadSampleData': {
@@ -228,8 +288,10 @@ export const financeReducer = (
         sampleDataLoaded: true,
         stashedLoans: state.loans,
         stashedInvestments: state.investments,
+        stashedAssets: state.assets,
         loans: action.loans,
         investments: action.investments,
+        assets: action.assets,
       };
     }
 
@@ -244,8 +306,10 @@ export const financeReducer = (
         sampleDataLoaded: false,
         loans: state.stashedLoans ?? [],
         investments: state.stashedInvestments ?? [],
+        assets: state.stashedAssets ?? [],
         stashedLoans: null,
         stashedInvestments: null,
+        stashedAssets: null,
       };
     }
 

--- a/src/state/sample-data.ts
+++ b/src/state/sample-data.ts
@@ -1,5 +1,6 @@
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
+import { Asset, AssetType } from '../models/asset-model';
 
 // Sample data for the onboarding empty state (roadmap 0.9).
 //
@@ -65,5 +66,41 @@ export const sampleInvestments: Investment[] = [
     StartDate: new Date(2019, 5, 1),
     RecurringContribution: 800,
     ContributionFrequency: CompoundingFrequency.Monthly,
+  },
+];
+
+// Phase 7 sample holdings: a high-yield savings account (7.1), the home whose
+// value backs the sample mortgage above (7.2, linked by LinkedLoanId so net
+// worth reflects home equity), and a depreciating car (7.3, a custom asset with
+// a negative growth rate). Stable Ids keep load/clear idempotent.
+export const sampleAssets: Asset[] = [
+  {
+    Id: '00000000-0000-0000-0000-000000000005',
+    Name: 'Sample: High-Yield Savings',
+    Provider: 'Sample Bank',
+    AssetType: AssetType.Cash,
+    Balance: 25000,
+    GrowthRate: 4.25,
+    CompoundingPeriod: CompoundingFrequency.Monthly,
+  },
+  {
+    Id: '00000000-0000-0000-0000-000000000006',
+    Name: 'Sample: Home',
+    Provider: 'Primary Residence',
+    AssetType: AssetType.Property,
+    Balance: 410000,
+    GrowthRate: 3,
+    // Paired with "Sample: Mortgage" so the app can show home equity.
+    LinkedLoanId: '00000000-0000-0000-0000-000000000001',
+    CompoundingPeriod: CompoundingFrequency.Monthly,
+  },
+  {
+    Id: '00000000-0000-0000-0000-000000000007',
+    Name: 'Sample: Car',
+    Provider: 'Personal',
+    AssetType: AssetType.CustomAsset,
+    Balance: 22000,
+    GrowthRate: -12,
+    CompoundingPeriod: CompoundingFrequency.Monthly,
   },
 ];


### PR DESCRIPTION
## Phase 7 — Whole Net Worth (target v1.1)

Makes the net-worth line _true_ by letting PathWise hold everything a person owns. Delivered through **one simple `Asset` model** — a balance plus an annual growth/decline rate — with an `AssetType` discriminator (`Cash` · `Property` · `CustomAsset` · `CustomLiability`) that covers all three roadmap work items. Ordinary assets add to net worth; custom liabilities subtract.

### Work items

| # | Item | How it's delivered |
| --- | --- | --- |
| **7.1** | Cash accounts (HYSA/CD/checking) | `AssetType.Cash` — a balance + APY. The biggest completeness win. |
| **7.2** | Property + mortgage pairing | `AssetType.Property` with an appreciation rate and an optional `LinkedLoanId`, yielding a **home-equity** figure (property value − linked mortgage balance) via `forecastHomeEquity`. |
| **7.3** | Custom asset / liability | `AssetType.CustomAsset` / `CustomLiability` — a catch-all with a simple growth/decline rate (a depreciating car, a private loan, collectibles). |

### What's wired up

- **Engine:** `forecastAsset` (monthly-axis compound growth anchored to today's balance) + `forecastHomeEquity`; assets fold into `forecastNetWorth` with `assetNetWorthSign`.
- **UI:** new **Assets** section/table (`src/asset/asset-table.tsx`), an add/edit dialog (`src/asset/add-edit-asset.tsx`), and an "Add Asset" command-bar button. The asset table shows live home equity for linked properties.
- **Dashboard & chart:** assets roll into the net-worth summary cards, the +5y/+10y/+30y milestones, and the forecast chart (one line per asset).
- **Persistence & I/O:** assets are validated through the JSON import boundary (`parseAssets`), exported, and saved on-device. **Export schema bumped to v4** — a new rung on the D8 migration ladder, so a v3 file simply gains an empty `assets` list on import.
- **Sample data:** a HYSA, the home backing the sample mortgage (linked), and a depreciating car.

### Math Correctness Charter

The new asset math ships with reference (hand-derived compound-growth oracles), property (fast-check: never-negative, monotonic growth), and edge-case tests, plus full validation/parse coverage. **`src/helpers/**` stays at 100% line + branch coverage.**

### Verification

All four gates pass locally:

- ✅ `npm test` — **527 passed**
- ✅ `npm run test:coverage` — 100% statements / branches / functions / lines on `src/helpers/**`
- ✅ `npm run build`
- ✅ `npm run check:lint` (0 errors) · `npm run check:format`

Version bumped to **1.1.0**; ROADMAP, CHANGELOG, README, and copilot-instructions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ULvWRSBi7JwWfpUTEmV1oe

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULvWRSBi7JwWfpUTEmV1oe)_