### PR TITLE
docs(roadmap): proposed UX, i18n, data-portability & forecast-honesty candidates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -157,6 +157,74 @@ Take PathWise off the single device without taking on a backend.
 
 ---
 
+### Candidate additions (proposed, unsequenced) — review queue
+
+Suggestions surfaced by a UX/codebase review (June 2026), kept separate from the
+curated phases above until triaged into one. Each passes the §5 non-goal filters
+(serves the core question, works with no backend, isn't budgeting) and is grouped
+by category. Status is **proposed** unless noted.
+
+#### UX & accessibility (extends Phase 6)
+
+- **C1 — Live-region announcements.** Add `aria-live`/`role="alert"` so screen
+  readers hear dynamic results — optimizer re-rank, snackbar undo offers, sort and
+  data-load changes. _Phase 6.1 added labels, landmarks, and a skip link but no
+  announcements, so the app's most dynamic surfaces (optimizer, chart) are silent
+  to assistive tech._
+- **C2 — `prefers-reduced-motion` support.** Gate dialog/alert/chart transitions on
+  the OS "reduce motion" preference. _A WCAG 2.3.3 expectation that's currently
+  unhandled; cheap to add and removes a real discomfort/vestibular trigger._
+- **C3 — Keyboard shortcuts & command palette.** App-level accelerators (add loan,
+  add investment, undo, toggle persistence) and a `Ctrl/Cmd-K` palette, with a
+  discoverable shortcut help sheet. _Navigation today is native tabbing only;
+  shortcuts make the multi-position workflow fast for the power users most likely
+  to track many loans and investments._
+- **C4 — General edit-level undo.** Extend the existing soft-undo (today scoped to
+  delete and import merges) to cover form edits, since saving an edit is currently
+  destructive. _Editing a wrong value over a good one has no recovery path, unlike
+  every other mutation in the app._
+- **C5 — Contextual field help & inline glossary.** Short helper text / info
+  tooltips on inputs (e.g. "Current Value vs. Starting Balance", compounding
+  frequency, step-up) linked to the README glossary. _Reduces input errors and
+  mis-anchored forecasts; complements but is narrower than 10.4 "show the math,"
+  which explains outputs rather than guiding inputs._
+
+#### Internationalization
+
+- **I1 — Locale & multi-currency display.** Make `format-helpers.ts` (today
+  hardcoded to `en-US`/`USD`) honor a user-selected or browser-detected locale and
+  currency symbol, with matching Day.js date locale. _Numbers and dates are the
+  app's entire output; a non-US user can't read their own net worth in their own
+  currency/format today. Pure presentation — no FX conversion or market data, so it
+  stays within the "no real-time market data" non-goal._
+
+#### Data portability & sharing
+
+- **P1 — CSV export of schedules & positions.** Offer CSV alongside JSON for the
+  amortization/growth schedules and the position list. _JSON round-trips the app's
+  own state; CSV lets users take the numbers into the spreadsheets and accountants'
+  tools they already use — serving the "stop doing this by hand in a spreadsheet"
+  ethos in reverse._
+- **P2 — Export the forecast chart as an image (PNG/SVG).** One-click download of
+  the current chart. _A lightweight, immediate version of the 11.3 PDF report — the
+  shareable artifact for a quick financial conversation, with no backend._
+
+#### Forecast honesty (new feature)
+
+- **F1 — Balance check-ins.** A periodic, low-friction prompt to update each
+  position's real current balance (`Loan.CurrentAmount` / `Investment.CurrentValue`),
+  keeping the today-anchor — and therefore every projection and the optimizer —
+  tied to reality over time. _The README already advertises "balance check-ins" as
+  post-1.0 work, but no phase actually defines it (see doc note below); it directly
+  addresses the live `CurrentValue` drift bugs (#110, #125) and is the natural
+  recurring-use loop for an app people return to as their finances change._
+
+> **Doc note:** README.md's roadmap blurb lists "balance check-ins" as sequenced
+> "in the full ROADMAP.md," but no phase currently defines it. Triaging **F1**
+> into a phase (or amending the README) resolves that inconsistency.
+
+---
+
 ## 6. Sequencing at a Glance
 
 ```


### PR DESCRIPTION
## Summary

A UX-and-codebase review of PathWise (v1.0.0) against the existing roadmap. The roadmap is already thorough — Phases 6–11 cover PWA, shareable links, PDF reports, "show the math," Monte Carlo, and more — and much of what a naive review would suggest **already ships** (soft-undo for delete/import, strong onboarding/empty states, sample-data toggle, excellent mobile cards-vs-tables, chart legend toggles + accessible table fallback, schema-versioned import with a preview). This PR adds only the gaps that are **genuinely uncovered** and pass the roadmap's §5 non-goal filters (serves the core question, works with no backend, isn't a budgeting app).

The additions land in a new, clearly-marked **"Candidate additions (proposed, unsequenced) — review queue"** subsection so the curated phase plan stays intact until each item is triaged into a phase. Each carries a 1–2 sentence rationale and is grouped by category.

## Proposed additions

**UX & accessibility (extends Phase 6)**
- **C1 — Live-region announcements** — Phase 6.1 added labels/landmarks/skip-link but no `aria-live`, so the optimizer re-rank and snackbars are silent to screen readers.
- **C2 — `prefers-reduced-motion` support** — currently unhandled (WCAG 2.3.3); cheap to add.
- **C3 — Keyboard shortcuts & command palette** — navigation is native tabbing only today.
- **C4 — General edit-level undo** — soft-undo exists for delete/import but saving an edit is destructive with no recovery.
- **C5 — Contextual field help & inline glossary** — reduces input errors / mis-anchored forecasts.

**Internationalization**
- **I1 — Locale & multi-currency display** — `src/helpers/format-helpers.ts` is hardcoded to `en-US`/`USD`; presentation-only, so it stays within the "no real-time market data" non-goal.

**Data portability & sharing**
- **P1 — CSV export** of schedules/positions, alongside the existing JSON.
- **P2 — Export the forecast chart as PNG/SVG** — a lightweight version of the 11.3 PDF report.

**Forecast honesty (new feature)**
- **F1 — Balance check-ins** — periodic prompt to refresh real balances so the today-anchor (and every projection + the optimizer) stays tied to reality. Directly addresses the live `CurrentValue` drift bugs #110 and #125.

## Doc inconsistency flagged
README.md advertises "balance check-ins" as sequenced "in the full ROADMAP.md," but no phase currently defines it. F1 (or a README amendment) resolves this — noted inline in the new section.

## Notes
- Documentation-only change; no code, no math touched, so the Math Correctness Charter is unaffected.
- Items deliberately **not** added because they already exist in the roadmap or codebase: PWA/offline (11.2), shareable links (11.1), PDF report (11.3), "show the math"/glossary outputs (10.4), employer match / lump-sum / escrow-PMI (Phase 8), Monte Carlo / inflation (Phase 9), and the already-shipped soft-undo, onboarding, and mobile work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpycYzb5XzMTMx9BFsxpvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpycYzb5XzMTMx9BFsxpvK)_