### PR TITLE
fix(investment): add Current Value input and align table/dashboard anchor

### DIFF
--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -303,6 +303,17 @@ export const forecastInvestment = (
   return points;
 };
 
+// Best-known value of an investment as of `today`: the explicit CurrentValue
+// anchor when set, otherwise the value the engine projects to today from the
+// investment's historical inputs. This is exactly forecastInvestment's index-0
+// anchor, exposed as a single source of truth so the investment table's
+// "Current Value" column/totals and the dashboard's "Total assets" never show
+// two different figures for the same position. (#125)
+export const currentInvestmentValue = (
+  investment: Investment,
+  today: Date = new Date()
+): number => forecastInvestment(investment, today, 0, today)[0].Value;
+
 // Forecast overall net worth on a shared monthly axis from today to the
 // horizon: total investment value, plus simple assets (cash/property/custom,
 // Phase 7), minus total loan balance and any custom-liability assets. Scenario

--- a/src/helpers/summary-helpers.test.ts
+++ b/src/helpers/summary-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { summarizePositions } from './summary-helpers';
-import { forecastNetWorth } from './forecast-helpers';
+import { currentInvestmentValue, forecastNetWorth } from './forecast-helpers';
 import { getMonthlyPayment } from './loan-helpers';
 import { Loan } from '../models/loan-model';
 import { CompoundingFrequency, Investment } from '../models/investment-model';
@@ -121,6 +121,28 @@ describe('summarizePositions', () => {
     expect(
       summarizePositions([zeroPayment], [], TODAY).monthlyCommitments
     ).toBeCloseTo(derived, 2);
+  });
+
+  it('totalAssets uses the same anchor as the table column for a past-dated investment with CurrentValue unset (#125)', () => {
+    // The investment table's "Current Value" column/totals and this dashboard
+    // total must read one figure. Previously the table fell back to
+    // StartingBalance while the dashboard projected to today, so the two
+    // disagreed for any past-dated investment with CurrentValue unset.
+    const pastDated: Investment = {
+      Id: 'inv-past',
+      Provider: 'Brokerage',
+      Name: 'Old Fund',
+      StartDate: new Date(2016, 5, 20),
+      StartingBalance: 10000,
+      AverageReturnRate: 7,
+      CompoundingPeriod: CompoundingFrequency.Annually,
+    };
+
+    const anchor = currentInvestmentValue(pastDated, TODAY);
+    // The projected-to-today value has grown well past the starting balance.
+    expect(anchor).toBeGreaterThan(pastDated.StartingBalance);
+    // The dashboard total reads exactly that same anchor.
+    expect(summarizePositions([], [pastDated], TODAY).totalAssets).toBe(anchor);
   });
 
   it('is all zeros with no positions', () => {

--- a/src/helpers/summary-helpers.ts
+++ b/src/helpers/summary-helpers.ts
@@ -2,7 +2,7 @@ import { Loan } from '../models/loan-model';
 import { Investment } from '../models/investment-model';
 import { Asset } from '../models/asset-model';
 import {
-  forecastInvestment,
+  currentInvestmentValue,
   forecastLoan,
   getEffectiveMonthlyPayment,
 } from './forecast-helpers';
@@ -53,8 +53,7 @@ export const summarizePositions = (
   );
   const totalAssets = roundToCents(
     investments.reduce(
-      (sum, investment) =>
-        sum + forecastInvestment(investment, today, 0, today)[0].Value,
+      (sum, investment) => sum + currentInvestmentValue(investment, today),
       0
     ) + assetHoldings.reduce((sum, asset) => sum + getAssetValueToday(asset), 0)
   );

--- a/src/investment/add-edit-investment.test.tsx
+++ b/src/investment/add-edit-investment.test.tsx
@@ -56,4 +56,50 @@ describe('AddEditInvestment (form)', () => {
     );
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('edits an investment’s Current Value and saves it as the forecast anchor (#110)', async () => {
+    const onSave = vi.fn();
+    renderWithProviders(
+      <AddEditInvestment
+        open
+        investment={validInvestment}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+
+    const currentValue = screen.getByLabelText(/Current Value/);
+    await userEvent.type(currentValue, '12500');
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Save Investment' })
+    );
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ Id: 'edit-1', CurrentValue: 12500 }),
+      expect.objectContaining({ Id: 'edit-1' })
+    );
+  });
+
+  it('blocks saving when Current Value is negative (#99 rule, now reachable)', async () => {
+    const onSave = vi.fn();
+    renderWithProviders(
+      <AddEditInvestment
+        open
+        investment={validInvestment}
+        onSave={onSave}
+        onClose={vi.fn()}
+      />
+    );
+
+    const currentValue = screen.getByLabelText(/Current Value/);
+    await userEvent.type(currentValue, '-100');
+
+    // The #99 negative-CurrentValue rule blocks Save (button disabled), and the
+    // per-field error is revealed once the field is touched.
+    expect(
+      screen.getByRole('button', { name: 'Save Investment' })
+    ).toBeDisabled();
+    expect(onSave).not.toHaveBeenCalled();
+  });
 });

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -136,6 +136,30 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
             )}
             required
           />
+          <NumericFormat
+            label="Current Value (Optional)"
+            value={newInvestment.CurrentValue ?? ''}
+            thousandSeparator
+            decimalScale={2}
+            prefix={'$'}
+            customInput={TextField}
+            onValueChange={(vs) => {
+              // Leave undefined when blank so the forecast falls back to the
+              // value projected to today (preserving prior behavior); set it to
+              // anchor the forecast to today's actual value, like a loan's
+              // Current Amount. (#110)
+              setNewInvestment({
+                ...newInvestment,
+                CurrentValue: vs.value ? Number(vs.value) : undefined,
+              });
+            }}
+            onBlur={() => touch('CurrentValue')}
+            error={Boolean(errorFor('CurrentValue'))}
+            helperText={fieldHelperText(
+              errorFor('CurrentValue'),
+              warningFor('CurrentValue')
+            )}
+          />
           <DatePicker
             label="Start Date"
             value={dayjs(newInvestment.StartDate)}

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -23,6 +23,7 @@ import {
   StepUpType,
 } from '../models/investment-model';
 import { getInvestmentPeriods } from '../helpers/investment-helpers';
+import { currentInvestmentValue } from '../helpers/forecast-helpers';
 import { formatCurrency, formatPercent } from '../helpers/format-helpers';
 import { sortBy, SortDirection, SortValue } from '../helpers/sort-helpers';
 import { filterBySearch } from '../helpers/filter-helpers';
@@ -61,10 +62,12 @@ interface InvestmentRowHandlers {
   onDelete: (investment: Investment) => void;
 }
 
-// Best-known current value: the explicit CurrentValue when set, else the
-// starting balance as a stand-in for the table/totals.
+// Best-known current value for the table column and totals: the explicit
+// CurrentValue when set, else the value the engine projects to today. Reuses
+// the same anchor the dashboard's "Total assets" reads so the two never
+// disagree for a past-dated investment with CurrentValue unset. (#125)
 const currentValue = (investment: Investment): number =>
-  investment.CurrentValue ?? investment.StartingBalance;
+  currentInvestmentValue(investment);
 
 const investmentActions = (
   investment: Investment,


### PR DESCRIPTION
## Summary

Fixes the two open `Current Value` bugs, which share a root cause: the engine treats `Investment.CurrentValue` as a first-class forecast anchor, but the UI couldn't write it and the table read a different "current value" than the dashboard.

### #110 — Add/Edit form had no `CurrentValue` input
- Added an optional **"Current Value"** numeric input to `add-edit-investment.tsx`, mirroring the loan form's `CurrentAmount` field and placed right after Starting Balance.
- Bound to `newInvestment.CurrentValue`; left `undefined` when blank, so investments that don't set it keep falling back to the projected-to-today value (no behavior change for existing data).
- Wired `errorFor`/`warningFor('CurrentValue')` through the existing `validateInvestment` + `useFieldTracking`, so the negative-value rule from #99 — previously unreachable from the UI — now blocks Save and shows a per-field error.

### #125 — Table "Current Value" contradicted the dashboard "Total assets"
- The table fell back to `StartingBalance` while the dashboard projected the value to today, so the two figures disagreed for any past-dated investment with `CurrentValue` unset.
- Factored a shared `currentInvestmentValue(investment, today)` helper in `forecast-helpers.ts` (exactly `forecastInvestment(...)[0].Value`, the engine's today-anchor) and had **both** the investment table (column, mobile card, totals, sorting) and `summarizePositions` consume it — a single source of truth. Investments with an explicit `CurrentValue` are unaffected (both already honored it).

## Testing
- `vitest run` — all 530 tests pass, including new regression tests:
  - dashboard `totalAssets` reads the same anchor as the table column for a past-dated, `CurrentValue`-unset investment (#125)
  - editing & saving `CurrentValue` from the form (#110)
  - negative `CurrentValue` disables Save (#99 rule, now reachable)
- `tsc -b`, `eslint`, and `prettier --check` all clean.

Closes #110
Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5gSbhkfuotwrerkTGRKz3)_