### PR TITLE
docs(roadmap): add Phase 13 — data safety, net-worth goals, CSV import & quick filters

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,6 +145,40 @@ item passes the §5 non-goal filters.
 
 ---
 
+### Phase 13 — Data Safety & Goal-Setting — _target v2.2_
+
+Surfaced by a June 2026 follow-up UX/codebase review. These close a data-loss
+gap, turn the read-only milestones into something users can aim at, and finish
+the spreadsheet round-trip. Each item passes the §5 non-goal filters
+(client-side, data stays on device, not a budgeting app). Items are grouped by
+category; the rationale column says why each earns a slot.
+
+**Data safety (UX)**
+
+| #    | Work item                          | Rationale / acceptance                                                                                                                                                                                                                                                                                            |
+| ---- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 13.1 | **Unsaved-changes guard**          | A `beforeunload` warning when positions exist but on-device persistence is **off**, so an accidental refresh or tab-close can't silently wipe everything the user just entered. There is no such guard today (no `beforeunload` listener anywhere), and the opt-in persistence toggle is the only safety net — a user who hasn't opted in loses all data on reload. Cheap, no backend, prevents the worst first-run experience. |
+
+**New features**
+
+| #    | Work item                          | Rationale / acceptance                                                                                                                                                                                                                                                                                            |
+| ---- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 13.2 | **Net-worth / savings goal**       | A user-set target (e.g. "$1M by 2040" or "debt-free by 2030") drawn as a reference line on the forecast chart, with a projected hit/miss and ETA against the current plan. The milestone callouts today are read-only _projections_ (`milestone-helpers.ts`); a goal turns them into something the optimizer and scenarios can be aimed at — directly serving the founding "where should my money go?" question. Pairs with the Phase 10 FI mode (10.3). |
+
+**Portability**
+
+| #    | Work item                          | Rationale / acceptance                                                                                                                                                                                                                                                                                            |
+| ---- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 13.3 | **CSV import (round-trip with 11.5)** | Pair the planned CSV _export_ (11.5) with CSV _import_ of positions, so users can bulk-add loans/investments/assets from the spreadsheets they already keep instead of one dialog at a time. Import is JSON-only today (`data-manager.tsx` accepts `.json` only); CSV is the format most users' existing position data actually lives in. Reuses the D8 validation/migration boundary on the parsed rows. |
+
+**Power-user UX**
+
+| #    | Work item                          | Rationale / acceptance                                                                                                                                                                                                                                                                                            |
+| ---- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 13.4 | **Quick filters by type & status** | Filtering today is a name/provider substring match only (`filter-helpers.ts`); add quick toggles to filter the positions view by type (loan / investment / cash / property / custom) and by active-scenario membership. Helps users with many positions find a row fast — a small, purely-derived UI addition with no engine impact. |
+
+---
+
 ### Considered but not currently planned
 
 Reviewed against the roadmap and intentionally **not** scheduled. Recorded here so
@@ -171,9 +205,10 @@ Phase 9  Honest Uncertainty               v1.3   (builds on the Phase 7 property
 Phase 10 From Calculator to Plan          v1.4
 Phase 11 Beyond Personal                  v2.0
 Phase 12 Accessibility & Interaction Polish  v2.1
+Phase 13 Data Safety & Goal-Setting       v2.2
 ```
 
-Rationale for the order: completeness (the true net-worth line) already shipped in Phase 7, so what's left is answer quality, then statistical honesty, then planning, then distribution, then accessibility & interaction polish on the now-complete surface.
+Rationale for the order: completeness (the true net-worth line) already shipped in Phase 7, so what's left is answer quality, then statistical honesty, then planning, then distribution, then accessibility & interaction polish on the now-complete surface, then a data-safety/goal-setting follow-up from the v2.x review.
 
 ---
 


### PR DESCRIPTION
## Summary

A follow-up UX/codebase review of PathWise against its current roadmap. The roadmap is already very thorough (Phases 8–12 plus an explicit "Considered but not planned" section), so this PR adds **only genuinely-new items that the code confirms are missing** and that pass the §5 non-goal filters (client-side, data stays on device, not a budgeting app).

Adds a new **Phase 13 — Data Safety & Goal-Setting (target v2.2)** to `ROADMAP.md`, organized by category, and updates the §6 sequencing block.

## What I checked first (to avoid re-proposing existing/planned work)

To keep the additions honest, I verified the following are **already present** and deliberately left them out:

- **Clone/duplicate** — exists for all three entity types (loans, investments, assets).
- **Chart controls** — 5Y/10Y/30Y/Full range + show/hide legend + table fallback already shipped.
- **Search** — name/provider substring search exists across tables.
- **Sample data + onboarding empty state + first-visit notice** — already present.
- **Already on the roadmap** — locale/multi-currency and balance check-ins (in "Considered but not planned"); a11y announcements, reduced-motion, command palette, edit-undo (Phase 12); CSV export, PDF/PNG export, shareable links (Phase 11).

## Suggested additions (each with rationale)

| #    | Category        | Item | Why |
| ---- | --------------- | ---- | --- |
| 13.1 | Data safety (UX)| **Unsaved-changes guard** | No `beforeunload` listener exists anywhere today, so an accidental refresh/close when on-device persistence is **off** silently wipes everything the user entered. Cheap, no backend, fixes the worst first-run failure mode. |
| 13.2 | New feature     | **Net-worth / savings goal** | Milestone callouts are read-only _projections_ today; a user-set target (e.g. "$1M by 2040") drawn as a chart reference line with a hit/miss ETA turns them into something the optimizer/scenarios can aim at — directly serving the founding "where should my money go?" question. Pairs with the planned FI mode (10.3). |
| 13.3 | Portability     | **CSV import (round-trip with 11.5)** | Import is JSON-only today; the roadmap plans CSV _export_ (11.5) but not the import side. CSV is where most users' existing position data lives; reuses the D8 validation boundary on parsed rows. |
| 13.4 | Power-user UX   | **Quick filters by type & status** | Filtering today is a name/provider substring match only; quick toggles by position type and active-scenario membership help users with many positions, as a purely-derived UI addition with no engine impact. |

## Notes

- Documentation-only change; no code or math touched, so the Math Correctness Charter (§4) is unaffected.
- Meaningful improvements **were** identified, so this PR is intended for review/merge (not a close-without-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185obtLZ3WHn7b9idTDLoaA

---
_Generated by [Claude Code](https://claude.ai/code/session_0185obtLZ3WHn7b9idTDLoaA)_