### PR TITLE
Resolve remaining optimizer/PIT robustness issues (#131, #134, #135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Detailed acceptance criteria for each phase live in the merged PRs and the
 
 ## [Unreleased]
 
+## [1.4.1] — Optimizer and projection robustness
+
+### Fixed
+
+- **The optimizer no longer shows a spinner that never resolves when its
+  background worker fails.** A worker error now clears the spinner and surfaces an
+  error message instead of a stuck "calculating…" state, and failures are reported
+  on the same channel as results so a stale failure can't flag the current search.
+  (#131)
+- **Bounded the optimizer's suggested-split search** so aggressive engine options
+  can no longer blow up the search space — the split is capped to at most four
+  targets and the step granularity is floored to keep the grid bounded. Default
+  behavior is unchanged. (#134)
+- **Clarified that the point-in-time investment calculator is a theoretical
+  projection from an investment's original inputs**, not the actual-value anchor
+  the dashboard and chart use, so its figures can legitimately differ for a
+  position with an explicit current value. Explained in code and in a caption on
+  the popout. (#135)
+
 ## [1.4.0] — Investments are a kind of asset
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-calculator",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/src/helpers/investment-helpers.test.ts
+++ b/src/helpers/investment-helpers.test.ts
@@ -483,6 +483,26 @@ describe('Investment Helpers', () => {
           100;
         expect(pit.ProjectedAnnualReturn).toBeCloseTo(expected, 2);
       });
+
+      it('is a theoretical projection that intentionally ignores the CurrentValue anchor (#135)', () => {
+        // The PIT popout is a "from original inputs" projection across the whole
+        // timeline; the actual-balance anchor belongs to the dashboard's
+        // currentInvestmentValue, not here. Setting CurrentValue must not move
+        // these figures — the divergence is documented and by design.
+        const endDate = new Date(2030, 0, 1);
+        const projected = getPitInvestmentCalculation(investment, endDate);
+        const withAnchor = getPitInvestmentCalculation(
+          { ...investment, CurrentValue: 999999 },
+          endDate
+        );
+        expect(withAnchor.CurrentValue).toBe(projected.CurrentValue);
+        expect(withAnchor.TotalInterestEarned).toBe(
+          projected.TotalInterestEarned
+        );
+        expect(withAnchor.ProjectedAnnualReturn).toBe(
+          projected.ProjectedAnnualReturn
+        );
+      });
     });
   });
 

--- a/src/helpers/investment-helpers.ts
+++ b/src/helpers/investment-helpers.ts
@@ -353,7 +353,24 @@ export const generateInvestmentGrowth = (
   return growth;
 };
 
-// Returns a point-in-time view of an investment using date-based calculations
+// Point-in-time view of an investment at an arbitrary date along its timeline.
+//
+// This is deliberately a THEORETICAL projection from the investment's original
+// inputs (StartingBalance + contributions + compounding) and intentionally does
+// NOT consult the `CurrentValue` actual-balance anchor. It backs the PIT popout,
+// whose "Projection Date" ranges over the whole life of the investment
+// ([StartDate, ∞)), so there is no single "today" at which an anchor would even
+// apply — applying CurrentValue uniformly across past and future projection
+// dates would be wrong.
+//
+// The dashboard, investment table, and chart instead report the actual-anchored
+// value as of today via `currentInvestmentValue` (= CurrentValue when set) — the
+// single source of truth for "what it's worth now". The two figures can
+// legitimately differ for an investment whose real balance has drifted from the
+// modeled curve; that divergence is by design. (A correct anchored projection
+// here would also have to duplicate forecastInvestment's off-boundary
+// compounding reconciliation (#88/#103), or import it and create an
+// investment-helpers <-> forecast-helpers dependency cycle.) (#135)
 export const getPitInvestmentCalculation = (
   investment: Investment,
   date?: Date

--- a/src/helpers/optimizer-helpers.test.ts
+++ b/src/helpers/optimizer-helpers.test.ts
@@ -258,6 +258,41 @@ describe('suggestPlans', () => {
       expect(sumAllocations(plan.plan.allocations)).toBeCloseTo(300, 2);
     }
   });
+
+  it('clamps maxCandidates and floors stepPercent so aggressive options cannot blow up the search (#134)', () => {
+    // Five targets with maxCandidates: 50 and stepPercent: 1 would, unclamped,
+    // enumerate integer compositions of 100 across up to 50 targets — millions of
+    // full forecasts, effectively a hang. The clamp caps the split to at most
+    // MAX_SPLIT_CANDIDATES (4) targets and floors the step, so the grid — and the
+    // plan count — stays bounded and the search terminates immediately.
+    const loans: Loan[] = Array.from({ length: 5 }, (_, i) => ({
+      ...loan,
+      Id: `loan-${i}`,
+      Name: `Loan ${i}`,
+    }));
+    // Short horizon → each per-composition forecast is cheap, so even the bounded
+    // worst-case grid runs fast under coverage instrumentation.
+    const horizon = new Date(2025, 3, 1);
+
+    const plans = suggestPlans(
+      loans,
+      [],
+      600,
+      { maxCandidates: 50, stepPercent: 1 },
+      TODAY,
+      horizon
+    );
+
+    // Bounded: 5 singles plus a small split grid, nowhere near the unclamped
+    // millions. And no plan splits across more than the clamped target count —
+    // un-capped, the topTargets (and thus some splits) would span all 5.
+    expect(plans.length).toBeGreaterThan(loans.length);
+    expect(plans.length).toBeLessThan(1000);
+    for (const plan of plans) {
+      expect(sumAllocations(plan.plan.allocations)).toBeCloseTo(600, 2);
+      expect(Object.keys(plan.plan.allocations).length).toBeLessThanOrEqual(4);
+    }
+  });
 });
 
 describe('rebalanceAllocation', () => {

--- a/src/helpers/optimizer-helpers.ts
+++ b/src/helpers/optimizer-helpers.ts
@@ -120,6 +120,18 @@ export interface SuggestOptions {
 const DEFAULT_STEP_PERCENT = 10;
 const DEFAULT_MAX_CANDIDATES = 3;
 
+// Hard upper bounds on the split search so it stays tractable regardless of the
+// caller's SuggestOptions (#134). The grid enumerates integer compositions of
+// (100 / stepPercent) across the split targets and runs a full multi-entity
+// forecast per composition, so a fine step over several targets blows up
+// combinatorially — e.g. stepPercent 1 with 5 targets is C(104, 4) ≈ 4.6M
+// forecasts, which would pin the worker indefinitely. Cap the number of split
+// targets and floor the step so the composition count stays within
+// MAX_SPLIT_GRID_POINTS. The defaults (10% / 3 candidates → 66 compositions) sit
+// far inside these bounds, so normal use is unaffected.
+const MAX_SPLIT_CANDIDATES = 4;
+const MAX_SPLIT_GRID_POINTS = 1000;
+
 // The split grid only sums to a true 100% when the step evenly divides 100;
 // otherwise `Math.round(100 / step) * step` lands short (e.g. step=7 → 98%),
 // drifting the displayed splitLabel percentages and share ratios away from a
@@ -132,6 +144,29 @@ const normalizeStepPercent = (requested: number): number => {
     Math.abs(divisor - requested) < Math.abs(best - requested) ? divisor : best
   );
 };
+
+// Number of integer compositions of `steps` over `parts` parts:
+// C(steps + parts - 1, parts - 1). Computed multiplicatively (exact for the
+// small, clamped inputs here) so the grid can be sized without enumerating it.
+const compositionCount = (steps: number, parts: number): number => {
+  let count = 1;
+  for (let i = 1; i < parts; i++) {
+    count = (count * (steps + i)) / i;
+  }
+  return count;
+};
+
+// Finest divisor of 100 whose composition grid over `parts` targets fits within
+// MAX_SPLIT_GRID_POINTS. Seeded with the coarsest divisor (100 → grid size
+// `parts`, which always fits), so it always returns a clean divisor of 100. (#134)
+const minFittingStepPercent = (parts: number): number =>
+  STEP_DIVISORS.reduce(
+    (finest, divisor) =>
+      compositionCount(100 / divisor, parts) <= MAX_SPLIT_GRID_POINTS
+        ? Math.min(finest, divisor)
+        : finest,
+    100
+  );
 
 // Every ordered list of `parts` non-negative integers that sum to `total`
 // (integer compositions including zeros), e.g. total=10, parts=2 →
@@ -203,10 +238,15 @@ export const suggestPlans = (
 ): PlanEvaluation[] => {
   if (!(monthlyExtra > 0)) return [];
 
-  const stepPercent = normalizeStepPercent(
+  const requestedStep = normalizeStepPercent(
     options.stepPercent ?? DEFAULT_STEP_PERCENT
   );
-  const maxCandidates = options.maxCandidates ?? DEFAULT_MAX_CANDIDATES;
+  // Clamp candidate count to a small bound so the split grid can't explode; the
+  // floor/min collapse a fractional, zero, or negative request into range. (#134)
+  const maxCandidates = Math.min(
+    Math.max(1, Math.floor(options.maxCandidates ?? DEFAULT_MAX_CANDIDATES)),
+    MAX_SPLIT_CANDIDATES
+  );
 
   const targets: Target[] = [
     ...loans.map((loan) => ({ id: loan.Id, name: loan.Name })),
@@ -258,6 +298,13 @@ export const suggestPlans = (
     });
 
   if (topTargets.length >= 2) {
+    // Floor the requested step so the composition grid over the actual number of
+    // split targets stays within budget — a fine step is coarsened, never the
+    // reverse, so an explicit coarse request is still honored. (#134)
+    const stepPercent = Math.max(
+      requestedStep,
+      minFittingStepPercent(topTargets.length)
+    );
     const steps = Math.round(100 / stepPercent);
     for (const composition of integerCompositions(steps, topTargets.length)) {
       const shares = composition.map((part) => part * stepPercent);

--- a/src/investment/pit-popout.tsx
+++ b/src/investment/pit-popout.tsx
@@ -162,6 +162,11 @@ export const PitPopout = (props: PitPopoutProps) => {
           <Typography>{`Current Value: ${formatCurrency(
             pitInvestment.CurrentValue
           )}`}</Typography>
+          <Typography variant="caption" color="text.secondary">
+            Theoretical projection from this investment&apos;s original inputs.
+            When you&apos;ve set an actual current value, your dashboard and the
+            chart reflect that instead, so the figures here may differ.
+          </Typography>
         </Box>
       </DialogContent>
     </ResponsiveDialog>

--- a/src/optimizer/optimizer-panel.tsx
+++ b/src/optimizer/optimizer-panel.tsx
@@ -76,7 +76,7 @@ export const OptimizerPanel = ({
     [horizonKey, loans, investments, today]
   );
 
-  const { plans, loading } = useOptimizer({
+  const { plans, loading, error } = useOptimizer({
     loans,
     investments,
     monthlyExtra,
@@ -143,6 +143,12 @@ export const OptimizerPanel = ({
         </Alert>
       ) : (
         <>
+          {error && (
+            <Alert severity="error">
+              The optimizer ran into a problem and couldn&apos;t finish. Try
+              adjusting your inputs.
+            </Alert>
+          )}
           <Table size="small" aria-label="Ranked allocation plans">
             <TableHead>
               <TableRow>

--- a/src/optimizer/optimizer.worker.ts
+++ b/src/optimizer/optimizer.worker.ts
@@ -32,6 +32,10 @@ export interface OptimizerRequest {
 export interface OptimizerResponse {
   requestId: number;
   plans: PlanEvaluation[];
+  // Set when the search threw. Routing the failure through this requestId-keyed
+  // channel lets the hook drop a stale failure exactly as it drops a stale
+  // success, rather than reacting to an uncorrelated main-thread ErrorEvent. (#131)
+  error?: boolean;
 }
 
 const ctx = self as unknown as DedicatedWorkerGlobalScope;
@@ -47,15 +51,24 @@ ctx.onmessage = (event: MessageEvent<OptimizerRequest>) => {
     horizon,
     assets,
   } = event.data;
-  const plans = suggestPlans(
-    loans,
-    investments,
-    monthlyExtra,
-    options,
-    today,
-    horizon,
-    assets
-  );
-  const response: OptimizerResponse = { requestId, plans };
-  ctx.postMessage(response);
+  try {
+    const plans = suggestPlans(
+      loans,
+      investments,
+      monthlyExtra,
+      options,
+      today,
+      horizon,
+      assets
+    );
+    const response: OptimizerResponse = { requestId, plans };
+    ctx.postMessage(response);
+  } catch {
+    // Report a search failure on the same requestId-keyed channel as success, so
+    // the hook can ignore it if the request has since been superseded, instead of
+    // letting the exception escape to the main thread's onerror where it can't be
+    // correlated to this request. (#131)
+    const response: OptimizerResponse = { requestId, plans: [], error: true };
+    ctx.postMessage(response);
+  }
 };

--- a/src/optimizer/use-optimizer.ts
+++ b/src/optimizer/use-optimizer.ts
@@ -17,6 +17,9 @@ interface UseOptimizerArgs {
 interface OptimizerResult {
   plans: PlanEvaluation[];
   loading: boolean;
+  // True when the worker failed, so the UI can report it instead of showing a
+  // spinner that never resolves. Cleared when a new search starts.
+  error: boolean;
 }
 
 const DEBOUNCE_MS = 250;
@@ -36,6 +39,7 @@ export const useOptimizer = ({
 }: UseOptimizerArgs): OptimizerResult => {
   const [plans, setPlans] = useState<PlanEvaluation[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const workerRef = useRef<Worker | null>(null);
   const requestIdRef = useRef(0);
 
@@ -51,6 +55,17 @@ export const useOptimizer = ({
       setPlans(event.data.plans);
       setLoading(false);
     };
+    // Without these, a worker-side failure (an exception in suggestPlans, a
+    // structured-clone or module-load failure) never resolves `loading`, so the
+    // spinner spins forever. The ErrorEvent carries no requestId, but `loading`
+    // is only ever true while a request is in flight, so clearing it on any
+    // worker error is safe. (#131)
+    const handleWorkerFailure = () => {
+      setLoading(false);
+      setError(true);
+    };
+    worker.onerror = handleWorkerFailure;
+    worker.onmessageerror = handleWorkerFailure;
     workerRef.current = worker;
     return () => {
       worker.terminate();
@@ -65,6 +80,7 @@ export const useOptimizer = ({
       requestIdRef.current += 1;
       setPlans([]);
       setLoading(false);
+      setError(false);
       return;
     }
 
@@ -72,6 +88,7 @@ export const useOptimizer = ({
     if (!worker) return;
 
     setLoading(true);
+    setError(false);
     const requestId = (requestIdRef.current += 1);
     const handle = window.setTimeout(() => {
       const request: OptimizerRequest = {
@@ -83,11 +100,19 @@ export const useOptimizer = ({
         horizon,
         assets,
       };
-      worker.postMessage(request);
+      try {
+        worker.postMessage(request);
+      } catch {
+        // A non-cloneable message would throw here synchronously, outside the
+        // worker's onerror handler; clear the spinner directly so it can't
+        // stick. (#131)
+        setLoading(false);
+        setError(true);
+      }
     }, DEBOUNCE_MS);
 
     return () => window.clearTimeout(handle);
   }, [loans, investments, monthlyExtra, today, horizon, assets]);
 
-  return { plans, loading };
+  return { plans, loading, error };
 };

--- a/src/optimizer/use-optimizer.ts
+++ b/src/optimizer/use-optimizer.ts
@@ -52,14 +52,21 @@ export const useOptimizer = ({
     worker.onmessage = (event: MessageEvent<OptimizerResponse>) => {
       // Ignore results for any request newer work has already superseded.
       if (event.data.requestId !== requestIdRef.current) return;
+      if (event.data.error) {
+        // The search failed for the current request; surface it, keep no plans.
+        setError(true);
+        setLoading(false);
+        return;
+      }
       setPlans(event.data.plans);
       setLoading(false);
     };
-    // Without these, a worker-side failure (an exception in suggestPlans, a
-    // structured-clone or module-load failure) never resolves `loading`, so the
-    // spinner spins forever. The ErrorEvent carries no requestId, but `loading`
-    // is only ever true while a request is in flight, so clearing it on any
-    // worker error is safe. (#131)
+    // Last-resort net for failures that never produce a response message — a
+    // worker module-load failure, or onmessageerror on an undeserializable
+    // message. A suggestPlans throw is reported through the requestId-keyed
+    // onmessage channel above (so it can be dropped if stale); these events carry
+    // no requestId, but `loading` is only ever true while a request is in flight,
+    // so clearing it and surfacing the error here is safe. (#131)
     const handleWorkerFailure = () => {
       setLoading(false);
       setError(true);


### PR DESCRIPTION
Resolves the three remaining open issues, each on its own commit for review.

### #135 — PIT investment view vs. CurrentValue (documentation)
`getPitInvestmentCalculation` projects purely from the original inputs and does not consult the `CurrentValue` actual-balance anchor, so the PIT popout could disagree with the dashboard/chart for an investment that has an explicit `CurrentValue`.

Resolved as the **intentional design** the issue itself offered as an option. The popout's *Projection Date* spans the whole life of the investment (`[StartDate, ∞)`), so there is no single "today" at which the anchor applies — and a correct anchored + forward projection would either duplicate `forecastInvestment`'s off-boundary compounding reconciliation (#88/#103) or import it and create an `investment-helpers ↔ forecast-helpers` dependency cycle.
- Documented the intent on the function, pointing at `currentInvestmentValue` as the actual-anchored source of truth.
- Added a caption to the popout so users see *why* the figures can differ from their dashboard.
- Regression test locks in that `CurrentValue` does not move the PIT figures.

### #134 — optimizer search-space blowup (fix)
`suggestPlans` took `maxCandidates`/`stepPercent` with no upper bound; a fine step over several candidates is a combinatorial blowup (e.g. `stepPercent 1 × 5 targets ≈ 4.6M` forecasts, effectively a hang). Latent today (the only caller passes no options) but unguarded for any future caller.
- Cap the split to `MAX_SPLIT_CANDIDATES` (4) targets and floor the step per target count so the composition grid stays within `MAX_SPLIT_GRID_POINTS` (1000).
- Defaults (10% / 3 candidates → 66 compositions) sit far inside the bounds, so normal results are unchanged.
- Regression test confirms aggressive options stay bounded.

### #131 — optimizer spinner sticks on worker error (fix)
`useOptimizer` only cleared `loading` in `onmessage`, so any worker-side failure (an exception in `suggestPlans`, a structured-clone or module-load failure) left the "calculating…" spinner spinning forever with no error surfaced.
- Added `worker.onerror`/`onmessageerror` handlers that clear loading and set an error flag, plus a `try/catch` around the synchronous `postMessage` (a non-cloneable message throws outside `onerror`).
- Surfaced the failure as an error `Alert` in the optimizer panel; the flag resets when a new search starts.
- Following a `/simplify` altitude review: the worker now catches its own `suggestPlans` exceptions and reports them on the same `requestId`-keyed channel as results, so a stale failure can't flag the current search; `onerror`/`onmessageerror` remain only as a last-resort net for response-less failures (module-load, undeserializable message).

### Release
Patch release **1.4.1** — `package.json` + `package-lock.json` bumped and a `1.4.1` entry added to `CHANGELOG.md` under Fixed.

### Quality
Build, lint, and format are green; the full suite passes (589 tests) and `src/helpers/**` stays at **100%** line/branch/function/statement coverage. The relocated `useOptimizer` hook and the worker are out of the coverage gate by construction (per `vite.config`).

Closes #131
Closes #134
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133jkCKi8aGhUtynvUyb8DK

---
_Generated by [Claude Code](https://claude.ai/code/session_0133jkCKi8aGhUtynvUyb8DK)_