### PR TITLE
Fix negative-asset oscillation and dropped employer-match migration field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ Detailed acceptance criteria for each phase live in the merged PRs and the
 
 ## [Unreleased]
 
+## [1.14.1] — Audit fixes
+
+### Fixed
+
+- **A depreciating asset with an extreme negative growth rate (beyond
+  -100%/yr for its compounding frequency, e.g. -150%/yr annually) could go
+  negative and oscillate in sign at each compounding boundary**, instead of
+  decaying toward — and staying at — zero as documented. `forecastAsset` now
+  floors the per-period factor at 0. `GrowthRate` is only warned on past
+  ±25%/yr, not blocked, so this was reachable through the normal UI/import
+  path. (#152)
+- **The v4→v5 schema migration silently dropped a folded investment's
+  employer 401(k)-match fields** (`EmployerMatchRate`, `EmployerMatchLimitPct`,
+  `AnnualSalary`), diverging from the canonical `investmentToAsset` converter
+  it's documented to mirror. A migrated forecast would have omitted the
+  employer match; real historical exports predate the match feature and were
+  unaffected, but a hand-edited or future v4 payload would have silently lost
+  the data. The migration step now carries all three fields. (#153)
+
 ## [1.14.0] — Holdings & property context (research links)
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-calculator",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.14.1",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/src/helpers/asset-helpers.test.ts
+++ b/src/helpers/asset-helpers.test.ts
@@ -149,6 +149,31 @@ describe('forecastAsset', () => {
     expect(series[12].Value).toBeLessThan(20000);
   });
 
+  // Regression (#152): with annual compounding, the per-period factor is
+  // 1 + GrowthRate/100. At -100%/yr it's exactly 0; beyond that (e.g. -150%/yr)
+  // it goes negative, so an unclamped `value *= factor` flips sign every
+  // compounding boundary instead of decaying toward — and staying at — zero as
+  // documented. GrowthRate is only warned on past ±25%/yr, not blocked, so this
+  // is reachable through the normal UI/import path.
+  it('floors at zero rather than going negative for an extreme negative rate', () => {
+    const horizon = new Date(2030, 0, 1);
+    const series = forecastAsset(
+      baseAsset({
+        Balance: 10000,
+        GrowthRate: -150,
+        CompoundingPeriod: CompoundingFrequency.Annually,
+        AssetType: AssetType.CustomAsset,
+      }),
+      horizon,
+      TODAY
+    );
+    // Hits zero at the first annual boundary (month 12) and stays there — no
+    // sign flip, no bounce back above zero on later boundaries.
+    expect(series[12].Value).toBe(0);
+    expect(series[series.length - 1].Value).toBe(0);
+    expect(series.every((p) => p.Value >= 0)).toBe(true);
+  });
+
   it('returns only the anchor when the horizon is today', () => {
     const series = forecastAsset(baseAsset({ Balance: 7500 }), TODAY, TODAY);
     expect(series).toHaveLength(1);
@@ -156,15 +181,27 @@ describe('forecastAsset', () => {
   });
 
   // Property: a non-negative balance can never produce a negative value, for any
-  // rate above −100%/yr (the only regime where a monthly factor stays positive).
-  it('never goes negative for a non-negative balance (property)', () => {
+  // finite rate (#152) — including well past −100%/yr, where an unclamped
+  // per-period factor would go negative. The rate range and compounding
+  // frequencies together cover every regime: monthly's threshold (−1200%/yr) is
+  // the most extreme of the three, so −2000 safely crosses all of them.
+  it('never goes negative for a non-negative balance, even at extreme negative rates (property)', () => {
     fc.assert(
       fc.property(
         fc.double({ min: 0, max: 1_000_000, noNaN: true }),
-        fc.double({ min: -90, max: 90, noNaN: true }),
-        (balance, rate) => {
+        fc.double({ min: -2000, max: 90, noNaN: true }),
+        fc.constantFrom(
+          CompoundingFrequency.Monthly,
+          CompoundingFrequency.Quarterly,
+          CompoundingFrequency.Annually
+        ),
+        (balance, rate, compounding) => {
           const series = forecastAsset(
-            baseAsset({ Balance: balance, GrowthRate: rate }),
+            baseAsset({
+              Balance: balance,
+              GrowthRate: rate,
+              CompoundingPeriod: compounding,
+            }),
             new Date(2035, 0, 1),
             TODAY
           );

--- a/src/helpers/asset-helpers.ts
+++ b/src/helpers/asset-helpers.ts
@@ -60,7 +60,11 @@ export const forecastAsset = (
 
   for (let month = 1; month <= months; month++) {
     if (month % compoundingInterval === 0) {
-      value *= 1 + periodRate;
+      // Floor the per-period factor at 0: an extreme negative GrowthRate (below
+      // -100%/yr equivalent for this compounding frequency, e.g. -1200%/yr
+      // monthly) would otherwise make `1 + periodRate` negative, flipping the
+      // sign every boundary instead of decaying toward zero as documented. (#152)
+      value *= Math.max(0, 1 + periodRate);
     }
     points.push({
       Date: start.add(month, 'month').toDate(),

--- a/src/helpers/migrate-helpers.test.ts
+++ b/src/helpers/migrate-helpers.test.ts
@@ -98,6 +98,36 @@ describe('migrate (D8 migration ladder)', () => {
     });
   });
 
+  // Regression (#153): investmentToSerializedAsset is documented as mirroring
+  // the canonical investmentToAsset converter, which carries the employer-match
+  // fields — a pre-fix version of this step omitted them, so a v4→v5 fold would
+  // silently drop 401(k) match data even though the v5 import boundary fully
+  // supports it.
+  it('preserves employer-match fields when folding an investment into an asset', () => {
+    const migrated = migrate({
+      schemaVersion: 4,
+      loans: [],
+      scenarios: [],
+      investments: [
+        {
+          Id: 'inv1',
+          StartingBalance: 10000,
+          AverageReturnRate: 7,
+          RecurringContribution: 500,
+          EmployerMatchRate: 50,
+          EmployerMatchLimitPct: 6,
+          AnnualSalary: 100000,
+        },
+      ],
+    });
+    const assets = migrated.assets as Record<string, unknown>[];
+    expect(assets[0]).toMatchObject({
+      EmployerMatchRate: 50,
+      EmployerMatchLimitPct: 6,
+      AnnualSalary: 100000,
+    });
+  });
+
   it('tolerates a v4 payload with no assets key and folds malformed investment entries defensively', () => {
     const migrated = migrate({
       schemaVersion: 4,

--- a/src/helpers/migrate-helpers.ts
+++ b/src/helpers/migrate-helpers.ts
@@ -20,7 +20,9 @@ type MigrationStep = (data: RawData) => RawData;
 
 // Convert a serialized Investment into its serialized AssetType.Investment
 // shape (the field correspondence mirrors investmentToAsset): StartingBalance →
-// Balance, AverageReturnRate → GrowthRate, everything else by the same name.
+// Balance, AverageReturnRate → GrowthRate, everything else by the same name —
+// including the employer-match fields (#153), which a pre-fix version of this
+// step silently dropped despite every other converter carrying them.
 const investmentToSerializedAsset = (
   investment: unknown
 ): Record<string, unknown> => {
@@ -39,6 +41,9 @@ const investmentToSerializedAsset = (
     ContributionStepUpAmount: i.ContributionStepUpAmount,
     ContributionStepUpType: i.ContributionStepUpType,
     CurrentValue: i.CurrentValue,
+    EmployerMatchRate: i.EmployerMatchRate,
+    EmployerMatchLimitPct: i.EmployerMatchLimitPct,
+    AnnualSalary: i.AnnualSalary,
   };
 };
 


### PR DESCRIPTION
## Summary

Reviewed both open issues against current `main`, confirmed each is a real defect, and fixed both in one branch. **#152**: an extreme negative asset growth rate could make the forecast go negative and oscillate in sign instead of decaying toward zero as documented. **#153**: the v4→v5 schema migration silently dropped a folded investment's employer 401(k)-match fields, diverging from the converter it's documented to mirror.

## Related

- Closes #152
- Closes #153
- Roadmap item: n/a (audit bug fixes, not a phase item)

## Type of change

- [x] Bug fix

## Details

### #152 — `forecastAsset` could go negative for an extreme negative growth rate

`forecastAsset`'s own doc comment promises a negative `GrowthRate` "decays the value geometrically toward — but never below — zero." That only holds while the per-period compounding factor `1 + periodRate` stays ≥ 0. Beyond −100%/yr equivalent for the asset's compounding frequency (−100 annually, −400 quarterly, −1200 monthly), the factor goes negative, so the value **flips sign every compounding boundary** instead of flooring at zero. `validateAsset` only *warns* past ±25%/yr — it doesn't block — so this is reachable through the normal UI/import path with a type-valid input (e.g. `GrowthRate: -150`, annual compounding).

Fixed by flooring the per-period factor at 0 (`value *= Math.max(0, 1 + periodRate)`), which holds the invariant unconditionally rather than relying on UI validation (which JSON import bypasses regardless).

- Added a named regression test at the exact reported repro (annual compounding, `GrowthRate: -150`): value hits 0 at the first boundary and **stays** at 0, never bounces back.
- Widened the existing property test's rate range to sweep well past every compounding frequency's threshold (was `[-90, 90]`, now `[-2000, 90]`), and parameterized it over all three compounding frequencies so the previously-buggy region is actually exercised.

### #153 — v4→v5 migration dropped employer-match fields

`investmentToSerializedAsset` (the migration step that folds a v4 `investments[]` entry into a v5 `AssetType.Investment` asset) is documented as mirroring the canonical `investmentToAsset` converter — but omitted `EmployerMatchRate`, `EmployerMatchLimitPct`, and `AnnualSalary`, which `investmentToAsset`, its inverse `assetToInvestment`, and the v5 import validator (`parseAssets`) all carry. A migrated forecast would silently omit the 401(k) employer match.

**Reachability**: the employer-match feature (#149) shipped after the v4→v5 fold (#141), so an organically-produced v4 export predates these fields and is unaffected in practice today. The defect is real nonetheless — the step diverges from its own documented contract, and any hand-edited or future v4 payload would silently lose the data.

Added the three fields (mirroring `investmentToAsset` exactly); added a regression test asserting they survive the fold.

## Math Correctness Charter

Both fixes touch `src/helpers/**` math/migration logic and ship with regression tests per the Charter's process rule ("every math bug found gets a failing regression test committed before the fix"). `src/helpers/**` stays at **100%** line/branch/function/statement coverage.

## Checklist

- [x] `npm test`, `npm run build`, `npm run check:lint`, and `npm run check:format` all pass
- [x] New business logic lives in `src/helpers/` with unit tests; UI stays thin (no UI changes — both fixes are pure-helper corrections)
- [x] Math-touching changes uphold the [Math Correctness Charter](../ROADMAP.md#4-math-correctness-charter-non-negotiable): cited reference tests, invariants, and 100% line+branch coverage on `src/helpers/**`
- [x] Models stay input-only (derived data is computed, never stored) — n/a, no model changes
- [x] Bumped the version in `package.json` (semver) — **1.14.0 → 1.14.1** (patch: pure bug fixes)
- [ ] Updated `README.md` / `.github/copilot-instructions.md` if structure changed — n/a, no structural/feature change; documented in `CHANGELOG.md` under `### Fixed`

## Verification

- ✅ 717 tests green at 100% helper coverage · lint/prettier clean · `npm run build` OK · bundle **214.38 kB gzip** (budget 250)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0133jkCKi8aGhUtynvUyb8DK)_