### PR TITLE
Fix forecast match accounting and improve table UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ Detailed acceptance criteria for each phase live in the merged PRs and the
 
 ## [Unreleased]
 
+## [1.14.2] — Review fixes (math consistency & UX)
+
+### Fixed
+
+- **A forecast anchored mid-investment-year re-granted employer 401(k) match
+  the employer had already paid that year.** `forecastInvestment` started its
+  annual-cap accrual at zero, so for an investment whose contributions exceed
+  the match cap, every live forecast (always anchored at "today", almost never
+  an anniversary) over-credited the first partial year by up to the full annual
+  match — and the overstated value then compounded for the rest of the horizon,
+  inflating the chart, milestones, and optimizer scores relative to the
+  canonical growth engine. The forecast now seeds the cap with the
+  contributions modeled between the last anniversary and today, restoring
+  cross-engine consistency (Charter §4) at every anchor date.
+- **The dashboard's "Monthly commitments" ignored contribution step-ups.** An
+  investment several years into a yearly step-up contributes more per month
+  than its base amount, and the forecast applies that stepped-up amount — but
+  the commitments card kept reporting the year-one base, understating the real
+  outflow. It now reports the current investment-year's contribution, the same
+  figure the engine applies this month.
+- **Two form fields could block saving without ever showing why.** The loan
+  form's Monthly Payment and the investment form's Recurring Contribution had
+  validation rules but no error wiring, so an invalid value (e.g. a $0 payment
+  or a negative contribution) silently disabled Save behind the misleading
+  "Fill in all required fields" prompt. Both fields now reveal their specific
+  error on blur, like every other validated field (the #99 reachability fix,
+  extended to the two fields it missed).
+- **Deleting a scenario was instant and unrecoverable.** The chip's small "×"
+  deleted a scenario with no confirmation and no undo — the only destructive
+  action in the app without either. Scenario deletion now uses the same
+  confirm dialog and soft-undo snackbar as every other delete, and undo
+  restores the scenario (re-activating it if it was the active overlay).
+- **The loan form's interest-rate slider had no accessible name** (WCAG 4.1.2);
+  it now carries an `aria-label`, matching the custom-split builder's sliders.
+- Header tagline typo ("forecastor" → "forecaster"), and the forecast table
+  fallback's caption now mentions asset columns.
+
+### Changed
+
+- **Table name sorting is human-friendly:** case-insensitive (a lowercase name
+  no longer sinks below every capitalized one) and numeric-aware ("Loan 2"
+  sorts before "Loan 10").
+- **The optimizer's three tables scroll in place on narrow viewports** (ranked
+  plans, strategy presets, side-by-side comparison) instead of forcing
+  page-level horizontal scroll.
+- The amortization schedule's Date column uses the shared "MMM YYYY" format,
+  and percentage step-ups render through the shared percent formatter.
+
 ## [1.14.1] — Audit fixes
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "finance-calculator",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "finance-calculator",
-      "version": "1.14.1",
+      "version": "1.14.2",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "homepage": "https://bberardi.github.io/finance-calculator/",
   "name": "finance-calculator",
   "private": true,
-  "version": "1.14.1",
+  "version": "1.14.2",
   "type": "module",
   "scripts": {
     "start": "npm run dev",

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -32,7 +32,7 @@ export const Header = () => {
             PathWise
           </Typography>
           <Typography variant="body2" sx={{ opacity: 0.9 }}>
-            Your financial calculator and forecastor
+            Your financial calculator and forecaster
           </Typography>
         </Stack>
       </Stack>

--- a/src/chart/forecast-data-table.tsx
+++ b/src/chart/forecast-data-table.tsx
@@ -47,8 +47,8 @@ export const ForecastDataTable = ({
       <Table size="small" aria-label="Forecast values at yearly intervals">
         <caption>
           <Typography variant="caption" color="text.secondary">
-            Projected values at yearly intervals — loan balances, investment
-            values, and overall net worth.
+            Projected values at yearly intervals — loan balances, investment and
+            asset values, and overall net worth.
           </Typography>
         </caption>
         <TableHead>

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -521,5 +521,49 @@ describe('Consistency: forecastInvestment matches growth WITH an employer match 
       );
       expect(forecast[forecast.length - 1].Value).toBe(117000);
     });
+
+    it('seeds from the PREVIOUS calendar year when the anniversary is still ahead', () => {
+      // Non-January anniversary: started Jul 1, anchored Mar 1 — the 2026
+      // anniversary hasn't happened yet, so the current investment-year opened
+      // at the 2025-07-01 anniversary. The seed must count Jul 2025–Feb 2026
+      // ($8,000, cap already consumed); seeding from the 2026 anniversary
+      // would find nothing and re-grant the whole year's match.
+      const julyStart: Investment = {
+        ...flat,
+        StartDate: new Date(2020, 6, 1),
+      };
+      // Canonical to Jul 2027: 84 × $1000 contributed + 7 × $3000 match.
+      const julyYearEnd = new Date(2027, 6, 1);
+      const growth = generateInvestmentGrowth(julyStart, julyYearEnd);
+      expect(growth[growth.length - 1].TotalValue).toBe(105000);
+
+      const forecast = forecastInvestment(
+        julyStart,
+        julyYearEnd,
+        0,
+        new Date(2026, 2, 1)
+      );
+      expect(forecast[forecast.length - 1].Value).toBe(105000);
+    });
+
+    it('grants and seeds no match when AnnualSalary is unset', () => {
+      // Rate + limit without a salary define no cap, so the canonical engine
+      // pays no match; the mid-year-anchored forecast must agree (pure
+      // contributions: 84 × $1000) rather than seed or grant anything.
+      const noSalary: Investment = {
+        ...flat,
+        AnnualSalary: undefined,
+      };
+      const growth = generateInvestmentGrowth(noSalary, yearEnd);
+      expect(growth[growth.length - 1].TotalValue).toBe(84000);
+
+      const forecast = forecastInvestment(
+        noSalary,
+        yearEnd,
+        0,
+        new Date(2026, 6, 1)
+      );
+      expect(forecast[forecast.length - 1].Value).toBe(84000);
+    });
   });
 });

--- a/src/helpers/forecast-consistency.test.ts
+++ b/src/helpers/forecast-consistency.test.ts
@@ -459,4 +459,67 @@ describe('Consistency: forecastInvestment matches growth WITH an employer match 
       }
     });
   });
+
+  // A forecast is almost never anchored on an anniversary in the live app
+  // (today = new Date()), so contributions made earlier in the CURRENT
+  // investment-year have already consumed match-cap headroom in the canonical
+  // engine — and they're baked into the anchor value. The forecast must seed its
+  // accrual state with them; a fresh cum-0 start re-grants match the employer
+  // already paid, over-crediting the first partial year by up to the full
+  // annual match. 0% return isolates the match accounting: every value is an
+  // exact sum of contributions + match, so the engines must agree to the cent.
+  describe('anchored mid-investment-year, the annual cap stays consumed', () => {
+    const flat = makeInvestment({
+      StartingBalance: 0,
+      AverageReturnRate: 0,
+      RecurringContribution: 1000,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+      ...match, // 50% of the first $6k/yr → $3,000/yr, earned Jan–Jun only
+    });
+    const yearEnd = new Date(2027, 0, 1);
+    // Canonical to Jan 2027: 84 × $1000 contributed + 7 × $3000 match.
+    const canonicalAtYearEnd = 105000;
+
+    it('re-grants no match once the year cap is exhausted (anchor after June)', () => {
+      const growth = generateInvestmentGrowth(flat, yearEnd);
+      expect(growth[growth.length - 1].TotalValue).toBe(canonicalAtYearEnd);
+
+      const forecast = forecastInvestment(
+        flat,
+        yearEnd,
+        0,
+        new Date(2026, 6, 1)
+      );
+      expect(forecast[forecast.length - 1].Value).toBe(canonicalAtYearEnd);
+    });
+
+    it('grants only the remaining headroom when the cap is partly consumed', () => {
+      // Anchored Mar 1: Jan+Feb ($2000) already matched ($1000); only $4000 of
+      // headroom remains, so the forecast may add $2000 more match this year.
+      const forecast = forecastInvestment(
+        flat,
+        yearEnd,
+        0,
+        new Date(2026, 2, 1)
+      );
+      expect(forecast[forecast.length - 1].Value).toBe(canonicalAtYearEnd);
+    });
+
+    it('seeds the consumed cap for an off-cadence (mid-month) anchor too', () => {
+      // Anchored Jul 10, the grid runs day-shifted (each firing lands ~9 days
+      // after its canonical contribution date), so right around an anniversary
+      // the two engines momentarily disagree by one firing's worth — inherent
+      // month-grid granularity, not cap accounting. Compare at a settled date
+      // (Sep 2027, well past the January rollover): the anchor bakes in
+      // $100,000 (79 contributions + $21,000 match), the grid adds 14 firings
+      // and must add only year-2027's $3,000 of match — no re-grant of 2026's.
+      const forecast = forecastInvestment(
+        flat,
+        new Date(2027, 8, 1),
+        0,
+        new Date(2026, 6, 10)
+      );
+      expect(forecast[forecast.length - 1].Value).toBe(117000);
+    });
+  });
 });

--- a/src/helpers/forecast-helpers.ts
+++ b/src/helpers/forecast-helpers.ts
@@ -13,10 +13,13 @@ import { assetNetWorthSign, forecastAsset } from './asset-helpers';
 import {
   employerMatchOnContribution,
   generateInvestmentGrowth,
+  getAnniversaryDate,
   getContributionForYear,
+  getContributionsWithStepUp,
   getInvestmentYear,
   getNextCompoundingDate,
   getPeriodsPerYear,
+  hasPassedAnniversary,
 } from './investment-helpers';
 
 const roundToCents = (value: number): number => Math.round(value * 100) / 100;
@@ -250,6 +253,40 @@ export const forecastInvestment = (
   // investment-year, reset at year boundaries so the annual cap holds.
   let matchYear = 0;
   let matchCumThisYear = 0;
+
+  // Contributions made earlier in the CURRENT investment-year (from the last
+  // StartDate anniversary up to `today`) already consumed match-cap headroom in
+  // the canonical engine, and they're baked into the anchor value. Seed the
+  // accrual state with them — otherwise a mid-year-anchored forecast re-grants
+  // match the employer already paid this year, over-crediting the first partial
+  // year by up to the full annual match whenever contributions exceed the cap.
+  // The window [last anniversary, today) is exactly the set of contribution
+  // dates getInvestmentYear attributes to the current year (anniversaries are
+  // contribution dates, so no date between them and `today` changes year).
+  const matchActive =
+    (investment.EmployerMatchRate ?? 0) > 0 &&
+    (investment.EmployerMatchLimitPct ?? 0) > 0 &&
+    (investment.AnnualSalary ?? 0) > 0;
+  if (
+    matchActive &&
+    baseContribution > 0 &&
+    investment.ContributionFrequency &&
+    today > investment.StartDate
+  ) {
+    const anniversaryYear = hasPassedAnniversary(today, investment.StartDate)
+      ? today.getFullYear()
+      : today.getFullYear() - 1;
+    matchYear = getInvestmentYear(today, investment.StartDate);
+    matchCumThisYear = getContributionsWithStepUp(
+      getAnniversaryDate(investment.StartDate, anniversaryYear),
+      today,
+      investment.StartDate,
+      baseContribution,
+      investment.ContributionFrequency,
+      investment.ContributionStepUpAmount,
+      investment.ContributionStepUpType
+    );
+  }
 
   let value = anchorValue;
   const points: ForecastPoint[] = [

--- a/src/helpers/sort-helpers.test.ts
+++ b/src/helpers/sort-helpers.test.ts
@@ -15,6 +15,18 @@ describe('compareSortValues', () => {
     expect(compareSortValues(5, 5)).toBe(0);
     expect(compareSortValues('x', 'x')).toBe(0);
   });
+
+  it('orders strings case-insensitively', () => {
+    // Code-point comparison would put every capitalized name first ('Z' < 'a'),
+    // sinking a lowercase "chase savings" below the whole alphabet.
+    expect(compareSortValues('chase savings', 'Vanguard 401k')).toBe(-1);
+    expect(compareSortValues('Apple', 'apple')).toBe(0);
+  });
+
+  it('orders numbered names numerically', () => {
+    // "Loan 2" belongs before "Loan 10"; plain string comparison reverses them.
+    expect(compareSortValues('Loan 2', 'Loan 10')).toBe(-1);
+  });
 });
 
 describe('sortBy', () => {

--- a/src/helpers/sort-helpers.ts
+++ b/src/helpers/sort-helpers.ts
@@ -6,6 +6,16 @@
 export type SortDirection = 'asc' | 'desc';
 export type SortValue = number | string | Date;
 
+// Human-friendly string ordering for table columns: case/accent-insensitive
+// (so "chase savings" doesn't sink below every capitalized name) and
+// numeric-aware (so "Loan 2" precedes "Loan 10"). One shared collator —
+// construction is expensive and comparisons run per row. 'en-US' matches the
+// locale format-helpers already pins.
+const stringCollator = new Intl.Collator('en-US', {
+  numeric: true,
+  sensitivity: 'base',
+});
+
 const toComparable = (value: SortValue): number | string =>
   value instanceof Date ? value.getTime() : value;
 
@@ -13,6 +23,9 @@ const toComparable = (value: SortValue): number | string =>
 export const compareSortValues = (a: SortValue, b: SortValue): number => {
   const ca = toComparable(a);
   const cb = toComparable(b);
+  if (typeof ca === 'string' && typeof cb === 'string') {
+    return Math.sign(stringCollator.compare(ca, cb));
+  }
   if (ca < cb) return -1;
   if (ca > cb) return 1;
   return 0;

--- a/src/helpers/summary-helpers.test.ts
+++ b/src/helpers/summary-helpers.test.ts
@@ -3,7 +3,11 @@ import { summarizePositions } from './summary-helpers';
 import { currentInvestmentValue, forecastNetWorth } from './forecast-helpers';
 import { getMonthlyPayment } from './loan-helpers';
 import { Loan } from '../models/loan-model';
-import { CompoundingFrequency, Investment } from '../models/investment-model';
+import {
+  CompoundingFrequency,
+  Investment,
+  StepUpType,
+} from '../models/investment-model';
 
 const TODAY = new Date(2025, 0, 1);
 
@@ -93,6 +97,23 @@ describe('summarizePositions', () => {
     );
     expect(summarizePositions([], [annual], TODAY).monthlyCommitments).toBe(
       100
+    );
+  });
+
+  it('reflects the stepped-up contribution for the current investment year', () => {
+    // Started 2024 with $100/mo stepping up $50/yr: by TODAY (year 2) the
+    // engine contributes $150/mo, so the commitments card must say $150 — the
+    // year-one base would understate the real outflow the forecast applies.
+    const steppedUp: Investment = {
+      ...investment,
+      Id: 'inv-s',
+      RecurringContribution: 100,
+      ContributionFrequency: CompoundingFrequency.Monthly,
+      ContributionStepUpAmount: 50,
+      ContributionStepUpType: StepUpType.Flat,
+    };
+    expect(summarizePositions([], [steppedUp], TODAY).monthlyCommitments).toBe(
+      150
     );
   });
 

--- a/src/helpers/summary-helpers.ts
+++ b/src/helpers/summary-helpers.ts
@@ -6,7 +6,11 @@ import {
   forecastLoan,
   getMonthlyPaymentBreakdown,
 } from './forecast-helpers';
-import { getPeriodsPerYear } from './investment-helpers';
+import {
+  getContributionForYear,
+  getInvestmentYear,
+  getPeriodsPerYear,
+} from './investment-helpers';
 import { getAssetValueToday, isAssetLiability } from './asset-helpers';
 
 // "Today" net-worth summary metrics for the dashboard (Phase 3.1). Debt and
@@ -69,13 +73,24 @@ export const summarizePositions = (
     0
   );
   const investmentCommitments = investments.reduce((sum, investment) => {
-    // Contributions only count when a cadence is set (mirrors the engine).
-    if (!investment.ContributionFrequency) {
+    // Contributions only count when both an amount and a cadence are set
+    // (mirrors the engine).
+    const base = investment.RecurringContribution ?? 0;
+    if (!investment.ContributionFrequency || !(base > 0)) {
       return sum;
     }
+    // The contribution actually being made now — the base stepped up to the
+    // current investment year — so the card reflects the same outflow the
+    // forecast applies this month, not the year-one amount. (#91-style
+    // cross-consistency, for step-ups.)
+    const current = getContributionForYear(
+      base,
+      getInvestmentYear(today, investment.StartDate),
+      investment.ContributionStepUpAmount,
+      investment.ContributionStepUpType
+    );
     const perYear =
-      (investment.RecurringContribution ?? 0) *
-      getPeriodsPerYear(investment.ContributionFrequency);
+      current * getPeriodsPerYear(investment.ContributionFrequency);
     return sum + perYear / 12;
   }, 0);
 

--- a/src/investment/add-edit-investment.tsx
+++ b/src/investment/add-edit-investment.tsx
@@ -282,6 +282,12 @@ export const AddEditInvestment = (props: AddEditInvestmentProps) => {
                   : undefined,
               });
             }}
+            onBlur={() => touch('RecurringContribution')}
+            error={Boolean(errorFor('RecurringContribution'))}
+            helperText={fieldHelperText(
+              errorFor('RecurringContribution'),
+              warningFor('RecurringContribution')
+            )}
           />
           {hasRecurringContribution && (
             <FormControl fullWidth>

--- a/src/investment/investment-table.tsx
+++ b/src/investment/investment-table.tsx
@@ -97,7 +97,7 @@ const formatContribution = (investment: Investment): string => {
   const stepUp =
     investment.ContributionStepUpType === StepUpType.Flat
       ? `+${formatCurrency(investment.ContributionStepUpAmount)}/yr`
-      : `+${investment.ContributionStepUpAmount}%/yr`;
+      : `+${formatPercent(investment.ContributionStepUpAmount)}/yr`;
   return `${base} (${stepUp})`;
 };
 

--- a/src/loan/add-edit-loan.tsx
+++ b/src/loan/add-edit-loan.tsx
@@ -313,6 +313,7 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
                       : newValue,
                   })
                 }
+                aria-label="Interest percentage"
                 valueLabelDisplay="auto"
                 step={0.25}
                 min={0}
@@ -362,6 +363,12 @@ export const AddEditLoan = (props: AddEditLoanProps) => {
               onValueChange={(vs) => {
                 setNewLoan({ ...newLoan, MonthlyPayment: Number(vs.value) });
               }}
+              onBlur={() => touch('MonthlyPayment')}
+              error={Boolean(errorFor('MonthlyPayment'))}
+              helperText={fieldHelperText(
+                errorFor('MonthlyPayment'),
+                warningFor('MonthlyPayment')
+              )}
               sx={{ flex: 6 }}
               required
             />

--- a/src/loan/amortization-popout.tsx
+++ b/src/loan/amortization-popout.tsx
@@ -63,7 +63,7 @@ export const AmortizationPopout = (props: AmortizationPopoutProps) => {
                     <TableCell>
                       {dayjs(startDate)
                         .add(entry.Term - 1, 'months')
-                        .format('YYYY/MM (MMM)')}
+                        .format('MMM YYYY')}
                     </TableCell>
                     <TableCell>
                       {formatCurrency(

--- a/src/optimizer/optimizer-panel.tsx
+++ b/src/optimizer/optimizer-panel.tsx
@@ -10,6 +10,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
   TextField,
@@ -169,61 +170,67 @@ export const OptimizerPanel = ({
               adjusting your inputs.
             </Alert>
           )}
-          <Table size="small" aria-label="Ranked allocation plans">
-            <TableHead>
-              <TableRow>
-                <TableCell>Plan</TableCell>
-                <TableCell align="right">Net worth added at horizon</TableCell>
-                <TableCell align="right">Interest saved</TableCell>
-                <TableCell align="right">Debt-free</TableCell>
-                <TableCell />
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {topPlans.map((evaluation, index) => (
-                <TableRow key={planKey(evaluation.plan)} hover>
-                  <TableCell>
-                    <Stack
-                      direction="row"
-                      spacing={1}
-                      sx={{ alignItems: 'center' }}
-                    >
-                      {index === 0 && (
-                        <Chip label="Best" color="primary" size="small" />
-                      )}
-                      <span>{evaluation.plan.label}</span>
-                    </Stack>
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatNetWorthDelta(evaluation.netWorthDelta)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatCurrency(evaluation.interestSaved)}
-                  </TableCell>
-                  <TableCell align="right">
-                    {formatPayoffSooner(evaluation.payoffMonthsEarlier)}
-                  </TableCell>
-                  <TableCell align="right">
-                    <Button
-                      size="small"
-                      onClick={() => onViewAsScenario(evaluation.plan)}
-                    >
-                      View as scenario
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-              {!loading && topPlans.length === 0 && (
+          {/* TableContainer lets the 5-column table scroll in place on narrow
+              viewports instead of forcing page-level horizontal scroll. */}
+          <TableContainer>
+            <Table size="small" aria-label="Ranked allocation plans">
+              <TableHead>
                 <TableRow>
-                  <TableCell colSpan={5}>
-                    <Typography variant="body2" color="text.secondary">
-                      No positions to fund yet — add a loan or investment.
-                    </Typography>
+                  <TableCell>Plan</TableCell>
+                  <TableCell align="right">
+                    Net worth added at horizon
                   </TableCell>
+                  <TableCell align="right">Interest saved</TableCell>
+                  <TableCell align="right">Debt-free</TableCell>
+                  <TableCell />
                 </TableRow>
-              )}
-            </TableBody>
-          </Table>
+              </TableHead>
+              <TableBody>
+                {topPlans.map((evaluation, index) => (
+                  <TableRow key={planKey(evaluation.plan)} hover>
+                    <TableCell>
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        sx={{ alignItems: 'center' }}
+                      >
+                        {index === 0 && (
+                          <Chip label="Best" color="primary" size="small" />
+                        )}
+                        <span>{evaluation.plan.label}</span>
+                      </Stack>
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatNetWorthDelta(evaluation.netWorthDelta)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatCurrency(evaluation.interestSaved)}
+                    </TableCell>
+                    <TableCell align="right">
+                      {formatPayoffSooner(evaluation.payoffMonthsEarlier)}
+                    </TableCell>
+                    <TableCell align="right">
+                      <Button
+                        size="small"
+                        onClick={() => onViewAsScenario(evaluation.plan)}
+                      >
+                        View as scenario
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!loading && topPlans.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5}>
+                      <Typography variant="body2" color="text.secondary">
+                        No positions to fund yet — add a loan or investment.
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
 
           {hasPositions && (
             <StrategyPresets

--- a/src/optimizer/strategy-comparison.tsx
+++ b/src/optimizer/strategy-comparison.tsx
@@ -8,6 +8,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
 } from '@mui/material';
@@ -90,71 +91,75 @@ export const StrategyComparison = ({
       </Button>
 
       <Collapse in={open} unmountOnExit>
+        {/* TableContainer lets the wide side-by-side table scroll in place on
+            narrow viewports instead of forcing page-level horizontal scroll. */}
         {comparison.length > 0 && (
-          <Table
-            size="small"
-            aria-label="Strategy comparison"
-            sx={{ marginTop: 1 }}
-          >
-            <TableHead>
-              <TableRow>
-                <TableCell />
-                {comparison.map((row, index) => (
-                  <TableCell key={row.kind} align="right">
-                    <Stack
-                      direction="row"
-                      spacing={0.5}
-                      sx={{
-                        justifyContent: 'flex-end',
-                        alignItems: 'center',
-                      }}
-                    >
-                      <span>{row.label}</span>
-                      {index === bestIndex && (
-                        <Chip label="Best" color="primary" size="small" />
-                      )}
-                    </Stack>
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {horizonYears.map((years, horizonIndex) => (
-                <TableRow key={`nw-${years}`}>
-                  <TableCell>Net worth +{years}y</TableCell>
-                  {comparison.map((row) => (
+          <TableContainer>
+            <Table
+              size="small"
+              aria-label="Strategy comparison"
+              sx={{ marginTop: 1 }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell />
+                  {comparison.map((row, index) => (
                     <TableCell key={row.kind} align="right">
-                      {formatCurrency(row.netWorthAt[horizonIndex].value)}
+                      <Stack
+                        direction="row"
+                        spacing={0.5}
+                        sx={{
+                          justifyContent: 'flex-end',
+                          alignItems: 'center',
+                        }}
+                      >
+                        <span>{row.label}</span>
+                        {index === bestIndex && (
+                          <Chip label="Best" color="primary" size="small" />
+                        )}
+                      </Stack>
                     </TableCell>
                   ))}
                 </TableRow>
-              ))}
-              <TableRow>
-                <TableCell>Debt-free</TableCell>
-                {comparison.map((row) => (
-                  <TableCell key={row.kind} align="right">
-                    {formatDate(row.debtFreeDate)}
-                  </TableCell>
+              </TableHead>
+              <TableBody>
+                {horizonYears.map((years, horizonIndex) => (
+                  <TableRow key={`nw-${years}`}>
+                    <TableCell>Net worth +{years}y</TableCell>
+                    {comparison.map((row) => (
+                      <TableCell key={row.kind} align="right">
+                        {formatCurrency(row.netWorthAt[horizonIndex].value)}
+                      </TableCell>
+                    ))}
+                  </TableRow>
                 ))}
-              </TableRow>
-              <TableRow>
-                <TableCell>Investments (+30y)</TableCell>
-                {comparison.map((row) => (
-                  <TableCell key={row.kind} align="right">
-                    {formatCurrency(row.finalInvestments)}
-                  </TableCell>
-                ))}
-              </TableRow>
-              <TableRow>
-                <TableCell>Debt left (+30y)</TableCell>
-                {comparison.map((row) => (
-                  <TableCell key={row.kind} align="right">
-                    {formatCurrency(row.finalDebt)}
-                  </TableCell>
-                ))}
-              </TableRow>
-            </TableBody>
-          </Table>
+                <TableRow>
+                  <TableCell>Debt-free</TableCell>
+                  {comparison.map((row) => (
+                    <TableCell key={row.kind} align="right">
+                      {formatDate(row.debtFreeDate)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+                <TableRow>
+                  <TableCell>Investments (+30y)</TableCell>
+                  {comparison.map((row) => (
+                    <TableCell key={row.kind} align="right">
+                      {formatCurrency(row.finalInvestments)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+                <TableRow>
+                  <TableCell>Debt left (+30y)</TableCell>
+                  {comparison.map((row) => (
+                    <TableCell key={row.kind} align="right">
+                      {formatCurrency(row.finalDebt)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
         )}
       </Collapse>
     </Box>

--- a/src/optimizer/strategy-presets.tsx
+++ b/src/optimizer/strategy-presets.tsx
@@ -5,6 +5,7 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableContainer,
   TableHead,
   TableRow,
   Typography,
@@ -75,42 +76,46 @@ export const StrategyPresets = ({
         {mode === 'oneTime' ? '' : '/month'} — compare them, then send any to
         the chart.
       </Typography>
-      <Table
-        size="small"
-        aria-label="Allocation strategy presets"
-        sx={{ marginTop: 1 }}
-      >
-        <TableHead>
-          <TableRow>
-            <TableCell>Strategy</TableCell>
-            <TableCell align="right">Net worth added at horizon</TableCell>
-            <TableCell align="right">Interest saved</TableCell>
-            <TableCell align="right">Debt-free</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {evaluations.map(({ plan, evaluation }) => (
-            <TableRow key={plan.kind} hover>
-              <TableCell>{plan.label}</TableCell>
-              <TableCell align="right">
-                {formatNetWorthDelta(evaluation.netWorthDelta)}
-              </TableCell>
-              <TableCell align="right">
-                {formatCurrency(evaluation.interestSaved)}
-              </TableCell>
-              <TableCell align="right">
-                {formatPayoffSooner(evaluation.payoffMonthsEarlier)}
-              </TableCell>
-              <TableCell align="right">
-                <Button size="small" onClick={() => onViewAsScenario(plan)}>
-                  View as scenario
-                </Button>
-              </TableCell>
+      {/* TableContainer lets the 5-column table scroll in place on narrow
+          viewports instead of forcing page-level horizontal scroll. */}
+      <TableContainer>
+        <Table
+          size="small"
+          aria-label="Allocation strategy presets"
+          sx={{ marginTop: 1 }}
+        >
+          <TableHead>
+            <TableRow>
+              <TableCell>Strategy</TableCell>
+              <TableCell align="right">Net worth added at horizon</TableCell>
+              <TableCell align="right">Interest saved</TableCell>
+              <TableCell align="right">Debt-free</TableCell>
+              <TableCell />
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {evaluations.map(({ plan, evaluation }) => (
+              <TableRow key={plan.kind} hover>
+                <TableCell>{plan.label}</TableCell>
+                <TableCell align="right">
+                  {formatNetWorthDelta(evaluation.netWorthDelta)}
+                </TableCell>
+                <TableCell align="right">
+                  {formatCurrency(evaluation.interestSaved)}
+                </TableCell>
+                <TableCell align="right">
+                  {formatPayoffSooner(evaluation.payoffMonthsEarlier)}
+                </TableCell>
+                <TableCell align="right">
+                  <Button size="small" onClick={() => onViewAsScenario(plan)}>
+                    View as scenario
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
     </Paper>
   );
 };

--- a/src/scenario/scenario-bar.tsx
+++ b/src/scenario/scenario-bar.tsx
@@ -1,10 +1,22 @@
 import { useMemo, useState } from 'react';
-import { Box, Button, Chip, Stack, Typography } from '@mui/material';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Snackbar,
+  Stack,
+  Typography,
+} from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { Scenario } from '../models/scenario-model';
 import { useFinanceData } from '../state/use-finance-data';
 import { investmentsFromAssets } from '../helpers/asset-investment-helpers';
+import { ConfirmDeleteDialog } from '../components/confirm-delete-dialog';
 import { ScenarioBuilderDialog } from './scenario-builder-dialog';
+
+// Matches the entity-delete undo window in Body.
+const DELETE_UNDO_DURATION_MS = 6000;
 
 // Scenario controls in the forecast section (Phase 4.2). Create a scenario,
 // switch the active overlay between "Baseline" and any saved scenario, and
@@ -22,6 +34,40 @@ export const ScenarioBar = () => {
   const investments = useMemo(() => investmentsFromAssets(assets), [assets]);
 
   const [builderOpen, setBuilderOpen] = useState(false);
+
+  // Deleting a scenario gets the same confirm + soft-undo treatment as every
+  // other delete in the app (roadmap 0.7): a hand-tuned split is real work, and
+  // the chip's small "×" is easy to hit by accident. Undo restores the scenario
+  // with its Id intact (addScenario keeps a provided Id) and re-activates it if
+  // it was the active overlay.
+  const [pendingDelete, setPendingDelete] = useState<Scenario>();
+  const [undoableDelete, setUndoableDelete] = useState<{
+    scenario: Scenario;
+    wasActive: boolean;
+  }>();
+
+  const onConfirmDelete = () => {
+    if (!pendingDelete) {
+      return;
+    }
+    setUndoableDelete({
+      scenario: pendingDelete,
+      wasActive: pendingDelete.Id === activeScenarioId,
+    });
+    deleteScenario(pendingDelete.Id);
+    setPendingDelete(undefined);
+  };
+
+  const onUndoDelete = () => {
+    if (!undoableDelete) {
+      return;
+    }
+    const id = addScenario(undoableDelete.scenario);
+    if (undoableDelete.wasActive) {
+      setActiveScenario(id);
+    }
+    setUndoableDelete(undefined);
+  };
 
   const handleSave = (scenario: Scenario) => {
     const id = addScenario(scenario);
@@ -56,7 +102,7 @@ export const ScenarioBar = () => {
               color={active ? 'primary' : 'default'}
               variant={active ? 'filled' : 'outlined'}
               onClick={() => setActiveScenario(active ? null : scenario.Id)}
-              onDelete={() => deleteScenario(scenario.Id)}
+              onDelete={() => setPendingDelete(scenario)}
             />
           );
         })}
@@ -77,6 +123,32 @@ export const ScenarioBar = () => {
         onSave={handleSave}
         onClose={() => setBuilderOpen(false)}
       />
+
+      <ConfirmDeleteDialog
+        itemName={pendingDelete?.Name}
+        onCancel={() => setPendingDelete(undefined)}
+        onConfirm={onConfirmDelete}
+      />
+
+      {/* Soft-undo, matching Body's entity-delete snackbar conventions. */}
+      <Snackbar
+        open={!!undoableDelete}
+        autoHideDuration={DELETE_UNDO_DURATION_MS}
+        onClose={() => setUndoableDelete(undefined)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert
+          severity="info"
+          sx={{ width: '100%' }}
+          action={
+            <Button color="inherit" size="small" onClick={onUndoDelete}>
+              UNDO
+            </Button>
+          }
+        >
+          {`Deleted ${undoableDelete?.scenario.Name ?? ''}`}
+        </Alert>
+      </Snackbar>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

This PR fixes a critical math bug where forecasts anchored mid-investment-year re-granted employer 401(k) match the employer had already paid that year, inflating chart values and optimizer scores. It also fixes the dashboard's "Monthly commitments" to reflect stepped-up contributions, adds confirmation + undo to scenario deletion (matching the app's delete pattern), improves table scrolling on narrow viewports, and makes table name sorting human-friendly (case-insensitive, numeric-aware).

## Related

- Roadmap item: 1.14.2 (review fixes)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Chore
- [ ] Performance

## Details

**Math fixes:**
- `forecastInvestment` now seeds the annual match-cap accrual with contributions made between the last anniversary and today, preventing mid-year anchors from re-granting match already paid by the employer (Charter §4 consistency).
- `summarizePositions` now reports the current investment-year's contribution (after step-ups) instead of the year-one base, so the dashboard's commitments card reflects the actual monthly outflow the forecast applies.

**UX improvements:**
- Scenario deletion now uses the same confirm dialog + soft-undo snackbar pattern as every other delete in the app, with undo restoring the scenario and re-activating it if it was the active overlay.
- The optimizer's three tables (ranked plans, strategy presets, side-by-side comparison) now wrap in `TableContainer` to scroll in place on narrow viewports instead of forcing page-level horizontal scroll.
- Table name sorting is now case-insensitive and numeric-aware (e.g., "Loan 2" sorts before "Loan 10"), using `Intl.Collator` for human-friendly ordering.

**Accessibility & polish:**
- The loan form's interest-rate slider now has an `aria-label` (WCAG 4.1.2).
- The loan form's Monthly Payment and investment form's Recurring Contribution fields now show validation errors on blur (extending the #99 reachability fix).
- Fixed header tagline typo ("forecastor" → "forecaster").
- Amortization schedule Date column and percentage step-ups now use shared formatters.

## Checklist

- [x] `npm test`, `npm run build`, `npm run check:lint`, and `npm run check:format` all pass
- [x] New business logic lives in `src/helpers/` with unit tests; UI stays thin
- [x] Math-touching changes uphold the Math Correctness Charter: added 3 new test cases to `forecast-consistency.test.ts` covering mid-year anchors with match caps, and updated `summary-helpers.test.ts` to verify stepped-up contributions
- [x] Models stay input-only
- [x] Bumped version to 1.14.2 in `package.json`
- [x] Updated `CHANGELOG.md` with detailed fix descriptions

https://claude.ai/code/session_01HpMjb2LzEJZaMQbzXHwTQb