### PR TITLE
docs(roadmap): add Phase 16 — Deeper Control &amp; Safer Data

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -209,6 +209,45 @@ earns a slot.
 
 ---
 
+### Phase 16 — Deeper Control & Safer Data — _target v2.5_
+
+Surfaced by a July 2026 follow-up UX/codebase review. Where Phases 9–15 added new
+_views_ (uncertainty, planning, dashboard insight, after-tax honesty), this phase
+gives users more _control_ over the modeling they already do — editing and
+comparing what-ifs, tuning the assumptions behind a projection, reading the chart
+closely — and closes two data-safety/portability gaps at the import/backup
+boundary. Each item passes the §5 non-goal filters (client-side, data stays on
+device, not a budgeting app); the rationale column says why each earns a slot.
+
+**Scenario & what-if depth (new features)**
+
+| #    | Work item                            | Rationale / acceptance                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ---- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 16.1 | **Editable & duplicable scenarios**  | The reducer already has `UpdateScenario` and `ScenarioBuilderDialog` already supports an "Edit scenario" path, but `ScenarioBar` (`scenario-bar.tsx`) only wires create + delete — so the edit capability is unreachable dead code, and a hand-tuned split must be rebuilt from scratch to change one number. Asymmetric with loans/investments/assets, which all have Duplicate. Low-cost: surface the built-in edit path plus a duplicate action. |
+| 16.2 | **Multi-scenario overlay & compare** | `activeScenarioId` holds a single id and the chart overlays exactly one scenario's dotted lines, so a user who builds "aggressive payoff" and "max investing" can't see them together. Let the chart overlay 2+ saved scenarios (and/or a small compare table), turning isolated what-ifs into the head-to-head the founding "which path?" question asks for. Distinct from the optimizer's preset-allocation table (`strategy-comparison.tsx`).    |
+| 16.3 | **User-adjustable inflation rate**   | The "today's dollars" view deflates at a hardcoded `DEFAULT_INFLATION_PCT = 3`/yr that `assumptions-panel.tsx` even advertises, with no way to change it — a user who assumes 2% or 4% can't. A single rate input (pure post-processing on the nominal forecast, exactly like the Phase 9.2 toggle itself; no engine change) makes the real view honest to the user's own assumption. Extends Phase 9.2.                                            |
+
+**Optimizer control (new feature)**
+
+| #    | Work item                               | Rationale / acceptance                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 16.4 | **Combined & stepped optimizer budget** | The optimizer's budget is an exclusive toggle between "per month" and "one-time" (`optimizer-panel.tsx`), so a user with both a monthly surplus and a windfall ("$500/mo _plus_ a $10k bonus") can't rank them together, and the recurring amount can't grow — even though investments already model contribution step-ups. Let one search consider a recurring + one-time budget (optionally stepping up), matching how real surpluses arrive. |
+
+**Chart interaction (UX)**
+
+| #    | Work item                         | Rationale / acceptance                                                                                                                                                                                                                                                                                                                                                                                             |
+| ---- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 16.5 | **Zoom/pan & pinned date cursor** | The forecast chart's only time control is the fixed 5Y/10Y/30Y/Full toggle (`forecast-chart.tsx`); there is no drag-to-zoom, pan, or pinned vertical cursor to read every series' value at one chosen month. On a 30-year line users can't focus on years 12–15 or lock a readout at a specific date. Adds close-reading of the projection without leaving the app; distinct from the planned image export (11.6). |
+
+**Data safety & portability (UX)**
+
+| #    | Work item                                  | Rationale / acceptance                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 16.6 | **Backup staleness reminder**              | Data lives in `localStorage` and the only durable copy is a manual JSON export; nothing records or surfaces when the user last exported, so there is no nudge before browser-storage loss. A lightweight "last backed up N days ago · export now" indicator closes the gap between opt-in persistence and a real off-device copy. Complements the planned unsaved-changes guard (13.1), which only covers the persistence-**off** case.                                         |
+| 16.7 | **Selective import & conflict resolution** | JSON import commits the entire pending file at once (`data-manager.tsx`) and an Id collision always silently overwrites the existing entity — the preview dialog only _lists_ items, with no way to deselect them, so a file that shares one Id forces overwriting it to import anything else. Add per-item checkboxes and a keep-mine / keep-theirs / keep-both choice on collisions, so a merge can't clobber data the user meant to keep. Reuses the D8 validation boundary. |
+
+---
+
 ### Considered but not currently planned
 
 Reviewed against the roadmap and intentionally **not** scheduled. Recorded here so
@@ -237,9 +276,10 @@ Phase 12 Accessibility & Interaction Polish  v2.1
 Phase 13 Data Safety & Goal-Setting       v2.2
 Phase 14 Dashboard Insight                v2.3
 Phase 15 Credibility & Accessibility Follow-ups  v2.4  (July 2026 review)
+Phase 16 Deeper Control & Safer Data          v2.5  (July 2026 follow-up review)
 ```
 
-Rationale for the order: completeness (the true net-worth line) shipped in Phase 7 and answer quality in Phase 8, so what's left is statistical honesty, then planning, then distribution, then accessibility & interaction polish on the now-complete surface, then a data-safety/goal-setting follow-up from the v2.x review, then a dashboard-insight follow-up that adds the last read-only "where is my money?" view, and finally a credibility/accessibility follow-up that finishes the after-tax honesty trio, makes the chart perceptible without color, and lowers the empty-state barrier.
+Rationale for the order: completeness (the true net-worth line) shipped in Phase 7 and answer quality in Phase 8, so what's left is statistical honesty, then planning, then distribution, then accessibility & interaction polish on the now-complete surface, then a data-safety/goal-setting follow-up from the v2.x review, then a dashboard-insight follow-up that adds the last read-only "where is my money?" view, then a credibility/accessibility follow-up that finishes the after-tax honesty trio, makes the chart perceptible without color, and lowers the empty-state barrier, and finally a control/safety follow-up that lets users edit and compare their what-ifs, tune the assumptions behind a projection, and read and back up their data more safely.
 
 ---
 


### PR DESCRIPTION
## Summary

A July 2026 follow-up review of the codebase and roadmap for user-experience and functionality opportunities. Phases 9–15 are already deep on new _views_ — statistical honesty, planning, dashboard insight, after-tax/colorblind honesty. This review looked instead at how much _control_ users have over the modeling they already do, and found several capabilities that are half-built, hardcoded, or single-valued. It adds one new **Phase 16 — Deeper Control & Safer Data** with seven suggestions, each grounded in current code, each with a 1–2 sentence rationale, and each passing the §5 non-goal filters (client-side, data stays on device, not a budgeting app). **Docs-only — no code or behavior change.**

Suggestions, organized by category:

**Scenario & what-if depth (new features)**
- **16.1 Editable & duplicable scenarios** — `UpdateScenario` and the dialog's "Edit scenario" path already exist, but `ScenarioBar` wires only create + delete, so the edit capability is unreachable and a hand-tuned split must be rebuilt from scratch to change one number (loans/investments/assets all have Duplicate; scenarios don't).
- **16.2 Multi-scenario overlay & compare** — `activeScenarioId` is a single id and the chart overlays exactly one scenario, so a user who builds "aggressive payoff" and "max investing" can't see them head-to-head. Distinct from the optimizer's preset-allocation table.
- **16.3 User-adjustable inflation rate** — the "today's dollars" view deflates at a hardcoded `DEFAULT_INFLATION_PCT = 3`/yr that the assumptions panel advertises but no control can change. Pure post-processing, exactly like the Phase 9.2 toggle; extends it.

**Optimizer control (new feature)**
- **16.4 Combined & stepped optimizer budget** — budget is an exclusive "per month" **or** "one-time" toggle, so "$500/mo _plus_ a $10k bonus" can't be optimized together, and the recurring amount can't grow even though investments already model contribution step-ups.

**Chart interaction (UX)**
- **16.5 Zoom/pan & pinned date cursor** — the chart's only time control is the fixed 5Y/10Y/30Y/Full toggle; there's no drag-to-zoom, pan, or pinned readout to focus years 12–15 or lock a value at one month. Distinct from the planned image export (11.6).

**Data safety & portability (UX)**
- **16.6 Backup staleness reminder** — nothing records or surfaces when the user last exported, so there's no nudge before browser-storage loss. Complements the planned unsaved-changes guard (13.1), which only covers the persistence-**off** case.
- **16.7 Selective import & conflict resolution** — JSON import commits the whole file at once and an Id collision always silently overwrites; the preview only _lists_ items with no deselect and no keep-mine/keep-theirs/keep-both choice. Reuses the D8 validation boundary.

Also updates the "Sequencing at a Glance" block and its closing rationale to include Phase 16.

### Notes for the reviewer

- **Numbering overlaps open PR #171**, which proposes a different "Phase 16 — Modeling Fidelity & Parity" (adjustable-rate loans, refinance, biweekly cadence, include/exclude, notes parity, memoization). The two proposals are **fully distinct in content** — none of these seven items appears in #171. I kept this as the natural next number on `main` (which ends at Phase 15); if #171 lands first, renumbering this to Phase 17 is a one-line docs edit.
- Deliberately excluded as already-planned or out of scope: after-tax view, tornado/sensitivity, CSV export/import, chart image/PDF export, shareable links, general undo, and everything in #171; plus locale/multi-currency and balance check-ins (already under "Considered but not currently planned"). The open issues (#165–#175) are math/UX **bugs**, not roadmap features, so they're left to their own tracking.

## Related

- Closes #
- Roadmap item: adds Roadmap Phase 16

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Chore
- [ ] Performance

## Checklist

- [x] `npm run check:format` passes for the changed file (docs-only; no code touched, so test/build/lint are unaffected)
- [x] No business logic changed — proposal only
- [x] Math-touching changes uphold the Math Correctness Charter — n/a (docs only); items 16.3–16.4 are post-processing/search over the existing engine and will be charter-bound when implemented
- [x] Models stay input-only — n/a (no code change)
- [x] Version bump — n/a (no behavior change)
- [x] Updated `README.md` / `.github/copilot-instructions.md` — n/a (no structure change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vFP1vfbAyZA7js8dPg8bM

---
_Generated by [Claude Code](https://claude.ai/code/session_014vFP1vfbAyZA7js8dPg8bM)_